### PR TITLE
fix(security): Eliminate unwrap panics, fix hardcoded roles, wire unmounted routes

### DIFF
--- a/apps/gateway/src/error.rs
+++ b/apps/gateway/src/error.rs
@@ -1,7 +1,7 @@
 //! Gateway error types and HTTP response handling.
 
 use axum::{
-    http::StatusCode,
+    http::{HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -100,9 +100,13 @@ impl IntoResponse for GatewayError {
 
         // Add Retry-After header for rate limiting
         if let GatewayError::RateLimited { retry_after } = &self {
-            response
-                .headers_mut()
-                .insert("Retry-After", retry_after.to_string().parse().unwrap());
+            response.headers_mut().insert(
+                "Retry-After",
+                retry_after
+                    .to_string()
+                    .parse()
+                    .unwrap_or(HeaderValue::from_static("60")),
+            );
         }
 
         response

--- a/apps/gateway/src/middleware/rate_limit.rs
+++ b/apps/gateway/src/middleware/rate_limit.rs
@@ -74,19 +74,28 @@ impl RateLimitState {
                     );
 
                     // Get or create limiter for this tenant
-                    let limiters = self.tenant_limiters.read().unwrap();
+                    let limiters = self
+                        .tenant_limiters
+                        .read()
+                        .unwrap_or_else(|e| e.into_inner());
                     if let Some(limiter) = limiters.get(tid) {
                         return limiter.clone();
                     }
                     drop(limiters);
 
-                    let mut limiters = self.tenant_limiters.write().unwrap();
+                    let mut limiters = self
+                        .tenant_limiters
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner());
                     let limiter = Arc::new(RateLimiter::direct(quota));
                     limiters.insert(tid.to_string(), limiter.clone());
                     limiter
                 } else {
                     // Use default quota for this tenant
-                    let limiters = self.tenant_limiters.read().unwrap();
+                    let limiters = self
+                        .tenant_limiters
+                        .read()
+                        .unwrap_or_else(|e| e.into_inner());
                     if let Some(limiter) = limiters.get(tid) {
                         return limiter.clone();
                     }
@@ -101,7 +110,10 @@ impl RateLimitState {
                             .unwrap_or(NonZeroU32::new(10).unwrap()),
                     );
 
-                    let mut limiters = self.tenant_limiters.write().unwrap();
+                    let mut limiters = self
+                        .tenant_limiters
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner());
                     let limiter = Arc::new(RateLimiter::direct(quota));
                     limiters.insert(tid.to_string(), limiter.clone());
                     limiter

--- a/apps/gateway/src/routes/proxy.rs
+++ b/apps/gateway/src/routes/proxy.rs
@@ -208,9 +208,13 @@ fn error_response(error: GatewayError, request_id: Option<uuid::Uuid>) -> Respon
 
     // Add Retry-After for rate limiting
     if let GatewayError::RateLimited { retry_after } = error {
-        response
-            .headers_mut()
-            .insert("Retry-After", retry_after.to_string().parse().unwrap());
+        response.headers_mut().insert(
+            "Retry-After",
+            retry_after
+                .to_string()
+                .parse()
+                .unwrap_or(HeaderValue::from_static("60")),
+        );
     }
 
     response

--- a/apps/idp-api/src/metrics.rs
+++ b/apps/idp-api/src/metrics.rs
@@ -129,7 +129,11 @@ pub async fn metrics_handler(State(state): State<crate::state::AppState>) -> imp
 
     // Encode registered metrics (http_requests_total, http_request_duration_seconds)
     {
-        let registry = state.metrics.registry.lock().unwrap();
+        let registry = state
+            .metrics
+            .registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if let Err(e) = prometheus_client::encoding::text::encode(&mut buf, &registry) {
             tracing::error!(error = %e, "Failed to encode metrics");
             return (

--- a/crates/xavyo-api-agents/src/error.rs
+++ b/crates/xavyo-api-agents/src/error.rs
@@ -234,6 +234,10 @@ pub enum ApiAgentsError {
     #[error("Secret type is not enabled: {0}")]
     SecretTypeDisabled(String),
 
+    /// Secret type is in use by permissions or credentials.
+    #[error("Secret type is in use: {0}")]
+    SecretTypeInUse(String),
+
     /// Agent does not have permission for the requested secret type.
     #[error("Agent does not have permission for secret type '{0}'")]
     SecretPermissionDenied(String),
@@ -741,6 +745,12 @@ impl ApiAgentsError {
                 StatusCode::FORBIDDEN,
             )
             .with_detail(format!("Secret type '{type_name}' is not enabled.")),
+            ApiAgentsError::SecretTypeInUse(msg) => ProblemDetails::new(
+                "secret-type-in-use",
+                "Secret Type In Use",
+                StatusCode::CONFLICT,
+            )
+            .with_detail(msg.clone()),
             ApiAgentsError::SecretPermissionDenied(type_name) => ProblemDetails::new(
                 "secret-permission-denied",
                 "Secret Permission Denied",
@@ -1156,6 +1166,7 @@ impl ApiAgentsError {
             | ApiAgentsError::ApprovalAlreadyDecided
             | ApiAgentsError::ApprovalExpired
             | ApiAgentsError::SecretTypeExists(_)
+            | ApiAgentsError::SecretTypeInUse(_)
             | ApiAgentsError::IdentityProviderExists
             | ApiAgentsError::DuplicateProviderName(_)
             | ApiAgentsError::IdentityProviderHasRoleMappings(_)

--- a/crates/xavyo-api-agents/src/handlers/credentials.rs
+++ b/crates/xavyo-api-agents/src/handlers/credentials.rs
@@ -79,14 +79,12 @@ pub async fn request_credentials(
         Ok((response, rate_info)) => {
             // Build response with rate limit headers
             let mut resp = (StatusCode::OK, Json(response)).into_response();
-            resp.headers_mut().insert(
-                "X-RateLimit-Remaining",
-                rate_info.remaining.to_string().parse().unwrap(),
-            );
-            resp.headers_mut().insert(
-                "X-RateLimit-Reset",
-                rate_info.reset_at.to_rfc3339().parse().unwrap(),
-            );
+            if let Ok(val) = rate_info.remaining.to_string().parse() {
+                resp.headers_mut().insert("X-RateLimit-Remaining", val);
+            }
+            if let Ok(val) = rate_info.reset_at.to_rfc3339().parse() {
+                resp.headers_mut().insert("X-RateLimit-Reset", val);
+            }
             Ok(resp)
         }
         Err(e) => {

--- a/crates/xavyo-api-agents/src/handlers/identity_federation.rs
+++ b/crates/xavyo-api-agents/src/handlers/identity_federation.rs
@@ -298,11 +298,12 @@ pub async fn request_cloud_credentials(
 
     // Add rate limit headers
     let mut headers = HeaderMap::new();
-    headers.insert("X-RateLimit-Remaining", "99".parse().unwrap()); // Placeholder
-    headers.insert(
-        "X-RateLimit-Reset",
-        chrono::Utc::now().timestamp().to_string().parse().unwrap(),
-    );
+    if let Ok(val) = "99".parse() {
+        headers.insert("X-RateLimit-Remaining", val);
+    }
+    if let Ok(val) = chrono::Utc::now().timestamp().to_string().parse() {
+        headers.insert("X-RateLimit-Reset", val);
+    }
 
     Ok((StatusCode::OK, headers, Json(dto)))
 }

--- a/crates/xavyo-api-auth/src/handlers/mfa/disable.rs
+++ b/crates/xavyo-api-auth/src/handlers/mfa/disable.rs
@@ -50,7 +50,13 @@ pub async fn disable_mfa(
         return Err(ApiAuthError::InvalidCredentials);
     }
 
-    // TODO: Check tenant MFA policy - reject if 'required'
+    // Check tenant MFA policy - reject if 'required'
+    let mfa_policy = xavyo_db::TenantMfaPolicy::get(&state.pool, *tenant_id.as_uuid())
+        .await
+        .map_err(ApiAuthError::Database)?;
+    if mfa_policy.mfa_policy == xavyo_db::MfaPolicy::Required {
+        return Err(ApiAuthError::CannotDisableMfaRequired);
+    }
 
     // Disable MFA (verifies TOTP code internally)
     state

--- a/crates/xavyo-api-auth/src/handlers/mfa/recovery.rs
+++ b/crates/xavyo-api-auth/src/handlers/mfa/recovery.rs
@@ -60,7 +60,9 @@ pub async fn verify_recovery_code(
         .ok_or(ApiAuthError::InvalidCredentials)?;
 
     // Generate full tokens using the shared token_service
-    let roles = vec!["user".to_string()]; // TODO: fetch from database
+    let roles = xavyo_db::UserRole::get_user_roles(&state.pool, user_id)
+        .await
+        .unwrap_or_else(|_| vec!["user".to_string()]);
     let tokens = state
         .token_service
         .create_tokens(

--- a/crates/xavyo-api-auth/src/handlers/mfa/verify.rs
+++ b/crates/xavyo-api-auth/src/handlers/mfa/verify.rs
@@ -59,7 +59,9 @@ pub async fn verify_totp(
         .ok_or(ApiAuthError::InvalidCredentials)?;
 
     // Generate full tokens using the shared token_service
-    let roles = vec!["user".to_string()]; // TODO: fetch from database
+    let roles = xavyo_db::UserRole::get_user_roles(&state.pool, user_id)
+        .await
+        .unwrap_or_else(|_| vec!["user".to_string()]);
     let tokens = state
         .token_service
         .create_tokens(

--- a/crates/xavyo-api-auth/src/router.rs
+++ b/crates/xavyo-api-auth/src/router.rs
@@ -328,9 +328,15 @@ impl AuthState {
         // Create device services (F026)
         let device_service = Arc::new(DeviceService::new(pool.clone()));
         let device_policy_service = Arc::new(DevicePolicyService::new(pool.clone()));
+        // Frontend base URL for email links (used by email change and admin invite)
+        let frontend_base_url = std::env::var("FRONTEND_BASE_URL")
+            .unwrap_or_else(|_| "https://app.xavyo.net".to_string());
         // Create profile services (F027)
         let profile_service = Arc::new(ProfileService::new(pool.clone()));
-        let email_change_service = Arc::new(EmailChangeService::new(pool.clone()));
+        let email_change_service = Arc::new(EmailChangeService::new(
+            pool.clone(),
+            frontend_base_url.clone(),
+        ));
         // Create IP restriction service (F028)
         let ip_restriction_service = Arc::new(IpRestrictionService::new(pool.clone()));
         // Create delegated admin service (F029)
@@ -361,8 +367,6 @@ impl AuthState {
         ));
 
         // Create admin invite service (F-ADMIN-INVITE)
-        let frontend_base_url = std::env::var("FRONTEND_BASE_URL")
-            .unwrap_or_else(|_| "https://app.xavyo.net".to_string());
         let admin_invite_service = Arc::new(AdminInviteService::new(
             pool.clone(),
             email_sender.clone(),

--- a/crates/xavyo-api-auth/src/services/asset_storage.rs
+++ b/crates/xavyo-api-auth/src/services/asset_storage.rs
@@ -253,13 +253,16 @@ impl AssetStorage for InMemoryAssetStorage {
         let storage_path = format!("{}/{}.{}", tenant_id, asset_id, extension);
         self.assets
             .write()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .insert(storage_path.clone(), data.to_vec());
         Ok(storage_path)
     }
 
     async fn delete(&self, storage_path: &str) -> Result<(), ApiAuthError> {
-        self.assets.write().unwrap().remove(storage_path);
+        self.assets
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(storage_path);
         Ok(())
     }
 
@@ -268,7 +271,10 @@ impl AssetStorage for InMemoryAssetStorage {
     }
 
     async fn exists(&self, storage_path: &str) -> bool {
-        self.assets.read().unwrap().contains_key(storage_path)
+        self.assets
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(storage_path)
     }
 }
 

--- a/crates/xavyo-api-connectors/src/lib.rs
+++ b/crates/xavyo-api-connectors/src/lib.rs
@@ -57,16 +57,17 @@ pub mod services;
 
 // Re-export for convenience
 pub use error::{ConnectorApiError, Result};
+pub use handlers::jobs::JobState;
 pub use handlers::scim_targets::ScimTargetState;
 pub use models::*;
 pub use router::{
-    connector_routes, connector_routes_full, operation_routes, reconciliation_global_routes,
-    reconciliation_routes, scim_target_routes, sync_routes, ConnectorState, OperationState,
-    ReconciliationState, SyncState,
+    connector_routes, connector_routes_full, job_routes, operation_routes,
+    reconciliation_global_routes, reconciliation_routes, scim_target_routes, sync_routes,
+    ConnectorState, OperationState, ReconciliationState, SyncState,
 };
 pub use services::{
     compute_next_run_at, validate_schedule_config, AttributeResponse, ConnectorService,
-    CreateMappingRequest, DiscoveryStateManager, MappingResponse, MappingService,
+    CreateMappingRequest, DiscoveryStateManager, JobService, MappingResponse, MappingService,
     ObjectClassResponse, OperationFilter, OperationListResponse, OperationLogResponse,
     OperationResponse, OperationService, PreviewMappingRequest, PreviewMappingResponse,
     QueueStatsResponse, ReconciliationService, ScheduleError, ScheduleResult, ScheduleService,

--- a/crates/xavyo-api-connectors/src/services/notification_service.rs
+++ b/crates/xavyo-api-connectors/src/services/notification_service.rs
@@ -166,17 +166,21 @@ This is an automated message. Do not reply to this email.
             "Sending schema change notification"
         );
 
-        // TODO: Actually send email via lettre when SMTP is configured
-        // For now, just log the notification
+        // SMTP sending is not yet implemented (requires lettre integration).
+        // Return an error so callers know the email was NOT actually sent.
         warn!(
             connector_id = %notification.connector_id,
             recipient = %notification.recipient_email,
-            "Email sending not implemented - notification logged only"
+            subject = %subject,
+            "Email notification skipped: SMTP not configured. \
+             Schema change notification was NOT delivered to recipient."
         );
 
-        debug!(body = %body, "Notification body");
+        debug!(body = %body, "Notification body that was not sent");
 
-        Ok(())
+        Err(NotificationError::SendFailed(
+            "Email notification skipped: SMTP sending not yet implemented".to_string(),
+        ))
     }
 }
 

--- a/crates/xavyo-api-governance/src/services/entitlement_service.rs
+++ b/crates/xavyo-api-governance/src/services/entitlement_service.rs
@@ -180,8 +180,10 @@ impl EntitlementService {
         // Verify entitlement exists
         let _existing = self.get_entitlement(tenant_id, entitlement_id).await?;
 
-        // TODO: Verify owner_id is a valid user in the tenant
-        // For now, we trust the caller has validated this
+        // Verify owner_id is a valid user in the tenant
+        if !xavyo_db::User::exists_in_tenant(&self.pool, tenant_id, owner_id).await? {
+            return Err(GovernanceError::UserNotFound(owner_id));
+        }
 
         GovEntitlement::set_owner(&self.pool, tenant_id, entitlement_id, owner_id)
             .await?

--- a/crates/xavyo-api-governance/src/services/template_expression_service.rs
+++ b/crates/xavyo-api-governance/src/services/template_expression_service.rs
@@ -864,7 +864,7 @@ impl TemplateExpressionService {
     fn get_or_compile_regex(&self, pattern: &str) -> ExpressionResult<Regex> {
         // Try read lock first
         {
-            let cache = self.regex_cache.read().unwrap();
+            let cache = self.regex_cache.read().unwrap_or_else(|e| e.into_inner());
             if let Some(regex) = cache.get(pattern) {
                 return Ok(regex.clone());
             }
@@ -873,7 +873,7 @@ impl TemplateExpressionService {
         // Compile and cache
         let regex = Regex::new(pattern).map_err(|e| ExpressionError::RegexError(e.to_string()))?;
 
-        let mut cache = self.regex_cache.write().unwrap();
+        let mut cache = self.regex_cache.write().unwrap_or_else(|e| e.into_inner());
         cache.insert(pattern.to_string(), regex.clone());
         Ok(regex)
     }

--- a/crates/xavyo-api-nhi/src/error.rs
+++ b/crates/xavyo-api-nhi/src/error.rs
@@ -23,6 +23,10 @@ pub enum ApiNhiError {
     #[error("Bad request: {0}")]
     BadRequest(String),
 
+    /// Forbidden: insufficient permissions.
+    #[error("Forbidden: {0}")]
+    Forbidden(String),
+
     /// Conflict error (e.g., duplicate resource).
     #[error("Conflict: {0}")]
     Conflict(String),
@@ -111,6 +115,9 @@ impl IntoResponse for ApiNhiError {
                     ApiNhiError::NotFound(msg) => (StatusCode::NOT_FOUND, "not_found", msg.clone()),
                     ApiNhiError::BadRequest(msg) => {
                         (StatusCode::BAD_REQUEST, "bad_request", msg.clone())
+                    }
+                    ApiNhiError::Forbidden(msg) => {
+                        (StatusCode::FORBIDDEN, "forbidden", msg.clone())
                     }
                     ApiNhiError::Conflict(msg) => (StatusCode::CONFLICT, "conflict", msg.clone()),
                     ApiNhiError::Internal(msg) => {

--- a/crates/xavyo-api-nhi/src/handlers/agents.rs
+++ b/crates/xavyo-api-nhi/src/handlers/agents.rs
@@ -106,6 +106,9 @@ pub async fn create_agent(
     Json(request): Json<CreateAgentRequest>,
 ) -> ApiResult<(StatusCode, Json<AgentResponse>)> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let user_id = extract_actor_id(&claims)?;
     let agent = state
         .agent_service
@@ -165,6 +168,9 @@ pub async fn update_agent(
     Json(request): Json<UpdateAgentRequest>,
 ) -> ApiResult<Json<AgentResponse>> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let agent = state.agent_service.update(tenant_id, id, request).await?;
     Ok(Json(agent))
 }
@@ -191,6 +197,9 @@ pub async fn delete_agent(
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     state.agent_service.delete(tenant_id, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -222,6 +231,9 @@ pub async fn suspend_agent(
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<AgentResponse>> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let agent = state.agent_service.suspend(tenant_id, id).await?;
     Ok(Json(agent))
 }
@@ -249,6 +261,9 @@ pub async fn reactivate_agent(
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<AgentResponse>> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let agent = state.agent_service.reactivate(tenant_id, id).await?;
     Ok(Json(agent))
 }

--- a/crates/xavyo-api-nhi/src/handlers/service_accounts.rs
+++ b/crates/xavyo-api-nhi/src/handlers/service_accounts.rs
@@ -134,6 +134,9 @@ pub async fn create_service_account(
     Json(request): Json<CreateNhiRequest>,
 ) -> ApiResult<(StatusCode, Json<NhiResponse>)> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let actor_id = extract_actor_id(&claims)?;
     let nhi = state
         .nhi_service
@@ -167,6 +170,9 @@ pub async fn update_service_account(
     Json(request): Json<UpdateNhiRequest>,
 ) -> ApiResult<Json<NhiResponse>> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let actor_id = extract_actor_id(&claims)?;
     let nhi = state
         .nhi_service
@@ -197,6 +203,9 @@ pub async fn delete_service_account(
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let actor_id = extract_actor_id(&claims)?;
     state.nhi_service.delete(tenant_id, id, actor_id).await?;
     Ok(StatusCode::NO_CONTENT)
@@ -231,6 +240,9 @@ pub async fn suspend_service_account(
     Json(request): Json<SuspendNhiRequest>,
 ) -> ApiResult<Json<NhiResponse>> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let actor_id = extract_actor_id(&claims)?;
     let nhi = state
         .nhi_service
@@ -264,6 +276,9 @@ pub async fn reactivate_service_account(
     Json(request): Json<ReactivateNhiRequest>,
 ) -> ApiResult<Json<NhiResponse>> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let actor_id = extract_actor_id(&claims)?;
     let nhi = state
         .nhi_service
@@ -297,6 +312,9 @@ pub async fn transfer_ownership(
     Json(request): Json<TransferOwnershipRequest>,
 ) -> ApiResult<Json<NhiResponse>> {
     let tenant_id = extract_tenant_id(&claims)?;
+    if !claims.has_role("admin") {
+        return Err(ApiNhiError::Forbidden("Admin role required".to_string()));
+    }
     let actor_id = extract_actor_id(&claims)?;
     let nhi = state
         .nhi_service

--- a/crates/xavyo-api-oidc-federation/src/handlers/federation.rs
+++ b/crates/xavyo-api-oidc-federation/src/handlers/federation.rs
@@ -146,8 +146,9 @@ pub async fn callback(
         .await?;
 
     // Generate Xavyo JWT for the user
-    // TODO: Load user roles from database
-    let roles = vec!["user".to_string()];
+    let roles = xavyo_db::UserRole::get_user_roles(&state.pool, user.id)
+        .await
+        .unwrap_or_else(|_| vec!["user".to_string()]);
     let xavyo_tokens = state
         .token_issuer
         .issue_tokens(user.id, token_result.session.tenant_id, roles, None)

--- a/crates/xavyo-api-oidc-federation/src/router.rs
+++ b/crates/xavyo-api-oidc-federation/src/router.rs
@@ -18,6 +18,8 @@ use crate::services::{
 /// the `TenantLayer` middleware via `Extension<xavyo_core::TenantId>`.
 #[derive(Clone)]
 pub struct FederationState {
+    /// Database connection pool (for role lookups, etc.).
+    pub pool: PgPool,
     /// `IdP` configuration service.
     pub idp_config: IdpConfigService,
     /// Validation service.
@@ -60,6 +62,7 @@ impl FederationState {
         let token_issuer = TokenIssuerService::new_default();
 
         Self {
+            pool: config.pool.clone(),
             idp_config,
             validation,
             hrd,

--- a/crates/xavyo-api-saml/src/error.rs
+++ b/crates/xavyo-api-saml/src/error.rs
@@ -232,9 +232,7 @@ impl IntoResponse for SamlError {
                 "Metadata generation failed".to_string()
             }
             SamlError::SignatureValidationFailed(_) => "Signature validation failed".to_string(),
-            SamlError::InvalidAuthnRequest(_) => {
-                "Invalid SAML authentication request".to_string()
-            }
+            SamlError::InvalidAuthnRequest(_) => "Invalid SAML authentication request".to_string(),
             SamlError::InvalidSpCertificate(_) => {
                 "Invalid Service Provider certificate".to_string()
             }

--- a/crates/xavyo-api-scim/src/middleware/rate_limit.rs
+++ b/crates/xavyo-api-scim/src/middleware/rate_limit.rs
@@ -90,7 +90,7 @@ impl RateLimiter {
     /// Returns `None` if allowed, or `Some(wait_time)` if rate limited.
     #[must_use]
     pub fn try_acquire(&self, tenant_id: Uuid) -> Option<Duration> {
-        let mut buckets = self.buckets.lock().unwrap();
+        let mut buckets = self.buckets.lock().unwrap_or_else(|e| e.into_inner());
 
         let bucket = buckets
             .entry(tenant_id)
@@ -102,7 +102,7 @@ impl RateLimiter {
     /// Clean up old buckets that haven't been used recently.
     pub fn cleanup(&self, max_age: Duration) {
         let now = Instant::now();
-        let mut buckets = self.buckets.lock().unwrap();
+        let mut buckets = self.buckets.lock().unwrap_or_else(|e| e.into_inner());
 
         buckets.retain(|_, bucket| now.duration_since(bucket.last_refill) < max_age);
     }

--- a/crates/xavyo-api-social/src/handlers/link.rs
+++ b/crates/xavyo-api-social/src/handlers/link.rs
@@ -52,10 +52,15 @@ pub async fn link_account(
     // Validate state
     let claims = state.oauth_service.validate_state(&request.state)?;
 
-    // Verify this linking flow was initiated for this user
+    // Verify this linking flow was initiated for this user and tenant
     if claims.user_id != Some(user_id) {
         return Err(SocialError::InvalidState {
             reason: "State was not created for this user".to_string(),
+        });
+    }
+    if claims.tenant_id != tenant_id {
+        return Err(SocialError::InvalidState {
+            reason: "State was not created for this tenant".to_string(),
         });
     }
 
@@ -116,17 +121,23 @@ pub async fn link_account(
             let team_id = additional
                 .get("team_id")
                 .and_then(|v| v.as_str())
-                .unwrap()
+                .ok_or(SocialError::ConfigurationError {
+                    message: "Apple config missing team_id".to_string(),
+                })?
                 .to_string();
             let key_id = additional
                 .get("key_id")
                 .and_then(|v| v.as_str())
-                .unwrap()
+                .ok_or(SocialError::ConfigurationError {
+                    message: "Apple config missing key_id".to_string(),
+                })?
                 .to_string();
             let private_key = additional
                 .get("private_key")
                 .and_then(|v| v.as_str())
-                .unwrap()
+                .ok_or(SocialError::ConfigurationError {
+                    message: "Apple config missing private_key".to_string(),
+                })?
                 .to_string();
 
             let p = crate::providers::ProviderFactory::apple(
@@ -278,17 +289,23 @@ pub async fn initiate_link(
             let team_id = additional
                 .get("team_id")
                 .and_then(|v| v.as_str())
-                .unwrap()
+                .ok_or(SocialError::ConfigurationError {
+                    message: "Apple config missing team_id".to_string(),
+                })?
                 .to_string();
             let key_id = additional
                 .get("key_id")
                 .and_then(|v| v.as_str())
-                .unwrap()
+                .ok_or(SocialError::ConfigurationError {
+                    message: "Apple config missing key_id".to_string(),
+                })?
                 .to_string();
             let private_key = additional
                 .get("private_key")
                 .and_then(|v| v.as_str())
-                .unwrap()
+                .ok_or(SocialError::ConfigurationError {
+                    message: "Apple config missing private_key".to_string(),
+                })?
                 .to_string();
 
             let p = crate::providers::ProviderFactory::apple(

--- a/crates/xavyo-api-social/src/providers/github.rs
+++ b/crates/xavyo-api-social/src/providers/github.rs
@@ -56,7 +56,10 @@ impl GithubProvider {
         Self {
             client_id,
             client_secret,
-            http_client: Client::new(),
+            http_client: Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap_or_else(|_| Client::new()),
         }
     }
 

--- a/crates/xavyo-api-social/src/providers/google.rs
+++ b/crates/xavyo-api-social/src/providers/google.rs
@@ -50,7 +50,10 @@ impl GoogleProvider {
         Self {
             client_id,
             client_secret,
-            http_client: Client::new(),
+            http_client: Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap_or_else(|_| Client::new()),
         }
     }
 }

--- a/crates/xavyo-api-social/src/providers/microsoft.rs
+++ b/crates/xavyo-api-social/src/providers/microsoft.rs
@@ -56,7 +56,10 @@ impl MicrosoftProvider {
             client_id,
             client_secret,
             tenant: tenant.unwrap_or_else(|| DEFAULT_TENANT.to_string()),
-            http_client: Client::new(),
+            http_client: Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap_or_else(|_| Client::new()),
         }
     }
 

--- a/crates/xavyo-api-tenants/src/handlers/delete.rs
+++ b/crates/xavyo-api-tenants/src/handlers/delete.rs
@@ -149,8 +149,10 @@ pub async fn delete_tenant_handler(
 
     Ok(Json(DeleteTenantResponse {
         tenant_id,
-        deleted_at: deleted_tenant.deleted_at.unwrap(),
-        scheduled_purge_at: deleted_tenant.scheduled_purge_at.unwrap(),
+        deleted_at: deleted_tenant.deleted_at.unwrap_or_else(chrono::Utc::now),
+        scheduled_purge_at: deleted_tenant
+            .scheduled_purge_at
+            .unwrap_or_else(chrono::Utc::now),
         reason: request.reason,
     }))
 }
@@ -315,8 +317,8 @@ pub async fn list_deleted_tenants_handler(
             id: t.id,
             name: t.name,
             slug: t.slug,
-            deleted_at: t.deleted_at.unwrap(),
-            scheduled_purge_at: t.scheduled_purge_at.unwrap(),
+            deleted_at: t.deleted_at.unwrap_or_else(chrono::Utc::now),
+            scheduled_purge_at: t.scheduled_purge_at.unwrap_or_else(chrono::Utc::now),
             deletion_reason: t.deletion_reason,
         })
         .collect();

--- a/crates/xavyo-api-tenants/src/handlers/suspend.rs
+++ b/crates/xavyo-api-tenants/src/handlers/suspend.rs
@@ -91,7 +91,7 @@ pub async fn suspend_tenant_handler(
         );
         return Ok(Json(SuspendTenantResponse {
             tenant_id,
-            suspended_at: target_tenant.suspended_at.unwrap(),
+            suspended_at: target_tenant.suspended_at.unwrap_or_else(chrono::Utc::now),
             suspension_reason: target_tenant.suspension_reason.unwrap_or_default(),
         }));
     }
@@ -133,7 +133,9 @@ pub async fn suspend_tenant_handler(
 
     Ok(Json(SuspendTenantResponse {
         tenant_id,
-        suspended_at: suspended_tenant.suspended_at.unwrap(),
+        suspended_at: suspended_tenant
+            .suspended_at
+            .unwrap_or_else(chrono::Utc::now),
         suspension_reason: request.reason,
     }))
 }

--- a/crates/xavyo-db/src/models/agent_secret_permission.rs
+++ b/crates/xavyo-db/src/models/agent_secret_permission.rs
@@ -378,6 +378,24 @@ impl AgentSecretPermission {
         Ok(result.rows_affected())
     }
 
+    /// Count permissions for a specific secret type (for deletion checks).
+    pub async fn count_by_secret_type(
+        pool: &sqlx::PgPool,
+        tenant_id: Uuid,
+        secret_type: &str,
+    ) -> Result<i64, sqlx::Error> {
+        sqlx::query_scalar(
+            r"
+            SELECT COUNT(*) FROM agent_secret_permissions
+            WHERE tenant_id = $1 AND secret_type = $2
+            ",
+        )
+        .bind(tenant_id)
+        .bind(secret_type)
+        .fetch_one(pool)
+        .await
+    }
+
     /// Delete expired permissions.
     pub async fn delete_expired(pool: &sqlx::PgPool, tenant_id: Uuid) -> Result<u64, sqlx::Error> {
         let result = sqlx::query(

--- a/crates/xavyo-db/src/models/dynamic_credential.rs
+++ b/crates/xavyo-db/src/models/dynamic_credential.rs
@@ -356,6 +356,24 @@ impl DynamicCredential {
         .await
     }
 
+    /// Count active credentials for a specific secret type (for deletion checks).
+    pub async fn count_active_by_secret_type(
+        pool: &sqlx::PgPool,
+        tenant_id: Uuid,
+        secret_type: &str,
+    ) -> Result<i64, sqlx::Error> {
+        sqlx::query_scalar(
+            r"
+            SELECT COUNT(*) FROM dynamic_credentials
+            WHERE tenant_id = $1 AND secret_type = $2 AND status = 'active'
+            ",
+        )
+        .bind(tenant_id)
+        .bind(secret_type)
+        .fetch_one(pool)
+        .await
+    }
+
     /// Find credentials by lease ID (for provider revocation callbacks).
     pub async fn find_by_lease_id(
         pool: &sqlx::PgPool,

--- a/crates/xavyo-db/src/models/gov_license_reclamation_rule.rs
+++ b/crates/xavyo-db/src/models/gov_license_reclamation_rule.rs
@@ -246,6 +246,7 @@ impl GovLicenseReclamationRule {
             FROM gov_license_reclamation_rules
             WHERE tenant_id = $1 AND enabled = true
             ORDER BY license_pool_id, trigger_type
+            LIMIT 1000
             "#,
             tenant_id
         )
@@ -278,6 +279,7 @@ impl GovLicenseReclamationRule {
               AND enabled = true
               AND trigger_type = 'inactivity'
             ORDER BY license_pool_id
+            LIMIT 1000
             "#,
             tenant_id
         )

--- a/crates/xavyo-db/src/models/gov_nhi_credential.rs
+++ b/crates/xavyo-db/src/models/gov_nhi_credential.rs
@@ -352,6 +352,7 @@ impl GovNhiCredential {
             WHERE is_active = true
                 AND valid_from <= NOW()
                 AND valid_until > NOW()
+            LIMIT 10000
             ",
         )
         .fetch_all(pool)
@@ -370,6 +371,7 @@ impl GovNhiCredential {
                 AND valid_from <= NOW()
                 AND valid_until > NOW()
                 AND nhi_type = $1
+            LIMIT 10000
             ",
         )
         .bind(nhi_type.to_string())

--- a/crates/xavyo-db/src/models/gov_sod_violation.rs
+++ b/crates/xavyo-db/src/models/gov_sod_violation.rs
@@ -411,6 +411,7 @@ impl GovSodViolation {
               AND ea2.status = 'active'
               AND ea1.entitlement_id = $2
               AND ea2.entitlement_id = $3
+            LIMIT 50000
             ",
         )
         .bind(tenant_id)

--- a/crates/xavyo-webhooks/src/worker.rs
+++ b/crates/xavyo-webhooks/src/worker.rs
@@ -181,7 +181,9 @@ async fn process_pending_retries(delivery_service: &DeliveryService) {
         let service = delivery_service.clone();
 
         let handle = tokio::spawn(async move {
-            let _permit = sem.acquire().await.expect("semaphore closed");
+            let Ok(_permit) = sem.acquire().await else {
+                return;
+            };
             service.process_retry(&delivery).await;
         });
 


### PR DESCRIPTION
## Summary
- **22+ unwrap panics eliminated** across gateway, rate limiting, metrics, credentials, and tenant handlers — replaced with graceful fallbacks (`unwrap_or_else(|e| e.into_inner())`)
- **MFA/social auth hardcoded roles fixed** — verify, recovery, federation, and social login now query `UserRole::get_user_roles()` from DB instead of hardcoding `"user"`
- **19 unmounted route handlers wired** — `operation_routes()` at `/operations`, `job_routes()` merged into `/connectors`
- **MFA disable policy enforcement** — returns 403 when tenant requires MFA
- **Social auth hardening** — open redirect prevention, cross-tenant validation, HTTP client timeouts (10s)
- **Email sender auto-detection** — uses SMTP when configured, mock with warning otherwise
- **Email change URL** — uses `FRONTEND_BASE_URL` env var instead of hardcoded `example.com`
- **Secret type deletion** — referential integrity check (permissions + credentials) before delete
- **Scheduled transitions** — actually executes lifecycle state change and marks request as Executed
- **Micro-cert revocation** — proper error handling replacing fire-and-forget `let _ =`
- **Webhook worker** — graceful semaphore acquisition replacing `.expect()` panic

## Test plan
- [ ] `cargo check --workspace` compiles cleanly
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Verify `/operations` and `/connectors/jobs` endpoints respond
- [ ] Verify MFA disable returns 403 when tenant policy requires MFA
- [ ] Verify social login assigns correct DB roles (not hardcoded "user")

🤖 Generated with [Claude Code](https://claude.com/claude-code)