### PR TITLE
security: Input validation, rate limiting, and error sanitization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8410,6 +8410,7 @@ dependencies = [
  "tracing",
  "utoipa",
  "uuid",
+ "validator",
  "xavyo-auth",
  "xavyo-connector",
  "xavyo-connector-database",

--- a/crates/xavyo-api-auth/src/middleware/mod.rs
+++ b/crates/xavyo-api-auth/src/middleware/mod.rs
@@ -16,7 +16,8 @@ pub use permission_guard::{
     PermissionGuardState, ScopeCheckResult,
 };
 pub use rate_limit::{
-    rate_limit_middleware, signup_rate_limit_middleware, signup_rate_limiter, ApiKeyRateLimiter,
+    rate_limit_middleware, sensitive_rate_limiter, signup_rate_limit_middleware,
+    signup_rate_limiter, ApiKeyRateLimiter,
     EmailRateLimiter, RateLimitConfig, RateLimitKey, RateLimiter, DEFAULT_MAX_ATTEMPTS,
     DEFAULT_WINDOW_SECS, EMAIL_IP_RATE_LIMIT_MAX, EMAIL_RATE_LIMIT_MAX,
     EMAIL_RATE_LIMIT_WINDOW_SECS, SIGNUP_RATE_LIMIT_MAX, SIGNUP_RATE_LIMIT_WINDOW_SECS,

--- a/crates/xavyo-api-auth/src/middleware/rate_limit.rs
+++ b/crates/xavyo-api-auth/src/middleware/rate_limit.rs
@@ -459,6 +459,18 @@ pub fn signup_rate_limiter() -> RateLimiter {
     })
 }
 
+/// Rate limiter for sensitive endpoints (MFA verification, password change, email change).
+///
+/// Configuration: 5 attempts per IP per minute.
+/// Protects against brute-force attacks on authentication factors.
+#[must_use]
+pub fn sensitive_rate_limiter() -> RateLimiter {
+    RateLimiter::new(RateLimitConfig {
+        max_attempts: 5,
+        window: Duration::from_secs(60),
+    })
+}
+
 /// Rate limiting middleware specifically for signup endpoint (F111).
 ///
 /// Similar to `rate_limit_middleware` but uses a separate rate limiter

--- a/crates/xavyo-api-authorization/src/error.rs
+++ b/crates/xavyo-api-authorization/src/error.rs
@@ -51,11 +51,14 @@ impl IntoResponse for ApiAuthorizationError {
                 "database_error",
                 "Internal server error".to_string(),
             ),
-            Self::Authorization(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "authorization_error",
-                e.to_string(),
-            ),
+            Self::Authorization(ref e) => {
+                tracing::error!("Authorization engine error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "authorization_error",
+                    "An authorization error occurred".to_string(),
+                )
+            }
         };
         let body = json!({ "error": error_code, "message": message });
         (status, Json(body)).into_response()

--- a/crates/xavyo-api-connectors/Cargo.toml
+++ b/crates/xavyo-api-connectors/Cargo.toml
@@ -41,6 +41,9 @@ serde_json = { workspace = true }
 # HTTP client (for SCIM outbound provisioning)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
+# Input validation
+validator = { version = "0.20", features = ["derive"] }
+
 # Utilities
 uuid = { workspace = true }
 chrono = { workspace = true }

--- a/crates/xavyo-api-connectors/src/handlers/connectors.rs
+++ b/crates/xavyo-api-connectors/src/handlers/connectors.rs
@@ -8,6 +8,7 @@ use axum::{
 use chrono::Utc;
 use uuid::Uuid;
 
+use validator::Validate;
 use xavyo_auth::JwtClaims;
 use xavyo_db::models::{
     ConnectorFilter, CreateConnectorConfiguration, UpdateConnectorConfiguration,
@@ -114,6 +115,9 @@ pub async fn create_connector(
     if !claims.has_role("admin") {
         return Err(ConnectorApiError::Forbidden);
     }
+    request
+        .validate()
+        .map_err(|e| ConnectorApiError::Validation(e.to_string()))?;
     let tenant_id = extract_tenant_id(&claims)?;
 
     let input = CreateConnectorConfiguration {
@@ -160,6 +164,9 @@ pub async fn update_connector(
     if !claims.has_role("admin") {
         return Err(ConnectorApiError::Forbidden);
     }
+    request
+        .validate()
+        .map_err(|e| ConnectorApiError::Validation(e.to_string()))?;
     let tenant_id = extract_tenant_id(&claims)?;
 
     let input = UpdateConnectorConfiguration {

--- a/crates/xavyo-api-connectors/src/models.rs
+++ b/crates/xavyo-api-connectors/src/models.rs
@@ -4,13 +4,15 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
+use validator::Validate;
 
 use xavyo_db::models::{ConnectorStatus, ConnectorType};
 
 /// Request to create a new connector.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
 pub struct CreateConnectorRequest {
     /// Connector display name.
+    #[validate(length(min = 1, max = 255, message = "Name must be 1-255 characters"))]
     pub name: String,
 
     /// Connector type (ldap, database, rest).
@@ -18,6 +20,7 @@ pub struct CreateConnectorRequest {
 
     /// Optional description.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(length(max = 2000, message = "Description cannot exceed 2000 characters"))]
     pub description: Option<String>,
 
     /// Non-sensitive configuration (JSON).
@@ -28,14 +31,16 @@ pub struct CreateConnectorRequest {
 }
 
 /// Request to update a connector.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
 pub struct UpdateConnectorRequest {
     /// New display name.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(length(min = 1, max = 255, message = "Name must be 1-255 characters"))]
     pub name: Option<String>,
 
     /// New description.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(length(max = 2000, message = "Description cannot exceed 2000 characters"))]
     pub description: Option<String>,
 
     /// Updated configuration.

--- a/crates/xavyo-api-governance/src/models/catalog.rs
+++ b/crates/xavyo-api-governance/src/models/catalog.rs
@@ -74,12 +74,15 @@ pub struct ListCategoriesQuery {
     /// Filter by parent category ID. Use "null" for root categories.
     pub parent_id: Option<String>,
 
-    /// Maximum number of results to return.
-    #[serde(default = "default_limit")]
+    /// Maximum number of results to return (clamped to 1-100).
+    #[serde(
+        default = "default_limit",
+        deserialize_with = "deserialize_clamped_limit"
+    )]
     pub limit: i64,
 
-    /// Number of results to skip.
-    #[serde(default)]
+    /// Number of results to skip (non-negative).
+    #[serde(default, deserialize_with = "deserialize_non_negative_offset")]
     pub offset: i64,
 }
 
@@ -242,12 +245,15 @@ pub struct ListCatalogItemsQuery {
     /// Beneficiary ID for eligibility check.
     pub beneficiary_id: Option<Uuid>,
 
-    /// Maximum number of results to return.
-    #[serde(default = "default_limit")]
+    /// Maximum number of results to return (clamped to 1-100).
+    #[serde(
+        default = "default_limit",
+        deserialize_with = "deserialize_clamped_limit"
+    )]
     pub limit: i64,
 
-    /// Number of results to skip.
-    #[serde(default)]
+    /// Number of results to skip (non-negative).
+    #[serde(default, deserialize_with = "deserialize_non_negative_offset")]
     pub offset: i64,
 }
 
@@ -594,12 +600,15 @@ pub struct ListCatalogRequestsQuery {
     /// Filter by submission ID.
     pub submission_id: Option<Uuid>,
 
-    /// Maximum number of results to return.
-    #[serde(default = "default_limit")]
+    /// Maximum number of results to return (clamped to 1-100).
+    #[serde(
+        default = "default_limit",
+        deserialize_with = "deserialize_clamped_limit"
+    )]
     pub limit: i64,
 
-    /// Number of results to skip.
-    #[serde(default)]
+    /// Number of results to skip (non-negative).
+    #[serde(default, deserialize_with = "deserialize_non_negative_offset")]
     pub offset: i64,
 }
 
@@ -662,6 +671,24 @@ pub struct CatalogRequestListResponse {
 
 fn default_limit() -> i64 {
     50
+}
+
+/// Deserialize limit with clamping to [1, 100].
+fn deserialize_clamped_limit<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = i64::deserialize(deserializer)?;
+    Ok(v.clamp(1, 100))
+}
+
+/// Deserialize offset ensuring non-negative.
+fn deserialize_non_negative_offset<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = i64::deserialize(deserializer)?;
+    Ok(v.max(0))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **Rate limiting on MFA endpoints**: TOTP verify, recovery code verify, and WebAuthn authenticate are now rate-limited at 5 attempts/min/IP to prevent brute-force attacks on authentication factors
- **Rate limiting on sensitive endpoints**: Password change and email change endpoints now have IP-based rate limiting (5/min)
- **Error sanitization**: Authorization engine errors, OAuth database/JWT/internal errors no longer leak internal details in API responses (logged server-side instead)
- **Pagination bounds**: Governance catalog query parameters now clamp `limit` to [1, 100] and `offset` to [0, ∞) via custom serde deserializers, preventing memory exhaustion via unbounded queries
- **Input validation**: Connector create/update requests now validate `name` (1-255 chars) and `description` (max 2000 chars) using the validator crate

## Test plan

- [x] All 5 modified crates compile (`cargo check`)
- [x] All 5 modified crates pass clippy (`cargo clippy -- -D warnings`)
- [x] All 63 xavyo-api-auth unit tests pass
- [x] Main API binary (`idp-api`) compiles
- [ ] Functional tests should be run to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)