### PR TITLE
fix: Super admin data isolation + tenant permission audit

### DIFF
--- a/crates/xavyo-api-tenants/src/handlers/invitations.rs
+++ b/crates/xavyo-api-tenants/src/handlers/invitations.rs
@@ -72,6 +72,13 @@ pub async fn create_invitation_handler(
         ));
     }
 
+    // Only admin/super_admin can create invitations
+    if !claims.has_role("admin") {
+        return Err(TenantError::Forbidden(
+            "Only administrators can manage invitations".to_string(),
+        ));
+    }
+
     // Get the user ID from claims
     let user_id = claims
         .sub
@@ -170,6 +177,13 @@ pub async fn list_invitations_handler(
         ));
     }
 
+    // Only admin/super_admin can list invitations
+    if !claims.has_role("admin") {
+        return Err(TenantError::Forbidden(
+            "Only administrators can manage invitations".to_string(),
+        ));
+    }
+
     // List invitations
     let service = TenantInvitationService::new(state.pool.clone());
     let (invitations, total) = service
@@ -244,6 +258,13 @@ pub async fn cancel_invitation_handler(
     if caller_tenant_id != tenant_id {
         return Err(TenantError::Forbidden(
             "You don't have access to this tenant's invitations".to_string(),
+        ));
+    }
+
+    // Only admin/super_admin can cancel invitations
+    if !claims.has_role("admin") {
+        return Err(TenantError::Forbidden(
+            "Only administrators can manage invitations".to_string(),
         ));
     }
 

--- a/crates/xavyo-api-tenants/src/handlers/oauth_clients.rs
+++ b/crates/xavyo-api-tenants/src/handlers/oauth_clients.rs
@@ -66,6 +66,13 @@ pub async fn rotate_oauth_secret_handler(
         ));
     }
 
+    // Only admin/super_admin can rotate OAuth client secrets
+    if !claims.has_role("admin") {
+        return Err(TenantError::Forbidden(
+            "Only administrators can manage OAuth clients".to_string(),
+        ));
+    }
+
     let admin_user_id = claims
         .sub
         .parse::<Uuid>()
@@ -176,6 +183,13 @@ pub async fn list_oauth_clients_handler(
         ));
     }
 
+    // Only admin/super_admin can list OAuth clients
+    if !claims.has_role("admin") {
+        return Err(TenantError::Forbidden(
+            "Only administrators can manage OAuth clients".to_string(),
+        ));
+    }
+
     let oauth_service = xavyo_api_oauth::services::OAuth2ClientService::new(state.pool.clone());
 
     let clients = oauth_service
@@ -240,6 +254,13 @@ pub async fn deactivate_oauth_client_handler(
     if caller_tenant_id != tenant_id {
         return Err(TenantError::Forbidden(
             "You don't have access to this tenant's OAuth clients".to_string(),
+        ));
+    }
+
+    // Only admin/super_admin can deactivate OAuth clients
+    if !claims.has_role("admin") {
+        return Err(TenantError::Forbidden(
+            "Only administrators can manage OAuth clients".to_string(),
         ));
     }
 

--- a/crates/xavyo-api-tenants/src/router.rs
+++ b/crates/xavyo-api-tenants/src/router.rs
@@ -152,8 +152,8 @@ pub fn system_admin_router(pool: PgPool) -> Router {
 /// ## Authorization
 ///
 /// Endpoints are accessible by:
-/// - System tenant administrators (can access any tenant)
-/// - Tenant's own users (can only access their tenant's keys/settings)
+/// - Tenant admins (can manage all keys/invitations within their tenant)
+/// - Tenant's own users (can only manage their own keys)
 /// - /api-keys/introspect requires a valid API key (introspects itself)
 pub fn api_keys_router(pool: PgPool) -> Router {
     let slug_service = Arc::new(SlugService::new(pool.clone()));
@@ -223,7 +223,7 @@ pub fn api_keys_router(pool: PgPool) -> Router {
 /// ## Authorization
 ///
 /// Endpoints are accessible by:
-/// - System tenant administrators (can access any tenant)
+/// - Tenant admins (can manage all OAuth clients within their tenant)
 /// - Tenant's own users (can only access their tenant's clients)
 pub fn oauth_clients_router(pool: PgPool) -> Router {
     let slug_service = Arc::new(SlugService::new(pool.clone()));


### PR DESCRIPTION
## Summary

- **Remove SYSTEM_TENANT_ID bypass** from 12 business data handlers (API keys, OAuth clients, invitations, settings) — closes privilege escalation where system admins could access any tenant's business data
- **Add admin permission checks** to API key (rotate/deactivate/list/usage), invitation (create/list/cancel), and OAuth client (list/rotate/deactivate) handlers — closes gap where any tenant user could manage all resources
- **Fix invitation role assignment** — accepted invitations now INSERT into `user_roles` within an RLS-safe transaction (fixes pre-existing bug where user INSERT used bare pool without tenant context)

## Test plan

- [x] `cargo check -p xavyo-api-tenants` — PASS
- [x] `cargo clippy -p xavyo-api-tenants -- -D warnings` — 0 warnings
- [x] `cargo test -p xavyo-api-tenants` — 15 passed, 0 failed
- [ ] Verify regular user gets 403 when rotating another user's API key
- [ ] Verify regular user only sees own keys in list
- [ ] Verify non-admin gets 403 on invitation create/list/cancel
- [ ] Verify non-admin gets 403 on OAuth client list/rotate/deactivate
- [ ] Verify system admin gets 403 on tenant business data endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)