### PR TITLE
security: Session revocation, SSRF protection, and atty replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,17 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auto-future"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,15 +2687,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -3293,7 +3273,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -4147,7 +4127,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -8812,7 +8792,6 @@ version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "atty",
  "base64 0.22.1",
  "chrono",
  "clap",

--- a/apps/xavyo-cli/Cargo.toml
+++ b/apps/xavyo-cli/Cargo.toml
@@ -71,9 +71,6 @@ indicatif = "0.17"
 # Interactive prompts
 dialoguer = "0.11"
 
-# TTY detection
-atty = "0.2"
-
 # UUID for parsing JWT claims
 uuid = { version = "1", features = ["serde", "v4"] }
 

--- a/apps/xavyo-cli/src/batch/executor.rs
+++ b/apps/xavyo-cli/src/batch/executor.rs
@@ -2,6 +2,8 @@
 //!
 //! Executes batch create, update, and delete operations with progress tracking.
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::batch::file::BatchFile;
 use crate::batch::filter::Filter;
@@ -268,7 +270,7 @@ impl BatchExecutor {
 
         // Confirm deletion
         if !options.force {
-            if !atty::is(atty::Stream::Stdin) {
+            if !std::io::stdin().is_terminal() {
                 return Err(CliError::Validation(
                     "Cannot confirm deletion in non-interactive mode. Use --force to skip confirmation."
                         .to_string(),
@@ -371,7 +373,7 @@ impl BatchExecutor {
 
         // Confirm with type-to-confirm
         if !options.force {
-            if !atty::is(atty::Stream::Stdin) {
+            if !std::io::stdin().is_terminal() {
                 return Err(CliError::Validation(
                     "Cannot confirm deletion in non-interactive mode. Use --force to skip confirmation."
                         .to_string(),
@@ -763,7 +765,7 @@ impl BatchExecutor {
 
         // Confirm deletion
         if !options.force {
-            if !atty::is(atty::Stream::Stdin) {
+            if !std::io::stdin().is_terminal() {
                 return Err(CliError::Validation(
                     "Cannot confirm deletion in non-interactive mode. Use --force to skip confirmation."
                         .to_string(),
@@ -866,7 +868,7 @@ impl BatchExecutor {
 
         // Confirm with type-to-confirm
         if !options.force {
-            if !atty::is(atty::Stream::Stdin) {
+            if !std::io::stdin().is_terminal() {
                 return Err(CliError::Validation(
                     "Cannot confirm deletion in non-interactive mode. Use --force to skip confirmation."
                         .to_string(),

--- a/apps/xavyo-cli/src/commands/apply.rs
+++ b/apps/xavyo-cli/src/commands/apply.rs
@@ -1,5 +1,7 @@
 //! Apply configuration from YAML file
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::config::{Config, ConfigPaths};
 use crate::error::{CliError, CliResult};
@@ -79,7 +81,7 @@ pub async fn execute(args: ApplyArgs) -> CliResult<()> {
 
     // Confirm before applying (unless --yes is passed)
     if !args.yes {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Cannot confirm in non-interactive mode. Use --yes to skip confirmation."
                     .to_string(),

--- a/apps/xavyo-cli/src/commands/cache.rs
+++ b/apps/xavyo-cli/src/commands/cache.rs
@@ -1,5 +1,7 @@
 //! Cache management CLI commands
 
+use std::io::IsTerminal;
+
 use crate::cache::{CacheStore, FileCacheStore};
 use crate::config::ConfigPaths;
 use crate::error::CliResult;
@@ -107,7 +109,7 @@ async fn execute_cache_clear(args: CacheClearArgs) -> CliResult<()> {
 
     // Confirm unless --yes is used
     if !args.yes {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(crate::error::CliError::Validation(
                 "Cannot confirm cache clear in non-interactive mode. Use --yes to skip confirmation."
                     .to_string(),

--- a/apps/xavyo-cli/src/commands/connectors.rs
+++ b/apps/xavyo-cli/src/commands/connectors.rs
@@ -1,5 +1,7 @@
 //! Connector management CLI commands
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::error::{CliError, CliResult};
 use crate::models::connector::{ConnectorResponse, CreateConnectorRequest};
@@ -165,7 +167,7 @@ async fn execute_delete(args: DeleteArgs) -> CliResult<()> {
     let conn = client.get_connector(id).await?;
 
     if !args.force {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Use --force in non-interactive mode.".to_string(),
             ));

--- a/apps/xavyo-cli/src/commands/diff.rs
+++ b/apps/xavyo-cli/src/commands/diff.rs
@@ -20,6 +20,8 @@
 //! xavyo diff config.yaml --remote --output json
 //! ```
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::commands::apply::{fetch_current_state, load_config};
 use crate::config::{Config, ConfigPaths};
@@ -189,7 +191,7 @@ fn should_use_color(no_color_flag: bool) -> bool {
     }
 
     // Check if stdout is a TTY
-    atty::is(atty::Stream::Stdout)
+    std::io::stdout().is_terminal()
 }
 
 /// Compare two local configuration files

--- a/apps/xavyo-cli/src/commands/nhi.rs
+++ b/apps/xavyo-cli/src/commands/nhi.rs
@@ -1,5 +1,7 @@
 //! Unified NHI management CLI commands
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::error::{CliError, CliResult};
 use crate::models::nhi::{
@@ -637,7 +639,7 @@ async fn execute_cred_revoke(args: CredRevokeArgs) -> CliResult<()> {
     let client = ApiClient::from_defaults()?;
 
     if !args.force {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Use --force in non-interactive mode.".to_string(),
             ));
@@ -960,7 +962,7 @@ async fn execute_sod_delete_rule(args: SodDeleteRuleArgs) -> CliResult<()> {
     let client = ApiClient::from_defaults()?;
 
     if !args.force {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Use --force in non-interactive mode.".to_string(),
             ));

--- a/apps/xavyo-cli/src/commands/service_accounts.rs
+++ b/apps/xavyo-cli/src/commands/service_accounts.rs
@@ -1,5 +1,7 @@
 //! Service account management CLI commands
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::error::{CliError, CliResult};
 use crate::models::service_account::{
@@ -206,7 +208,7 @@ async fn execute_delete(args: DeleteArgs) -> CliResult<()> {
     let sa = client.get_service_account(id).await?;
 
     if !args.force {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Use --force in non-interactive mode.".to_string(),
             ));

--- a/apps/xavyo-cli/src/commands/sessions.rs
+++ b/apps/xavyo-cli/src/commands/sessions.rs
@@ -1,5 +1,7 @@
 //! Session management CLI commands
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::config::{Config, ConfigPaths};
 use crate::error::{CliError, CliResult};
@@ -165,7 +167,7 @@ async fn execute_revoke_single(
     if session.is_current {
         // Warn about revoking current session
         if !skip_confirm {
-            if !atty::is(atty::Stream::Stdin) {
+            if !std::io::stdin().is_terminal() {
                 return Err(CliError::Validation(
                     "Cannot revoke current session in non-interactive mode. Use 'xavyo logout' instead.".to_string(),
                 ));
@@ -188,7 +190,7 @@ async fn execute_revoke_single(
         }
     } else if !skip_confirm {
         // Confirm revocation for non-current session
-        if atty::is(atty::Stream::Stdin) {
+        if std::io::stdin().is_terminal() {
             let device_info = format!("{} ({})", session.device_name, session.device_type);
             let confirm = Confirm::new()
                 .with_prompt(format!("Revoke session '{}'?", device_info))
@@ -227,7 +229,7 @@ async fn execute_revoke_all(client: &ApiClient, skip_confirm: bool) -> CliResult
 
     // Confirm revocation
     if !skip_confirm {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Cannot confirm revocation in non-interactive mode. Use --yes to skip confirmation.".to_string(),
             ));

--- a/apps/xavyo-cli/src/commands/shell.rs
+++ b/apps/xavyo-cli/src/commands/shell.rs
@@ -3,6 +3,8 @@
 //! Provides a REPL (Read-Eval-Print-Loop) interface for executing
 //! multiple xavyo commands in sequence with tab completion and history.
 
+use std::io::IsTerminal;
+
 use crate::config::ConfigPaths;
 use crate::error::{CliError, CliResult};
 use crate::repl::{CommandExecutor, ExecuteResult, Prompt, ShellSession};
@@ -23,7 +25,7 @@ pub struct ShellArgs {
 /// Execute the shell command
 pub async fn execute(args: ShellArgs) -> CliResult<()> {
     // Check if running in a TTY
-    if !atty::is(atty::Stream::Stdin) {
+    if !std::io::stdin().is_terminal() {
         return Err(CliError::Validation(
             "Interactive shell requires a terminal.\nUse standard commands for scripted operations.".to_string(),
         ));

--- a/apps/xavyo-cli/src/commands/templates/mod.rs
+++ b/apps/xavyo-cli/src/commands/templates/mod.rs
@@ -5,6 +5,8 @@ mod data_pipeline;
 mod saas_startup;
 mod security_scanner;
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::commands::apply::{
     apply_changes, compute_changes, fetch_current_state, print_planned_changes, validate_config,
@@ -358,7 +360,7 @@ async fn use_template(
 
     // Confirm before applying (unless --yes is passed)
     if !yes && !json_output {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Cannot confirm in non-interactive mode. Use --yes to skip confirmation."
                     .to_string(),

--- a/apps/xavyo-cli/src/commands/tools.rs
+++ b/apps/xavyo-cli/src/commands/tools.rs
@@ -1,5 +1,7 @@
 //! Tool management CLI commands
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::config::{Config, ConfigPaths};
 use crate::error::{CliError, CliResult};
@@ -279,7 +281,7 @@ async fn execute_delete(args: DeleteArgs) -> CliResult<()> {
 
     // Confirm deletion unless --force is used
     if !args.force {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Cannot confirm deletion in non-interactive mode. Use --force to skip confirmation."
                     .to_string(),
@@ -353,7 +355,7 @@ fn parse_json_schema(schema_str: &str) -> CliResult<serde_json::Value> {
 
 /// Interactive prompt for JSON schema
 fn prompt_schema() -> CliResult<serde_json::Value> {
-    if !atty::is(atty::Stream::Stdin) {
+    if !std::io::stdin().is_terminal() {
         return Err(CliError::Validation(
             "Schema is required. Use --schema flag in non-interactive mode.".to_string(),
         ));

--- a/apps/xavyo-cli/src/commands/users.rs
+++ b/apps/xavyo-cli/src/commands/users.rs
@@ -1,5 +1,7 @@
 //! User management CLI commands
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::error::{CliError, CliResult};
 use crate::models::user::{CreateUserRequest, UpdateUserRequest, UserResponse};
@@ -232,7 +234,7 @@ async fn execute_delete(args: DeleteArgs) -> CliResult<()> {
     let user = client.get_user(id).await?;
 
     if !args.force {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Cannot confirm deletion in non-interactive mode. Use --force to skip confirmation."
                     .to_string(),

--- a/apps/xavyo-cli/src/commands/webhooks.rs
+++ b/apps/xavyo-cli/src/commands/webhooks.rs
@@ -1,5 +1,7 @@
 //! Webhook management CLI commands
 
+use std::io::IsTerminal;
+
 use crate::api::ApiClient;
 use crate::error::{CliError, CliResult};
 use crate::models::webhook::{CreateWebhookRequest, UpdateWebhookRequest, WebhookResponse};
@@ -200,7 +202,7 @@ async fn execute_delete(args: DeleteArgs) -> CliResult<()> {
     let webhook = client.get_webhook(id).await?;
 
     if !args.force {
-        if !atty::is(atty::Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             return Err(CliError::Validation(
                 "Use --force in non-interactive mode.".to_string(),
             ));

--- a/apps/xavyo-cli/src/repl/prompt.rs
+++ b/apps/xavyo-cli/src/repl/prompt.rs
@@ -3,6 +3,8 @@
 //! Generates context-aware prompts showing the current tenant
 //! and authentication status.
 
+use std::io::IsTerminal;
+
 use crate::repl::ShellSession;
 
 /// Prompt generator for the interactive shell
@@ -37,7 +39,7 @@ impl Prompt {
 
     /// Check if the terminal supports colors
     pub fn supports_color() -> bool {
-        std::env::var("NO_COLOR").is_err() && atty::is(atty::Stream::Stdout)
+        std::env::var("NO_COLOR").is_err() && std::io::stdout().is_terminal()
     }
 
     /// Generate the appropriate prompt based on terminal capabilities

--- a/apps/xavyo-cli/src/webauthn/detection.rs
+++ b/apps/xavyo-cli/src/webauthn/detection.rs
@@ -2,6 +2,8 @@
 //!
 //! Detects whether the current environment supports passkey authentication.
 
+use std::io::IsTerminal;
+
 use crate::models::webauthn::{AuthenticatorCapability, DetectedKey};
 
 /// Detect WebAuthn capabilities of the current environment
@@ -33,7 +35,7 @@ pub fn detect_capabilities() -> AuthenticatorCapability {
 /// - No display available
 pub fn is_headless() -> bool {
     // Check if stdin is a TTY
-    if !atty::is(atty::Stream::Stdin) {
+    if !std::io::stdin().is_terminal() {
         return true;
     }
 

--- a/crates/xavyo-api-auth/src/middleware/mod.rs
+++ b/crates/xavyo-api-auth/src/middleware/mod.rs
@@ -17,9 +17,9 @@ pub use permission_guard::{
 };
 pub use rate_limit::{
     rate_limit_middleware, sensitive_rate_limiter, signup_rate_limit_middleware,
-    signup_rate_limiter, ApiKeyRateLimiter,
-    EmailRateLimiter, RateLimitConfig, RateLimitKey, RateLimiter, DEFAULT_MAX_ATTEMPTS,
-    DEFAULT_WINDOW_SECS, EMAIL_IP_RATE_LIMIT_MAX, EMAIL_RATE_LIMIT_MAX,
-    EMAIL_RATE_LIMIT_WINDOW_SECS, SIGNUP_RATE_LIMIT_MAX, SIGNUP_RATE_LIMIT_WINDOW_SECS,
+    signup_rate_limiter, ApiKeyRateLimiter, EmailRateLimiter, RateLimitConfig, RateLimitKey,
+    RateLimiter, DEFAULT_MAX_ATTEMPTS, DEFAULT_WINDOW_SECS, EMAIL_IP_RATE_LIMIT_MAX,
+    EMAIL_RATE_LIMIT_MAX, EMAIL_RATE_LIMIT_WINDOW_SECS, SIGNUP_RATE_LIMIT_MAX,
+    SIGNUP_RATE_LIMIT_WINDOW_SECS,
 };
 pub use session_activity::session_activity_middleware;

--- a/crates/xavyo-api-oidc-federation/tests/interop/auth0_tests.rs
+++ b/crates/xavyo-api-oidc-federation/tests/interop/auth0_tests.rs
@@ -95,7 +95,7 @@ async fn test_auth0_valid_token_verification() {
     .with_email("user@example.com");
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -126,7 +126,7 @@ async fn test_auth0_namespaced_claims() {
     );
     let token = create_test_token_with_custom_claims(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -157,7 +157,7 @@ async fn test_auth0_trailing_slash_issuer() {
     let token = create_test_token(&claims, kid);
 
     // Verify with expected issuer including trailing slash
-    let verifier = TokenVerifierService::new(VerificationConfig::default().issuer(&issuer));
+    let verifier = mock.verifier(VerificationConfig::default().issuer(&issuer));
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -185,7 +185,7 @@ async fn test_auth0_invalid_signature_rejected() {
     );
     let token = create_invalid_signature_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());
@@ -215,7 +215,7 @@ async fn test_auth0_expired_token_rejected() {
     );
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());
@@ -239,7 +239,7 @@ async fn test_auth0_subject_format() {
     let claims = TestClaims::new(sub, &issuer, vec!["https://api.myapp.com".to_string()]);
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(

--- a/crates/xavyo-api-oidc-federation/tests/interop/azure_ad_tests.rs
+++ b/crates/xavyo-api-oidc-federation/tests/interop/azure_ad_tests.rs
@@ -108,7 +108,7 @@ async fn test_azure_ad_v2_valid_token() {
     );
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -129,7 +129,7 @@ async fn test_azure_ad_jwks_with_x5t() {
     // Azure AD JWKS includes x5t (thumbprint)
     mock.mount_jwks(azure_fixtures::jwks(kid)).await;
 
-    let cache = xavyo_api_oidc_federation::services::JwksCache::default();
+    let cache = mock.cache();
     let result = cache.get_keys(&mock.jwks_uri).await;
 
     assert!(result.is_ok());
@@ -159,7 +159,7 @@ async fn test_azure_ad_tid_oid_claims() {
     );
     let token = create_test_token_with_custom_claims(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -192,7 +192,7 @@ async fn test_azure_ad_groups_claim() {
     );
     let token = create_test_token_with_custom_claims(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -218,7 +218,7 @@ async fn test_azure_ad_invalid_signature_rejected() {
     );
     let token = create_invalid_signature_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());
@@ -249,7 +249,7 @@ async fn test_azure_ad_multi_tenant_issuer_validation() {
     let token = create_test_token(&claims, kid);
 
     // Verify with expected issuer matching
-    let verifier = TokenVerifierService::new(VerificationConfig::default().issuer(&issuer));
+    let verifier = mock.verifier(VerificationConfig::default().issuer(&issuer));
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(

--- a/crates/xavyo-api-oidc-federation/tests/interop/common.rs
+++ b/crates/xavyo-api-oidc-federation/tests/interop/common.rs
@@ -226,6 +226,24 @@ impl IdpMockServer {
     pub fn base_url(&self) -> String {
         self.server.uri()
     }
+
+    /// Create a `TokenVerifierService` that allows local IPs (for mock server testing).
+    pub fn verifier(
+        &self,
+        config: xavyo_api_oidc_federation::services::VerificationConfig,
+    ) -> xavyo_api_oidc_federation::services::TokenVerifierService {
+        let cache = xavyo_api_oidc_federation::services::JwksCache::new_allow_local(
+            std::time::Duration::from_secs(600),
+        );
+        xavyo_api_oidc_federation::services::TokenVerifierService::with_cache(config, cache)
+    }
+
+    /// Create a `JwksCache` that allows local IPs (for mock server testing).
+    pub fn cache(&self) -> xavyo_api_oidc_federation::services::JwksCache {
+        xavyo_api_oidc_federation::services::JwksCache::new_allow_local(
+            std::time::Duration::from_secs(600),
+        )
+    }
 }
 
 /// Generate a standard OIDC discovery document

--- a/crates/xavyo-api-oidc-federation/tests/interop/google_tests.rs
+++ b/crates/xavyo-api-oidc-federation/tests/interop/google_tests.rs
@@ -84,7 +84,7 @@ async fn test_google_valid_token_verification() {
     .with_email("user@gmail.com");
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -111,7 +111,7 @@ async fn test_google_workspace_hd_claim() {
     );
     let token = create_test_token_with_custom_claims(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -133,7 +133,7 @@ async fn test_google_personal_account_no_hd() {
     let claims = google_fixtures::gmail_claims("118234567890123456789", "user@gmail.com");
     let token = create_test_token_with_custom_claims(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -159,7 +159,7 @@ async fn test_google_invalid_signature_rejected() {
     );
     let token = create_invalid_signature_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());
@@ -188,7 +188,7 @@ async fn test_google_expired_token_rejected() {
     );
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());
@@ -213,8 +213,7 @@ async fn test_google_issuer_always_accounts_google() {
     let token = create_test_token(&claims, kid);
 
     // Verify with expected Google issuer
-    let verifier =
-        TokenVerifierService::new(VerificationConfig::default().issuer(google_fixtures::ISSUER));
+    let verifier = mock.verifier(VerificationConfig::default().issuer(google_fixtures::ISSUER));
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(

--- a/crates/xavyo-api-oidc-federation/tests/interop/okta_tests.rs
+++ b/crates/xavyo-api-oidc-federation/tests/interop/okta_tests.rs
@@ -75,7 +75,7 @@ async fn test_okta_valid_token_verification() {
     let token = create_test_token(&claims, kid);
 
     // Verify token
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -98,7 +98,7 @@ async fn test_okta_jwks_parsing() {
     mock.mount_jwks(okta_fixtures::jwks(kid)).await;
 
     // Fetch JWKS directly via cache
-    let cache = xavyo_api_oidc_federation::services::JwksCache::default();
+    let cache = mock.cache();
     let result = cache.get_keys(&mock.jwks_uri).await;
 
     assert!(result.is_ok(), "JWKS fetch failed: {:?}", result.err());
@@ -125,7 +125,7 @@ async fn test_okta_groups_claim_extraction() {
     );
     let token = create_test_token_with_custom_claims(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -149,7 +149,7 @@ async fn test_okta_invalid_signature_rejected() {
     let claims = TestClaims::new("user123", &issuer, vec!["api://default".to_string()]);
     let token = create_invalid_signature_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());
@@ -175,7 +175,7 @@ async fn test_okta_expired_token_rejected() {
         TestClaims::with_exp_offset("user123", &issuer, vec!["api://default".to_string()], -3600);
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());
@@ -198,7 +198,7 @@ async fn test_okta_key_rotation() {
     let claims = TestClaims::new("user123", &issuer, vec!["api://default".to_string()]);
     let token = create_test_token(&claims, "okta-key-2");
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(

--- a/crates/xavyo-api-oidc-federation/tests/interop/ping_tests.rs
+++ b/crates/xavyo-api-oidc-federation/tests/interop/ping_tests.rs
@@ -74,7 +74,7 @@ async fn test_ping_valid_token_verification() {
     let claims = ping_fixtures::claims("user123", &issuer);
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -101,7 +101,7 @@ async fn test_ping_key_selection_by_kid() {
     let claims = ping_fixtures::claims("user123", &issuer);
     let token = create_test_token(&claims, "ping-key-2");
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(
@@ -125,7 +125,7 @@ async fn test_ping_invalid_signature_rejected() {
     let claims = ping_fixtures::claims("user123", &issuer);
     let token = create_invalid_signature_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());
@@ -151,7 +151,7 @@ async fn test_ping_expired_token_rejected() {
         TestClaims::with_exp_offset("user123", &issuer, vec!["app-client-id".to_string()], -3600);
     let token = create_test_token(&claims, kid);
 
-    let verifier = TokenVerifierService::new(VerificationConfig::default());
+    let verifier = mock.verifier(VerificationConfig::default());
     let result = verifier.verify_token(&token, &mock.jwks_uri).await;
 
     assert!(result.is_err());


### PR DESCRIPTION
## Summary

Addresses three security audit findings across 6 crates and 35 files:

### 1. Session Revocation on Security-Sensitive Operations (CRITICAL/HIGH)
- **Role assign/revoke**: Invalidate all user sessions when roles change via governance action executors, preventing stale privilege tokens
- **Password change**: Mandatory session + refresh token revocation after successful password change
- **MFA disable**: Revoke all sessions when MFA is disabled (security downgrade)
- **MFA enable (TOTP + WebAuthn)**: Revoke sessions after MFA credential registration to force re-authentication with stronger auth

### 2. SSRF Protection (MEDIUM)
Added internal/private IP and hostname validation to 4 network-facing services:
- **OIDC discovery** (`discovery.rs`): Validate discovery URL before fetching
- **JWKS cache** (`jwks_cache.rs`): Validate JWKS URI with `allow_local` flag for test mock servers
- **SCIM target** (`scim_target_service.rs`): Validate target URL on create/update
- **LDAP connector** (`config.rs`): Validate host in config validation

Blocked ranges: loopback, private (RFC 1918), link-local, broadcast, documentation, metadata (169.254.169.254), cloud metadata hostnames (metadata.google.internal, metadata.goog)

### 3. Replace Unmaintained `atty` Crate (MEDIUM)
- Removed `atty = "0.2"` dependency from xavyo-cli
- Replaced all 20 usages across 15 files with `std::io::IsTerminal` (stable since Rust 1.70)

## Crates Modified
| Crate | Changes |
|-------|---------|
| `xavyo-api-auth` | Session revocation in password change, MFA disable/enable, WebAuthn register |
| `xavyo-api-governance` | Session revocation in role assign/revoke action executors |
| `xavyo-api-oidc-federation` | SSRF validation in discovery + JWKS cache; `allow_local` for tests |
| `xavyo-api-connectors` | SSRF validation in SCIM target service |
| `xavyo-connector-ldap` | SSRF host validation in config + 4 new SSRF unit tests |
| `xavyo-cli` | Replace `atty` with `std::io::IsTerminal` across 15 files |

## Test plan
- [x] `cargo test -p xavyo-cli` — 20 passed
- [x] `cargo test -p xavyo-api-oidc-federation` — 65 passed (37 lib + 28 interop)
- [x] `cargo test -p xavyo-connector-ldap` — 243 passed (including 4 new SSRF tests)
- [x] `cargo clippy` clean on all 6 crates
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)