### PR TITLE
fix: resolve CI failures — clippy, type mismatches, formatting

### DIFF
--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -65,7 +65,10 @@ use xavyo_api_oidc_federation::{
 };
 use xavyo_api_saml::{create_saml_state, saml_admin_router, saml_public_router};
 use xavyo_api_scim::{scim_admin_router, scim_resource_router, ScimConfig};
-use xavyo_api_social::{admin_social_router, authenticated_social_router, public_social_router, SocialConfig, SocialState};
+use xavyo_api_social::{
+    admin_social_router, authenticated_social_router, public_social_router, SocialConfig,
+    SocialState,
+};
 use xavyo_api_tenants::{
     api_keys_router, oauth_clients_router, suspension_check_middleware, system_admin_router,
     tenant_router,

--- a/crates/xavyo-api-auth/src/models/branding_requests.rs
+++ b/crates/xavyo-api-auth/src/models/branding_requests.rs
@@ -130,8 +130,14 @@ impl Validate for UpdateBrandingRequest {
 
         // Consent button text: max 100 chars (VARCHAR(100))
         let button_fields: &[(&Option<String>, &str)] = &[
-            (&self.consent_approval_button_text, "consent_approval_button_text"),
-            (&self.consent_denial_button_text, "consent_denial_button_text"),
+            (
+                &self.consent_approval_button_text,
+                "consent_approval_button_text",
+            ),
+            (
+                &self.consent_denial_button_text,
+                "consent_denial_button_text",
+            ),
         ];
         for (field, name) in button_fields {
             if let Some(v) = field {

--- a/crates/xavyo-api-authorization/src/services/mapping_service.rs
+++ b/crates/xavyo-api-authorization/src/services/mapping_service.rs
@@ -58,7 +58,7 @@ impl MappingService {
             .map_err(|e| {
                 if let sqlx::Error::Database(ref db_err) = e {
                     // Check for unique constraint violation
-                    if db_err.constraint().map_or(false, |c| {
+                    if db_err.constraint().is_some_and(|c| {
                         c == "eam_tenant_entitlement_action_resource_unique"
                     }) {
                         return ApiAuthorizationError::Conflict(
@@ -66,7 +66,7 @@ impl MappingService {
                         );
                     }
                     // Check for foreign key violation (e.g. entitlement doesn't exist)
-                    if db_err.constraint().map_or(false, |c| {
+                    if db_err.constraint().is_some_and(|c| {
                         c.contains("entitlement")
                     }) {
                         return ApiAuthorizationError::Validation(

--- a/crates/xavyo-api-governance/src/jobs/micro_cert_expiration_job.rs
+++ b/crates/xavyo-api-governance/src/jobs/micro_cert_expiration_job.rs
@@ -291,13 +291,9 @@ impl MicroCertExpirationJob {
 
             // Get the trigger rule to check auto_revoke setting
             let rule = if let Some(rule_id) = cert.trigger_rule_id {
-                GovMicroCertTrigger::find_by_id(
-                    self.service.pool(),
-                    cert.tenant_id,
-                    rule_id,
-                )
-                .await
-                .map_err(|e| MicroCertExpirationJobError::Database(e.to_string()))?
+                GovMicroCertTrigger::find_by_id(self.service.pool(), cert.tenant_id, rule_id)
+                    .await
+                    .map_err(|e| MicroCertExpirationJobError::Database(e.to_string()))?
             } else {
                 None
             };

--- a/crates/xavyo-api-governance/src/services/identity_merge_service.rs
+++ b/crates/xavyo-api-governance/src/services/identity_merge_service.rs
@@ -400,7 +400,10 @@ impl IdentityMergeService {
 
         // 4. Transfer group memberships (IGA edge case) — use savepoint to protect transaction
         let groups_transferred = {
-            sqlx::query("SAVEPOINT sp_groups").execute(&mut *tx).await.ok();
+            sqlx::query("SAVEPOINT sp_groups")
+                .execute(&mut *tx)
+                .await
+                .ok();
             match self
                 .transfer_group_memberships(
                     &mut *tx,
@@ -411,12 +414,18 @@ impl IdentityMergeService {
                 .await
             {
                 Ok(count) => {
-                    sqlx::query("RELEASE SAVEPOINT sp_groups").execute(&mut *tx).await.ok();
+                    sqlx::query("RELEASE SAVEPOINT sp_groups")
+                        .execute(&mut *tx)
+                        .await
+                        .ok();
                     count
                 }
                 Err(e) => {
                     tracing::debug!(error = %e, "Group membership transfer failed, rolling back savepoint");
-                    sqlx::query("ROLLBACK TO SAVEPOINT sp_groups").execute(&mut *tx).await.ok();
+                    sqlx::query("ROLLBACK TO SAVEPOINT sp_groups")
+                        .execute(&mut *tx)
+                        .await
+                        .ok();
                     0
                 }
             }
@@ -424,7 +433,10 @@ impl IdentityMergeService {
 
         // 5. Handle pending access requests (IGA edge case) — use savepoint to protect transaction
         let access_requests_cancelled = {
-            sqlx::query("SAVEPOINT sp_access_requests").execute(&mut *tx).await.ok();
+            sqlx::query("SAVEPOINT sp_access_requests")
+                .execute(&mut *tx)
+                .await
+                .ok();
             match self
                 .handle_pending_access_requests(
                     &mut *tx,
@@ -435,12 +447,18 @@ impl IdentityMergeService {
                 .await
             {
                 Ok(count) => {
-                    sqlx::query("RELEASE SAVEPOINT sp_access_requests").execute(&mut *tx).await.ok();
+                    sqlx::query("RELEASE SAVEPOINT sp_access_requests")
+                        .execute(&mut *tx)
+                        .await
+                        .ok();
                     count
                 }
                 Err(e) => {
                     tracing::debug!(error = %e, "Access request cancellation failed, rolling back savepoint");
-                    sqlx::query("ROLLBACK TO SAVEPOINT sp_access_requests").execute(&mut *tx).await.ok();
+                    sqlx::query("ROLLBACK TO SAVEPOINT sp_access_requests")
+                        .execute(&mut *tx)
+                        .await
+                        .ok();
                     0
                 }
             }
@@ -448,7 +466,10 @@ impl IdentityMergeService {
 
         // 6. Transfer resource ownerships (IGA edge case) — use savepoint to protect transaction
         let ownerships_transferred = {
-            sqlx::query("SAVEPOINT sp_ownerships").execute(&mut *tx).await.ok();
+            sqlx::query("SAVEPOINT sp_ownerships")
+                .execute(&mut *tx)
+                .await
+                .ok();
             match self
                 .transfer_ownerships(
                     &mut tx,
@@ -459,12 +480,18 @@ impl IdentityMergeService {
                 .await
             {
                 Ok(count) => {
-                    sqlx::query("RELEASE SAVEPOINT sp_ownerships").execute(&mut *tx).await.ok();
+                    sqlx::query("RELEASE SAVEPOINT sp_ownerships")
+                        .execute(&mut *tx)
+                        .await
+                        .ok();
                     count
                 }
                 Err(e) => {
                     tracing::debug!(error = %e, "Ownership transfer failed, rolling back savepoint");
-                    sqlx::query("ROLLBACK TO SAVEPOINT sp_ownerships").execute(&mut *tx).await.ok();
+                    sqlx::query("ROLLBACK TO SAVEPOINT sp_ownerships")
+                        .execute(&mut *tx)
+                        .await
+                        .ok();
                     0
                 }
             }

--- a/crates/xavyo-api-governance/src/services/micro_certification_service.rs
+++ b/crates/xavyo-api-governance/src/services/micro_certification_service.rs
@@ -673,7 +673,10 @@ impl MicroCertificationService {
 
                 // For SoD violations, create an exemption (would need SodExemptionService)
                 // This is a placeholder - actual implementation depends on SoD integration
-                if rule.as_ref().map_or(false, |r| r.trigger_type == MicroCertTriggerType::SodViolation) {
+                if rule
+                    .as_ref()
+                    .is_some_and(|r| r.trigger_type == MicroCertTriggerType::SodViolation)
+                {
                     // TODO: Create SoD exemption via SodExemptionService
                     info!(
                         certification_id = %certification_id,
@@ -691,9 +694,10 @@ impl MicroCertificationService {
                 // Revoke the assignment
                 if let Some(assignment_id) = certification.assignment_id {
                     // For SoD violations with revoke_triggering_assignment, revoke the newest assignment
-                    if rule.as_ref().map_or(false, |r| r.trigger_type == MicroCertTriggerType::SodViolation
-                        && r.revoke_triggering_assignment)
-                    {
+                    if rule.as_ref().is_some_and(|r| {
+                        r.trigger_type == MicroCertTriggerType::SodViolation
+                            && r.revoke_triggering_assignment
+                    }) {
                         // The assignment_id on the certification is the triggering one
                         revoked_assignment_id = Some(assignment_id);
                     } else {
@@ -1690,7 +1694,7 @@ mod tests {
         GovMicroCertification {
             id: Uuid::new_v4(),
             tenant_id: Uuid::new_v4(),
-            trigger_rule_id: Uuid::new_v4(),
+            trigger_rule_id: Some(Uuid::new_v4()),
             assignment_id: Some(Uuid::new_v4()),
             user_id: Uuid::new_v4(),
             entitlement_id: Uuid::new_v4(),

--- a/crates/xavyo-api-governance/src/services/nhi_service.rs
+++ b/crates/xavyo-api-governance/src/services/nhi_service.rs
@@ -17,11 +17,9 @@ use uuid::Uuid;
 
 use xavyo_db::{
     CreateGovNhiAuditEvent, CreateNhiIdentity, CreateNhiServiceAccount, GovNhiAuditEvent,
-    GovServiceAccount, NhiAuditEventType, NhiIdentity,
-    NhiServiceAccount as NhiServiceAccountModel, NhiSuspensionReason, ServiceAccountFilter,
-    ServiceAccountStatus, UpdateGovServiceAccount, User,
+    GovServiceAccount, NhiAuditEventType, NhiIdentity, NhiServiceAccount as NhiServiceAccountModel,
+    NhiSuspensionReason, ServiceAccountFilter, ServiceAccountStatus, UpdateGovServiceAccount, User,
 };
-use xavyo_nhi::NhiType;
 #[cfg(feature = "kafka")]
 use xavyo_events::{
     events::nhi::{
@@ -30,6 +28,7 @@ use xavyo_events::{
     EventProducer,
 };
 use xavyo_governance::error::{GovernanceError, Result};
+use xavyo_nhi::NhiType;
 
 use crate::models::{
     CreateNhiRequest, ListNhisQuery, NhiListResponse, NhiResponse, NhiSummary, UpdateNhiRequest,
@@ -256,9 +255,7 @@ impl NhiService {
             backup_owner_id: identity.backup_owner_id,
             status: ServiceAccountStatus::Active,
             expires_at: identity.expires_at,
-            days_until_expiry: identity.expires_at.map(|e| {
-                (e - Utc::now()).num_days()
-            }),
+            days_until_expiry: identity.expires_at.map(|e| (e - Utc::now()).num_days()),
             rotation_interval_days: identity.rotation_interval_days,
             last_rotation_at: identity.last_rotation_at,
             needs_rotation: false,

--- a/crates/xavyo-api-nhi/src/handlers/a2a.rs
+++ b/crates/xavyo-api-nhi/src/handlers/a2a.rs
@@ -115,7 +115,8 @@ pub async fn list_tasks(
         "Listing A2A tasks"
     );
 
-    let response = a2a_service::list_tasks(&state.pool, tenant_id, agent_id, is_admin, query).await?;
+    let response =
+        a2a_service::list_tasks(&state.pool, tenant_id, agent_id, is_admin, query).await?;
 
     Ok(Json(response))
 }

--- a/crates/xavyo-api-oauth/src/handlers/authorize_grant.rs
+++ b/crates/xavyo-api-oauth/src/handlers/authorize_grant.rs
@@ -40,9 +40,7 @@ async fn validate_authorize_request(
         .client_service
         .validate_redirect_uri(&client, redirect_uri)?;
 
-    let validated_scope = state
-        .client_service
-        .validate_scopes(&client, scope)?;
+    let validated_scope = state.client_service.validate_scopes(&client, scope)?;
 
     state
         .client_service

--- a/crates/xavyo-api-oauth/src/lib.rs
+++ b/crates/xavyo-api-oauth/src/lib.rs
@@ -56,5 +56,7 @@ pub use middleware::{
     clear_session_cookie, create_session_cookie, extract_session_cookie, set_session_cookie,
     SESSION_COOKIE_MAX_AGE, SESSION_COOKIE_NAME,
 };
-pub use router::{device_router, oauth_router, user_oauth_router, well_known_router, OAuthSigningKey, OAuthState};
+pub use router::{
+    device_router, oauth_router, user_oauth_router, well_known_router, OAuthSigningKey, OAuthState,
+};
 pub use utils::{extract_country_code, extract_origin_ip, UNKNOWN_COUNTRY};

--- a/crates/xavyo-api-oauth/src/services/client.rs
+++ b/crates/xavyo-api-oauth/src/services/client.rs
@@ -967,6 +967,8 @@ mod tests {
             grant_types: vec!["client_credentials".to_string()],
             scopes: vec!["api:read".to_string(), "api:write".to_string()],
             is_active: true,
+            logo_url: None,
+            description: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -1003,6 +1005,8 @@ mod tests {
             grant_types: vec!["authorization_code".to_string()],
             scopes: vec!["openid".to_string(), "profile".to_string()],
             is_active: true,
+            logo_url: None,
+            description: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/crates/xavyo-api-social/src/extractors.rs
+++ b/crates/xavyo-api-social/src/extractors.rs
@@ -68,13 +68,13 @@ where
             let user_id = Uuid::parse_str(&claims.sub).map_err(|_| SocialError::InternalError {
                 message: "Invalid user ID in JWT claims".to_string(),
             })?;
-            let tenant_id = claims.tenant_id().map(|tid| *tid.as_uuid()).ok_or_else(|| SocialError::InternalError {
-                message: "Tenant ID not found in JWT claims".to_string(),
-            })?;
-            return Ok(AuthenticatedUser {
-                user_id,
-                tenant_id,
-            });
+            let tenant_id = claims
+                .tenant_id()
+                .map(|tid| *tid.as_uuid())
+                .ok_or_else(|| SocialError::InternalError {
+                    message: "Tenant ID not found in JWT claims".to_string(),
+                })?;
+            return Ok(AuthenticatedUser { user_id, tenant_id });
         }
 
         // Fallback: try to get from typed extensions

--- a/crates/xavyo-api-users/src/handlers/group_crud.rs
+++ b/crates/xavyo-api-users/src/handlers/group_crud.rs
@@ -13,10 +13,7 @@ use crate::models::{
     GroupMembersResponse, UpdateGroupRequest,
 };
 use crate::services::GroupHierarchyService;
-use axum::{
-    extract::Path,
-    Extension, Json,
-};
+use axum::{extract::Path, Extension, Json};
 use sqlx::PgPool;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/xavyo-db/src/bootstrap/system_tenant.rs
+++ b/crates/xavyo-db/src/bootstrap/system_tenant.rs
@@ -103,13 +103,10 @@ async fn disable_rls(pool: &PgPool) -> Result<(), BootstrapError> {
             warn!("session_replication_role not available (managed DB?): {e}");
             // Fallback: set the RLS context variable to system tenant ID
             // This allows bootstrap INSERTs to pass RLS WITH CHECK policies
-            sqlx::query(&format!(
-                "SET app.current_tenant = '{}'",
-                SYSTEM_TENANT_ID
-            ))
-            .execute(pool)
-            .await
-            .map_err(BootstrapError::RlsBypass)?;
+            sqlx::query(&format!("SET app.current_tenant = '{}'", SYSTEM_TENANT_ID))
+                .execute(pool)
+                .await
+                .map_err(BootstrapError::RlsBypass)?;
             info!("RLS context set to system tenant ID (managed DB fallback)");
         }
     }
@@ -129,9 +126,7 @@ async fn enable_rls(pool: &PgPool) -> Result<(), BootstrapError> {
         }
         Err(_) => {
             // On managed DBs, just reset the tenant context
-            let _ = sqlx::query("RESET app.current_tenant")
-                .execute(pool)
-                .await;
+            let _ = sqlx::query("RESET app.current_tenant").execute(pool).await;
             info!("RLS context reset after bootstrap operations (managed DB)");
         }
     }

--- a/crates/xavyo-db/src/lib.rs
+++ b/crates/xavyo-db/src/lib.rs
@@ -781,6 +781,6 @@ pub use models::{
 // Unified NHI Identity exports (201-tool-nhi-promotion)
 pub use models::{
     CreateNhiCredential, CreateNhiIdentity, CreateNhiServiceAccount, NhiCredential, NhiIdentity,
-    NhiIdentityFilter, NhiServiceAccount, NhiServiceAccountFilter,
-    NhiServiceAccountWithIdentity, UpdateNhiIdentity, UpdateNhiServiceAccount,
+    NhiIdentityFilter, NhiServiceAccount, NhiServiceAccountFilter, NhiServiceAccountWithIdentity,
+    UpdateNhiIdentity, UpdateNhiServiceAccount,
 };

--- a/crates/xavyo-db/src/models/gov_micro_certification.rs
+++ b/crates/xavyo-db/src/models/gov_micro_certification.rs
@@ -952,7 +952,7 @@ mod tests {
         let cert = GovMicroCertification {
             id: Uuid::new_v4(),
             tenant_id: Uuid::new_v4(),
-            trigger_rule_id: Uuid::new_v4(),
+            trigger_rule_id: Some(Uuid::new_v4()),
             assignment_id: Some(Uuid::new_v4()),
             user_id: Uuid::new_v4(),
             entitlement_id: Uuid::new_v4(),
@@ -990,7 +990,7 @@ mod tests {
         let mut cert = GovMicroCertification {
             id: Uuid::new_v4(),
             tenant_id: Uuid::new_v4(),
-            trigger_rule_id: Uuid::new_v4(),
+            trigger_rule_id: Some(Uuid::new_v4()),
             assignment_id: Some(Uuid::new_v4()),
             user_id: Uuid::new_v4(),
             entitlement_id: Uuid::new_v4(),
@@ -1030,7 +1030,7 @@ mod tests {
         let cert = GovMicroCertification {
             id: Uuid::new_v4(),
             tenant_id: Uuid::new_v4(),
-            trigger_rule_id: Uuid::new_v4(),
+            trigger_rule_id: Some(Uuid::new_v4()),
             assignment_id: Some(Uuid::new_v4()),
             user_id: Uuid::new_v4(),
             entitlement_id: Uuid::new_v4(),
@@ -1065,7 +1065,7 @@ mod tests {
         let mut cert = GovMicroCertification {
             id: Uuid::new_v4(),
             tenant_id: Uuid::new_v4(),
-            trigger_rule_id: Uuid::new_v4(),
+            trigger_rule_id: Some(Uuid::new_v4()),
             assignment_id: Some(Uuid::new_v4()),
             user_id: Uuid::new_v4(),
             entitlement_id: Uuid::new_v4(),

--- a/crates/xavyo-governance/src/error.rs
+++ b/crates/xavyo-governance/src/error.rs
@@ -2414,12 +2414,6 @@ impl GovernanceError {
                 | Self::RoleConstructionNotFound(_)
                 | Self::RoleInducementNotFound(_)
                 | Self::ConnectorNotFound(_)
-                // Power of Attorney (F-PoA)
-                | Self::PoaNotFound(_)
-                | Self::PoaAssumedSessionNotFound(_)
-                | Self::PoaDonorNotFound(_)
-                | Self::PoaAttorneyNotFound(_)
-                | Self::PoaAuditEventNotFound(_)
         )
     }
 


### PR DESCRIPTION
## Summary
- Remove duplicate PoA patterns in `governance/error.rs` causing `unreachable_patterns` errors
- Replace `map_or(false, ...)` with `is_some_and()` to fix `clippy::unnecessary_map_or` lints
- Add missing `logo_url`/`description` fields to OAuth client test structs
- Fix `trigger_rule_id` type (`Uuid` → `Option<Uuid>`) in micro certification tests
- Run `cargo fmt` to fix pre-existing formatting issues across 12 files

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [x] `cargo fmt --all --check` passes clean
- [x] `cargo check --workspace` compiles with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)