### PR TITLE
feat: add role selector to admin invitations

### DIFF
--- a/crates/xavyo-api-auth/src/handlers/admin_invite.rs
+++ b/crates/xavyo-api-auth/src/handlers/admin_invite.rs
@@ -66,12 +66,15 @@ pub async fn create_invitation_handler(
     let ip_address = None; // Would come from request headers in real impl
     let user_agent = None;
 
+    let role = request.resolved_role();
+
     let invitation = state
         .service
         .create_invitation(
             tenant_uuid,
             &request.email,
             request.role_template_id,
+            role,
             admin_user_id,
             ip_address,
             user_agent,


### PR DESCRIPTION
## Summary
- Add optional `role` field ("member"/"admin") to `CreateInvitationRequest`, defaults to "admin" for backward compatibility
- Dynamic email subject/body based on role ("an administrator" vs "a member")
- Assign `invitation.role` to `user_roles` table on acceptance (fixes missing role assignment)
- Include `role` in `InvitationResponse` and audit trail
- Add validation + unit tests for role field

## Test plan
- [ ] Create invitation without role → defaults to "admin" (backward compat)
- [ ] Create invitation with role "member" → stored correctly, email says "a member"
- [ ] Create invitation with role "admin" → email says "an administrator"
- [ ] Accept invitation → user gets correct role in `user_roles` table
- [ ] Resend invitation → email text matches original role
- [ ] Invalid role value → returns 400 validation error
- [ ] `cargo test` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)