### PR TITLE
fix: Remove SYSTEM_TENANT_ID bypass from business data handlers

### DIFF
--- a/crates/xavyo-api-tenants/src/handlers/oauth_clients.rs
+++ b/crates/xavyo-api-tenants/src/handlers/oauth_clients.rs
@@ -10,10 +10,7 @@ use axum::{
 use chrono::Utc;
 use uuid::Uuid;
 use xavyo_auth::JwtClaims;
-use xavyo_db::{
-    bootstrap::SYSTEM_TENANT_ID,
-    models::{AdminAction, AdminAuditLog, AdminResourceType, CreateAuditLogEntry},
-};
+use xavyo_db::models::{AdminAction, AdminAuditLog, AdminResourceType, CreateAuditLogEntry};
 
 use crate::error::TenantError;
 use crate::models::{
@@ -63,8 +60,7 @@ pub async fn rotate_oauth_secret_handler(
         .tid
         .ok_or_else(|| TenantError::Unauthorized("JWT claims missing tenant_id".to_string()))?;
 
-    // Allow system tenant admins or the tenant's own users
-    if caller_tenant_id != SYSTEM_TENANT_ID && caller_tenant_id != tenant_id {
+    if caller_tenant_id != tenant_id {
         return Err(TenantError::Forbidden(
             "You don't have access to this tenant's OAuth clients".to_string(),
         ));
@@ -174,7 +170,7 @@ pub async fn list_oauth_clients_handler(
         .tid
         .ok_or_else(|| TenantError::Unauthorized("JWT claims missing tenant_id".to_string()))?;
 
-    if caller_tenant_id != SYSTEM_TENANT_ID && caller_tenant_id != tenant_id {
+    if caller_tenant_id != tenant_id {
         return Err(TenantError::Forbidden(
             "You don't have access to this tenant's OAuth clients".to_string(),
         ));
@@ -241,7 +237,7 @@ pub async fn deactivate_oauth_client_handler(
         .tid
         .ok_or_else(|| TenantError::Unauthorized("JWT claims missing tenant_id".to_string()))?;
 
-    if caller_tenant_id != SYSTEM_TENANT_ID && caller_tenant_id != tenant_id {
+    if caller_tenant_id != tenant_id {
         return Err(TenantError::Forbidden(
             "You don't have access to this tenant's OAuth clients".to_string(),
         ));

--- a/crates/xavyo-api-tenants/src/handlers/settings.rs
+++ b/crates/xavyo-api-tenants/src/handlers/settings.rs
@@ -32,7 +32,6 @@ use crate::router::TenantAppState;
 ///
 /// Authorization:
 /// - Tenant users can only view settings for their own tenant
-/// - System administrators can view settings for any tenant
 #[utoipa::path(
     get,
     path = "/tenants/{tenant_id}/settings",
@@ -60,9 +59,8 @@ pub async fn get_tenant_user_settings_handler(
         .tid
         .ok_or_else(|| TenantError::Unauthorized("JWT claims missing tenant_id".to_string()))?;
 
-    // Authorization check: must be own tenant OR system admin
-    let is_system_admin = caller_tenant_id == SYSTEM_TENANT_ID;
-    if !is_system_admin && caller_tenant_id != tenant_id {
+    // Authorization check: must be own tenant
+    if caller_tenant_id != tenant_id {
         return Err(TenantError::Forbidden(
             "You don't have access to this tenant's settings".to_string(),
         ));
@@ -77,7 +75,6 @@ pub async fn get_tenant_user_settings_handler(
     tracing::debug!(
         tenant_id = %tenant_id,
         caller_tenant_id = %caller_tenant_id,
-        is_system_admin = %is_system_admin,
         "Tenant user retrieved settings"
     );
 


### PR DESCRIPTION
## Summary

- Remove `SYSTEM_TENANT_ID` bypass from 12 business data handlers across 4 files in `xavyo-api-tenants`
- Super admin can no longer access tenant API keys, OAuth clients, invitations, or settings via `/tenants/{id}/` endpoints
- Platform management endpoints (`/system/tenants/{id}/`) remain unchanged — super admin retains full tenant lifecycle capabilities

## Security Impact

**HIGH** — Closes a privilege escalation path where system tenant users could access business data across all tenants by exploiting the `SYSTEM_TENANT_ID` bypass in authorization checks.

### Before
```rust
if caller_tenant_id != SYSTEM_TENANT_ID && caller_tenant_id != tenant_id {
    return Err(Forbidden);
}
```

### After
```rust
if caller_tenant_id != tenant_id {
    return Err(Forbidden);
}
```

## Files Changed

| File | Handlers Fixed | Import Change |
|------|---------------|---------------|
| `api_keys.rs` | 5 (create, rotate, list, deactivate, usage) | Removed `SYSTEM_TENANT_ID` |
| `oauth_clients.rs` | 3 (rotate_secret, list, deactivate) | Removed `SYSTEM_TENANT_ID` |
| `invitations.rs` | 3 (create, list, cancel) | Removed `SYSTEM_TENANT_ID` |
| `settings.rs` | 1 (get_tenant_user_settings) | Kept (used by system handlers) |

## Audit Verification

- Confirmed NHI handlers are safe — they derive `TenantId` from JWT claims via `Extension<TenantId>`, not URL path parameters
- `jwt_auth_middleware` sets `Extension<TenantId>` from `claims.tid` (line 247), so all JWT-authenticated routes are scoped to the caller's own tenant
- Platform management handlers (`suspend.rs`, `delete.rs`, `usage.rs`, `provision.rs`, system settings) verified unchanged

## Test plan

- [x] `cargo check -p xavyo-api-tenants` — clean
- [x] `cargo clippy -p xavyo-api-tenants -- -D warnings` — 0 warnings
- [x] `cargo test -p xavyo-api-tenants` — 281 tests pass
- [x] `cargo fmt --check` — clean
- [ ] Manual verification: super admin gets 403 on `/tenants/{id}/api-keys`
- [ ] Manual verification: tenant admin gets 200 on `/tenants/{own_id}/api-keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)