### PR TITLE
fix: Add admin permission checks to 52 unprotected handlers

### DIFF
--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -54,7 +54,7 @@ use xavyo_api_nhi::{nhi_router, NhiState};
 use xavyo_api_oauth::router::{
     admin_oauth_router, device_router, oauth_router, well_known_router, OAuthState,
 };
-use xavyo_api_oidc_federation::{create_federation_router, FederationConfig};
+use xavyo_api_oidc_federation::{admin_routes as federation_admin_routes_fn, auth_routes as federation_auth_routes_fn, FederationConfig, FederationState};
 use xavyo_api_saml::{create_saml_state, saml_admin_router, saml_public_router};
 use xavyo_api_scim::{scim_admin_router, scim_resource_router, ScimConfig};
 use xavyo_api_social::{admin_social_router, public_social_router, SocialConfig, SocialState};
@@ -719,6 +719,7 @@ async fn main() {
     // Social login admin routes (requires admin role and tenant)
     let social_admin_routes = admin_social_router()
         .with_state(social_state)
+        .layer(axum::middleware::from_fn(admin_guard))
         .layer(axum::middleware::from_fn(jwt_auth_middleware))
         .layer(axum::Extension(JwtPublicKey(config.jwt_public_key.clone())))
         .layer(TenantLayer::with_config(
@@ -743,8 +744,9 @@ async fn main() {
                 .require_tenant(true)
                 .build(),
         ));
-    // SAML admin routes (SP/cert management) - require tenant and JWT auth
+    // SAML admin routes (SP/cert management) - require tenant, JWT auth, and admin role
     let saml_admin_routes = saml_admin_router(saml_state)
+        .layer(axum::middleware::from_fn(admin_guard))
         .layer(axum::middleware::from_fn(jwt_auth_middleware))
         .layer(axum::Extension(JwtPublicKey(config.jwt_public_key.clone())))
         .layer(TenantLayer::with_config(
@@ -760,8 +762,24 @@ async fn main() {
         master_key: config.federation_encryption_key,
         callback_base_url: config.issuer_url.clone(),
     };
-    let federation_routes =
-        create_federation_router(federation_config).layer(TenantLayer::with_config(
+    let federation_state = FederationState::new(&federation_config);
+    // Federation public routes (discover, authorize, callback, logout) - no auth required
+    let federation_public_routes = Router::new()
+        .nest("/auth/federation", federation_auth_routes_fn())
+        .with_state(federation_state.clone())
+        .layer(TenantLayer::with_config(
+            xavyo_tenant::TenantConfig::builder()
+                .require_tenant(true)
+                .build(),
+        ));
+    // Federation admin routes (IdP CRUD, domains) - require tenant, JWT auth, and admin role
+    let federation_admin_routes = Router::new()
+        .nest("/admin/federation", federation_admin_routes_fn())
+        .with_state(federation_state)
+        .layer(axum::middleware::from_fn(admin_guard))
+        .layer(axum::middleware::from_fn(jwt_auth_middleware))
+        .layer(axum::Extension(JwtPublicKey(config.jwt_public_key.clone())))
+        .layer(TenantLayer::with_config(
             xavyo_tenant::TenantConfig::builder()
                 .require_tenant(true)
                 .build(),
@@ -1098,8 +1116,10 @@ async fn main() {
         .merge(saml_public_routes)
         // SAML admin routes (SP/cert management)
         .nest("/admin/saml", saml_admin_routes)
-        // OIDC Federation routes (external IdP integration)
-        .merge(federation_routes)
+        // OIDC Federation public routes (discover, authorize, callback, logout)
+        .merge(federation_public_routes)
+        // OIDC Federation admin routes (IdP CRUD, domains - requires admin role)
+        .merge(federation_admin_routes)
         // SCIM 2.0 resource provisioning routes (SCIM Bearer token auth)
         .nest("/scim/v2", scim_resource_routes)
         // SCIM admin routes (JWT + admin role)

--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -63,7 +63,8 @@ use xavyo_api_tenants::{
     tenant_router,
 };
 use xavyo_api_users::{
-    attribute_definitions_router, bulk_operations_router, groups_router, users_router, UsersState,
+    attribute_definitions_router, bulk_operations_router, groups_router,
+    middleware::admin_guard, users_router, UsersState,
 };
 use xavyo_connector::crypto::CredentialEncryption;
 use xavyo_connector::registry::ConnectorRegistry;
@@ -782,6 +783,7 @@ async fn main() {
     // Governance routes (F033 - IGA Entitlement Management)
     // F113: Support both API key and JWT authentication for programmatic access
     let governance_routes = governance_router(pool.clone())
+        .layer(axum::middleware::from_fn(admin_guard))
         .layer(axum::middleware::from_fn(jwt_auth_middleware))
         .layer(axum::middleware::from_fn(api_key_auth_middleware))
         .layer(axum::Extension(JwtPublicKey(config.jwt_public_key.clone())))

--- a/crates/xavyo-api-connectors/src/handlers/scim_log.rs
+++ b/crates/xavyo-api-connectors/src/handlers/scim_log.rs
@@ -72,6 +72,9 @@ pub async fn list_provisioning_log(
     Path(target_id): Path<Uuid>,
     Query(query): Query<ListProvisioningLogQuery>,
 ) -> Result<Json<ProvisioningLogListResponse>> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
 
@@ -127,6 +130,9 @@ pub async fn get_log_detail(
     Extension(claims): Extension<JwtClaims>,
     Path((target_id, log_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<ScimProvisioningLog>> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
 

--- a/crates/xavyo-api-connectors/src/handlers/scim_mappings.rs
+++ b/crates/xavyo-api-connectors/src/handlers/scim_mappings.rs
@@ -85,6 +85,9 @@ pub async fn list_mappings(
     Path(target_id): Path<Uuid>,
     Query(query): Query<ListMappingsQuery>,
 ) -> Result<Json<MappingListResponse>> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
 

--- a/crates/xavyo-api-connectors/src/handlers/scim_provisioning.rs
+++ b/crates/xavyo-api-connectors/src/handlers/scim_provisioning.rs
@@ -82,6 +82,9 @@ pub async fn list_provisioning_state(
     Path(target_id): Path<Uuid>,
     Query(query): Query<ListProvisioningStateQuery>,
 ) -> Result<Json<ProvisioningStateListResponse>> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
 
@@ -138,6 +141,9 @@ pub async fn retry_provisioning(
     Extension(claims): Extension<JwtClaims>,
     Path((target_id, state_id)): Path<(Uuid, Uuid)>,
 ) -> Result<(StatusCode, Json<RetryResponse>)> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
 

--- a/crates/xavyo-api-connectors/src/handlers/scim_sync.rs
+++ b/crates/xavyo-api-connectors/src/handlers/scim_sync.rs
@@ -80,6 +80,9 @@ pub async fn trigger_sync(
     Extension(claims): Extension<JwtClaims>,
     Path(target_id): Path<Uuid>,
 ) -> Result<(StatusCode, Json<TriggerSyncResponse>)> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
     let triggered_by = Uuid::parse_str(&claims.sub).ok();
@@ -148,6 +151,9 @@ pub async fn trigger_reconciliation(
     Extension(claims): Extension<JwtClaims>,
     Path(target_id): Path<Uuid>,
 ) -> Result<(StatusCode, Json<TriggerSyncResponse>)> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
     let triggered_by = Uuid::parse_str(&claims.sub).ok();
@@ -217,6 +223,9 @@ pub async fn list_sync_runs(
     Path(target_id): Path<Uuid>,
     Query(query): Query<ListSyncRunsQuery>,
 ) -> Result<Json<SyncRunListResponse>> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
 
@@ -271,6 +280,9 @@ pub async fn get_sync_run(
     Extension(claims): Extension<JwtClaims>,
     Path((target_id, run_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<ScimSyncRun>> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let pool = state.scim_target_service.pool();
 

--- a/crates/xavyo-api-connectors/src/handlers/scim_targets.rs
+++ b/crates/xavyo-api-connectors/src/handlers/scim_targets.rs
@@ -94,6 +94,9 @@ pub async fn list_scim_targets(
     Extension(claims): Extension<JwtClaims>,
     Query(query): Query<ListScimTargetsQuery>,
 ) -> Result<Json<ScimTargetListResponse>> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let limit = query.limit.clamp(1, 100);
     let offset = query.offset.max(0);
@@ -122,6 +125,9 @@ pub async fn get_scim_target(
     Extension(claims): Extension<JwtClaims>,
     Path(target_id): Path<Uuid>,
 ) -> Result<Json<ScimTargetResponse>> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let target = state
         .scim_target_service

--- a/crates/xavyo-api-connectors/src/handlers/sync.rs
+++ b/crates/xavyo-api-connectors/src/handlers/sync.rs
@@ -363,6 +363,9 @@ pub async fn get_sync_token(
     Extension(claims): Extension<JwtClaims>,
     Path(connector_id): Path<Uuid>,
 ) -> Result<Json<SyncTokenResponse>, ApiError> {
+    if !claims.has_role("admin") {
+        return Err(ConnectorApiError::Forbidden);
+    }
     let _tenant_id = extract_tenant_id(&claims)?;
 
     let token = state

--- a/crates/xavyo-api-nhi/src/handlers/certification.rs
+++ b/crates/xavyo-api-nhi/src/handlers/certification.rs
@@ -161,8 +161,12 @@ pub async fn create_campaign(
 pub async fn list_campaigns(
     State(state): State<NhiState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Query(query): Query<ListCampaignsQuery>,
 ) -> Result<impl IntoResponse, NhiApiError> {
+    if !claims.has_role("admin") {
+        return Err(NhiApiError::Forbidden);
+    }
     let tenant_uuid = *tenant_id.as_uuid();
     let limit = query.limit.unwrap_or(20).clamp(1, 100);
     let offset = query.offset.unwrap_or(0).max(0);

--- a/crates/xavyo-api-nhi/src/handlers/permissions.rs
+++ b/crates/xavyo-api-nhi/src/handlers/permissions.rs
@@ -162,9 +162,13 @@ pub async fn revoke_permission(
 pub async fn list_agent_tools(
     State(state): State<NhiState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Path(agent_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<PaginatedResponse<NhiToolPermission>>, NhiApiError> {
+    if !claims.has_role("admin") {
+        return Err(NhiApiError::Forbidden);
+    }
     let tenant_uuid = *tenant_id.as_uuid();
     let limit = query.limit.unwrap_or(20).clamp(1, 100);
     let offset = query.offset.unwrap_or(0).max(0);
@@ -199,9 +203,13 @@ pub async fn list_agent_tools(
 pub async fn list_tool_agents(
     State(state): State<NhiState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Path(tool_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<PaginatedResponse<NhiToolPermission>>, NhiApiError> {
+    if !claims.has_role("admin") {
+        return Err(NhiApiError::Forbidden);
+    }
     let tenant_uuid = *tenant_id.as_uuid();
     let limit = query.limit.unwrap_or(20).clamp(1, 100);
     let offset = query.offset.unwrap_or(0).max(0);

--- a/crates/xavyo-api-nhi/src/handlers/sod.rs
+++ b/crates/xavyo-api-nhi/src/handlers/sod.rs
@@ -199,8 +199,12 @@ pub async fn create_sod_rule(
 pub async fn list_sod_rules(
     State(state): State<NhiState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<PaginatedResponse<SodRule>>, NhiApiError> {
+    if !claims.has_role("admin") {
+        return Err(NhiApiError::Forbidden);
+    }
     let tenant_uuid = *tenant_id.as_uuid();
     let limit = query.limit.unwrap_or(20).clamp(1, 100);
     let offset = query.offset.unwrap_or(0).max(0);
@@ -289,8 +293,12 @@ pub async fn delete_sod_rule(
 pub async fn check_sod(
     State(state): State<NhiState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Json(request): Json<SodCheckRequest>,
 ) -> Result<Json<SodCheckResult>, NhiApiError> {
+    if !claims.has_role("admin") {
+        return Err(NhiApiError::Forbidden);
+    }
     let tenant_uuid = *tenant_id.as_uuid();
 
     // Get the agent's current tool permissions (non-expired)

--- a/crates/xavyo-api-oauth/src/handlers/client_admin.rs
+++ b/crates/xavyo-api-oauth/src/handlers/client_admin.rs
@@ -15,6 +15,7 @@ use axum::{
     Extension, Json,
 };
 use uuid::Uuid;
+use xavyo_auth::JwtClaims;
 use xavyo_core::TenantId;
 
 /// Lists all `OAuth2` clients for the current tenant.
@@ -32,7 +33,11 @@ use xavyo_core::TenantId;
 pub async fn list_clients_handler(
     State(state): State<OAuthState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
 ) -> Result<Json<ClientListResponse>, OAuthError> {
+    if !claims.has_role("admin") {
+        return Err(OAuthError::AccessDenied("Admin role required".into()));
+    }
     let tid = *tenant_id.as_uuid();
 
     let clients = state.client_service.list_clients(tid).await?;
@@ -60,8 +65,12 @@ pub async fn list_clients_handler(
 pub async fn get_client_handler(
     State(state): State<OAuthState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ClientResponse>, OAuthError> {
+    if !claims.has_role("admin") {
+        return Err(OAuthError::AccessDenied("Admin role required".into()));
+    }
     let tid = *tenant_id.as_uuid();
 
     let client = state.client_service.get_client_by_id(tid, id).await?;
@@ -86,8 +95,12 @@ pub async fn get_client_handler(
 pub async fn create_client_handler(
     State(state): State<OAuthState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Json(request): Json<CreateClientRequest>,
 ) -> Result<Json<CreateClientResponse>, OAuthError> {
+    if !claims.has_role("admin") {
+        return Err(OAuthError::AccessDenied("Admin role required".into()));
+    }
     let tid = *tenant_id.as_uuid();
 
     // Validate the request
@@ -152,9 +165,13 @@ pub async fn create_client_handler(
 pub async fn update_client_handler(
     State(state): State<OAuthState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Path(id): Path<Uuid>,
     Json(request): Json<UpdateClientRequest>,
 ) -> Result<Json<ClientResponse>, OAuthError> {
+    if !claims.has_role("admin") {
+        return Err(OAuthError::AccessDenied("Admin role required".into()));
+    }
     let tid = *tenant_id.as_uuid();
 
     // Validate grant types if provided
@@ -193,8 +210,12 @@ pub async fn update_client_handler(
 pub async fn delete_client_handler(
     State(state): State<OAuthState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, OAuthError> {
+    if !claims.has_role("admin") {
+        return Err(OAuthError::AccessDenied("Admin role required".into()));
+    }
     let tid = *tenant_id.as_uuid();
 
     state.client_service.deactivate_client(tid, id).await?;
@@ -222,8 +243,12 @@ pub async fn delete_client_handler(
 pub async fn regenerate_secret_handler(
     State(state): State<OAuthState>,
     Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<RegenerateSecretResponse>, OAuthError> {
+    if !claims.has_role("admin") {
+        return Err(OAuthError::AccessDenied("Admin role required".into()));
+    }
     let tid = *tenant_id.as_uuid();
 
     let new_secret = state

--- a/crates/xavyo-webhooks/src/error.rs
+++ b/crates/xavyo-webhooks/src/error.rs
@@ -32,6 +32,9 @@ pub enum WebhookError {
     #[error("Unauthorized")]
     Unauthorized,
 
+    #[error("Forbidden: admin role required")]
+    Forbidden,
+
     #[error("Invalid request: {0}")]
     Validation(String),
 
@@ -83,6 +86,7 @@ impl IntoResponse for WebhookError {
                 (StatusCode::INTERNAL_SERVER_ERROR, "encryption_error")
             }
             WebhookError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized"),
+            WebhookError::Forbidden => (StatusCode::FORBIDDEN, "forbidden"),
             WebhookError::Validation(_) => (StatusCode::BAD_REQUEST, "validation_error"),
             WebhookError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal_error"),
             // Circuit breaker errors

--- a/crates/xavyo-webhooks/src/handlers/dlq.rs
+++ b/crates/xavyo-webhooks/src/handlers/dlq.rs
@@ -137,6 +137,9 @@ pub async fn delete_dlq_entry_handler(
     Extension(claims): Extension<JwtClaims>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
+    if !claims.has_role("admin") {
+        return Err(WebhookError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
 
     let deleted = state.dlq_service.delete_entry(tenant_id, id).await?;
@@ -173,6 +176,9 @@ pub async fn replay_single_handler(
     Extension(claims): Extension<JwtClaims>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<ReplayResponse>> {
+    if !claims.has_role("admin") {
+        return Err(WebhookError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
 
     let response = state.dlq_service.replay_single(tenant_id, id).await?;
@@ -198,6 +204,9 @@ pub async fn replay_bulk_handler(
     Extension(claims): Extension<JwtClaims>,
     Json(request): Json<BulkReplayRequest>,
 ) -> ApiResult<Json<BulkReplayResponse>> {
+    if !claims.has_role("admin") {
+        return Err(WebhookError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
 
     let response = state.dlq_service.replay_bulk(tenant_id, request).await?;

--- a/crates/xavyo-webhooks/src/handlers/subscriptions.rs
+++ b/crates/xavyo-webhooks/src/handlers/subscriptions.rs
@@ -48,6 +48,9 @@ pub async fn create_subscription_handler(
     Extension(claims): Extension<JwtClaims>,
     Json(request): Json<CreateWebhookSubscriptionRequest>,
 ) -> ApiResult<(StatusCode, Json<WebhookSubscriptionResponse>)> {
+    if !claims.has_role("admin") {
+        return Err(WebhookError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
     let actor_id = Uuid::parse_str(&claims.sub).ok();
 
@@ -143,6 +146,9 @@ pub async fn update_subscription_handler(
     Path(id): Path<Uuid>,
     Json(request): Json<UpdateWebhookSubscriptionRequest>,
 ) -> ApiResult<Json<WebhookSubscriptionResponse>> {
+    if !claims.has_role("admin") {
+        return Err(WebhookError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
 
     request
@@ -177,6 +183,9 @@ pub async fn delete_subscription_handler(
     Extension(claims): Extension<JwtClaims>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
+    if !claims.has_role("admin") {
+        return Err(WebhookError::Forbidden);
+    }
     let tenant_id = extract_tenant_id(&claims)?;
 
     state


### PR DESCRIPTION
## Summary

Comprehensive permission audit across all 15 API crates found **52 handlers** missing admin role enforcement, allowing any authenticated tenant user to access admin-only endpoints. One route group (OIDC Federation admin) had **no authentication at all**.

### Commit 1: Handler-level fixes (31 handlers across 7 crates)

- **xavyo-api-auth** (2): Session policy get/update had zero permission checks
- **xavyo-webhooks** (6): Subscription create/update/delete + DLQ delete/replay/bulk-replay; added `Forbidden` error variant
- **xavyo-api-connectors** (12): SCIM targets list/get, mappings list, sync trigger/reconcile/list/get, provisioning list/retry, log list/get, sync-token get
- **xavyo-api-oauth** (6): Client admin list/get/create/update/delete and regenerate-secret; added `JwtClaims` extraction
- **xavyo-api-nhi** (7): Risk get/summary, SoD list/check, permissions list-agent-tools/list-tool-agents, certification list-campaigns
- **xavyo-api-governance** (600+): `admin_guard` middleware layer applied to all governance routes

### Commit 2: Middleware-level fixes (21 handlers across 3 route groups)

- **SAML admin** (8): SP/certificate CRUD — added `admin_guard` middleware
- **Social admin** (3): Provider config — added `admin_guard` middleware
- **OIDC Federation admin** (10): **CRITICAL** — IdP CRUD and domain management had NO JWT auth at all. Split combined router into public (discover/authorize/callback/logout) and admin (IdP CRUD/domains) with separate middleware stacks: admin now has TenantLayer + JWT auth + `admin_guard`

### Crates confirmed clean (no changes needed)

- xavyo-api-authorization (12/12 handlers protected)
- xavyo-api-scim inbound (5/5 admin handlers protected)
- xavyo-api-import (7/7 protected)
- xavyo-api-protocols (MCP/A2A all checked)
- xavyo-api-users (uses `admin_guard` middleware)

## Test plan

- [x] `cargo check` passes for all affected crates
- [x] `cargo clippy -- -D warnings` passes for all affected crates
- [x] `cargo test` passes for xavyo-api-oauth, xavyo-api-nhi, xavyo-api-auth, xavyo-webhooks, xavyo-api-connectors
- [ ] Full functional test suite (`tests/functional/run-all-batches.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)