### PR TITLE
feat: enforce email verification on login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,7 +2832,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5372,7 +5372,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6296,6 +6296,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "sha2",
@@ -6306,6 +6307,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7637,6 +7639,15 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/xavyo-api-auth/src/handlers/login.rs
+++ b/crates/xavyo-api-auth/src/handlers/login.rs
@@ -321,6 +321,11 @@ pub async fn login_handler(
         return Err(ApiAuthError::AccountLocked);
     }
 
+    // Check if email is verified
+    if !user.email_verified {
+        return Err(ApiAuthError::EmailNotVerified);
+    }
+
     // Check if password is expired
     if user.needs_password_change() {
         // Don't lock out for expired password, but don't allow full access


### PR DESCRIPTION
## Summary
- Add `email_verified` check in login handler before password expiry and MFA checks
- Unverified users get 403 with `EmailNotVerified` ProblemDetails error (existing variant)
- No new error types or model changes needed

## Test plan
- [x] Login with unverified user → 403 with type `email-not-verified`
- [x] Login with verified user → succeeds with tokens
- [x] Existing users grandfathered via production SQL migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)