### PR TITLE
fix: Eliminate CLI unwrap panics and standardize dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,17 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,7 +367,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "hex",
  "http 1.4.0",
  "ring",
@@ -438,7 +427,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 1.4.0",
  "http-body 1.0.1",
  "percent-encoding",
@@ -464,7 +453,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -488,7 +477,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -512,7 +501,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -537,7 +526,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -669,7 +658,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -812,7 +801,7 @@ dependencies = [
  "axum",
  "axum-core",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -835,35 +824,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "axum-test"
-version = "14.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167294800740b4b6bc7bfbccbf3a1d50a6c6e097342580ec4c11d1672e456292"
-dependencies = [
- "anyhow",
- "async-trait",
- "auto-future",
- "axum",
- "bytes",
- "cookie",
- "http 1.4.0",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "mime",
- "pretty_assertions",
- "reserve-port",
- "rust-multipart-rfc7578_2",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "tokio",
- "tower 0.4.13",
- "url",
 ]
 
 [[package]]
@@ -905,12 +865,6 @@ name = "base32"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1749,19 +1703,6 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
-dependencies = [
- "async-trait",
- "deadpool-runtime",
- "num_cpus",
- "retain_mut",
- "tokio",
-]
-
-[[package]]
-name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
@@ -2135,15 +2076,6 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
@@ -2348,21 +2280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,7 +2332,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "axum-test 14.10.0",
+ "axum-test",
  "governor",
  "hyper 1.8.1",
  "hyper-util",
@@ -2437,7 +2354,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui 6.0.0",
  "uuid",
- "wiremock 0.5.22",
+ "wiremock",
  "xavyo-auth",
  "xavyo-core",
 ]
@@ -2455,17 +2372,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -2473,7 +2379,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2809,27 +2715,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel",
- "base64 0.13.1",
- "futures-lite",
- "http 0.2.12",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,7 +2998,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "axum-test 15.7.4",
+ "axum-test",
  "base64 0.22.1",
  "chrono",
  "dotenvy",
@@ -3219,12 +3104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,15 +3130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -3533,7 +3403,7 @@ dependencies = [
  "chumsky",
  "email-encoding",
  "email_address",
- "fastrand 2.3.0",
+ "fastrand",
  "futures-io",
  "futures-util",
  "hostname",
@@ -3837,7 +3707,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -3848,7 +3718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -5093,7 +4963,7 @@ dependencies = [
  "mach2",
  "once_cell",
  "raw-cpuid 10.7.0",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "web-sys",
  "winapi",
 ]
@@ -5108,7 +4978,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid 11.6.0",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "web-sys",
  "winapi",
 ]
@@ -5222,19 +5092,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -5252,16 +5109,6 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5286,15 +5133,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -5309,15 +5147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5562,12 +5391,6 @@ checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
 dependencies = [
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "rfc6979"
@@ -6140,17 +5963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6816,7 +6628,7 @@ version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
@@ -7257,7 +7069,6 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -7635,12 +7446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7658,12 +7463,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -8232,35 +8031,13 @@ dependencies = [
 
 [[package]]
 name = "wiremock"
-version = "0.5.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a3a53eaf34f390dd30d7b1b078287dd05df2aa2e21a589ccb80f5c7253c2e9"
-dependencies = [
- "assert-json-diff",
- "async-trait",
- "base64 0.21.7",
- "deadpool 0.9.5",
- "futures",
- "futures-timer",
- "http-types",
- "hyper 0.14.32",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
  "base64 0.22.1",
- "deadpool 0.12.3",
+ "deadpool",
  "futures",
  "http 1.4.0",
  "http-body-util",
@@ -8333,7 +8110,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-sts",
  "axum",
- "axum-test 15.7.4",
+ "axum-test",
  "base64 0.22.1",
  "chrono",
  "dashmap",
@@ -8382,7 +8159,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
- "axum-test 14.10.0",
+ "axum-test",
  "base64 0.22.1",
  "chrono",
  "ciborium",
@@ -8435,7 +8212,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "axum-test 14.10.0",
+ "axum-test",
  "chrono",
  "http 1.4.0",
  "serde",
@@ -8463,7 +8240,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "axum-test 15.7.4",
+ "axum-test",
  "chrono",
  "cron",
  "reqwest",
@@ -8500,7 +8277,7 @@ dependencies = [
  "argon2",
  "async-trait",
  "axum",
- "axum-test 14.10.0",
+ "axum-test",
  "base64 0.22.1",
  "chrono",
  "futures",
@@ -8581,7 +8358,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "axum",
- "axum-test 15.7.4",
+ "axum-test",
  "base64 0.22.1",
  "chrono",
  "rand 0.8.5",
@@ -8612,7 +8389,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "axum-test 14.10.0",
+ "axum-test",
  "base64 0.22.1",
  "chrono",
  "hex",
@@ -8668,13 +8445,11 @@ dependencies = [
  "sqlx",
  "thiserror 1.0.69",
  "tokio",
- "tower 0.5.3",
- "tower-http 0.6.8",
  "tracing",
  "url",
  "utoipa",
  "uuid",
- "wiremock 0.6.5",
+ "wiremock",
  "xavyo-auth",
  "xavyo-core",
  "xavyo-db",
@@ -8767,7 +8542,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
- "wiremock 0.6.5",
+ "wiremock",
  "xavyo-auth",
  "xavyo-core",
  "xavyo-db",
@@ -8779,7 +8554,7 @@ name = "xavyo-api-tenants"
 version = "0.1.0"
 dependencies = [
  "axum",
- "axum-test 14.10.0",
+ "axum-test",
  "base64 0.22.1",
  "chrono",
  "hex",
@@ -8812,7 +8587,7 @@ name = "xavyo-api-users"
 version = "0.1.0"
 dependencies = [
  "axum",
- "axum-test 15.7.4",
+ "axum-test",
  "chrono",
  "regex",
  "serde",
@@ -8849,7 +8624,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
- "wiremock 0.5.22",
+ "wiremock",
  "xavyo-core",
 ]
 
@@ -8909,7 +8684,7 @@ dependencies = [
  "toml",
  "urlencoding",
  "uuid",
- "wiremock 0.6.5",
+ "wiremock",
 ]
 
 [[package]]
@@ -8969,7 +8744,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "wiremock 0.6.5",
+ "wiremock",
  "xavyo-connector",
  "xavyo-core",
 ]
@@ -9008,7 +8783,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "wiremock 0.6.5",
+ "wiremock",
  "xavyo-connector",
 ]
 
@@ -9139,7 +8914,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "uuid",
- "wiremock 0.6.5",
+ "wiremock",
  "xavyo-api-scim",
  "xavyo-connector",
  "xavyo-core",
@@ -9194,7 +8969,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "wiremock 0.6.5",
+ "wiremock",
  "xavyo-db",
 ]
 
@@ -9248,7 +9023,7 @@ dependencies = [
  "utoipa",
  "uuid",
  "validator",
- "wiremock 0.6.5",
+ "wiremock",
  "xavyo-auth",
  "xavyo-core",
  "xavyo-db",

--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -50,9 +50,9 @@ xavyo-auth = { path = "../../crates/xavyo-auth" }
 xavyo-core = { path = "../../crates/xavyo-core" }
 
 [dev-dependencies]
-axum-test = "14"
-tokio-test = "0.4"
-wiremock = "0.5"
+axum-test = { workspace = true }
+tokio-test = { workspace = true }
+wiremock = "0.6"
 
 [[bin]]
 name = "gateway"

--- a/crates/xavyo-api-auth/Cargo.toml
+++ b/crates/xavyo-api-auth/Cargo.toml
@@ -109,7 +109,7 @@ ciborium = "0.2"
 [dev-dependencies]
 tokio = { version = "1.35", features = ["full", "test-util"] }
 tower = { version = "0.4", features = ["util"] }
-axum-test = "14"
+axum-test = { workspace = true }
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "postgres", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 proptest = "1.4"

--- a/crates/xavyo-api-authorization/Cargo.toml
+++ b/crates/xavyo-api-authorization/Cargo.toml
@@ -55,7 +55,7 @@ http = "1.0"
 [dev-dependencies]
 tokio = { version = "1.35", features = ["full", "test-util"] }
 tower = { version = "0.4", features = ["util"] }
-axum-test = "14"
+axum-test = { workspace = true }
 
 [features]
 default = []

--- a/crates/xavyo-api-governance/Cargo.toml
+++ b/crates/xavyo-api-governance/Cargo.toml
@@ -96,7 +96,7 @@ xavyo-siem = { path = "../xavyo-siem" }
 [dev-dependencies]
 tokio = { version = "1.35", features = ["full", "test-util"] }
 tower = { version = "0.4", features = ["util"] }
-axum-test = "14"
+axum-test = { workspace = true }
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "postgres", "macros"] }
 xavyo-events = { path = "../xavyo-events" }
 futures = "0.3"

--- a/crates/xavyo-api-oauth/Cargo.toml
+++ b/crates/xavyo-api-oauth/Cargo.toml
@@ -86,7 +86,7 @@ urlencoding = "2.1"
 [dev-dependencies]
 tokio = { version = "1.35", features = ["full", "test-util"] }
 tower = { version = "0.4", features = ["util"] }
-axum-test = "14"
+axum-test = { workspace = true }
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "postgres", "macros"] }
 serde_urlencoded = "0.7"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/xavyo-api-oidc-federation/Cargo.toml
+++ b/crates/xavyo-api-oidc-federation/Cargo.toml
@@ -20,8 +20,6 @@ rand = "0.8"
 
 # Web framework
 axum = { version = "0.7", features = ["macros"] }
-tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/xavyo-api-tenants/Cargo.toml
+++ b/crates/xavyo-api-tenants/Cargo.toml
@@ -67,7 +67,7 @@ url = "2.5"
 [dev-dependencies]
 tokio = { version = "1.35", features = ["full", "test-util"] }
 tower = { version = "0.4", features = ["util"] }
-axum-test = "14"
+axum-test = { workspace = true }
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "postgres", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/crates/xavyo-auth/Cargo.toml
+++ b/crates/xavyo-auth/Cargo.toml
@@ -46,7 +46,7 @@ base64 = "0.22"
 
 [dev-dependencies]
 tokio = { version = "1.35", features = ["full"] }
-wiremock = "0.5"
+wiremock = "0.6"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- **CLI batch executor**: Replaced 10 `.unwrap()` calls on user-provided `Option` fields with proper validation and graceful failure reporting (prevents panics on malformed batch input)
- **Dependency standardization**: Unified `axum-test` to workspace version across 6 crates, upgraded `wiremock` 0.5→0.6 in 2 crates, removed unused `tower`/`tower-http` from oidc-federation
- **All quality gates pass**: `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check`

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [ ] Run `cargo test --workspace` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)