### PR TITLE
fix: multi-tenant security audit & remediation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "hex",
  "hmac",
  "hyper 1.8.1",
+ "ipnetwork",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",

--- a/apps/idp-api/Cargo.toml
+++ b/apps/idp-api/Cargo.toml
@@ -61,6 +61,9 @@ hex = "0.4"
 # Rate limiting (F082)
 governor = "0.6"
 
+# CIDR parsing for trusted proxy validation
+ipnetwork = "0.20"
+
 # HMAC/SHA2 for CSRF (F082)
 hmac = "0.12"
 sha2 = "0.10"

--- a/crates/xavyo-api-auth/src/handlers/login.rs
+++ b/crates/xavyo-api-auth/src/handlers/login.rs
@@ -560,8 +560,16 @@ pub async fn login_handler(
         )
         .await
     {
-        // Log but don't fail login if session creation fails
-        tracing::warn!("Failed to create session entry: {}", e);
+        // Emit structured security audit event for session creation failure
+        SecurityAudit::emit(
+            SecurityEventType::SessionCreationFailed,
+            Some(*tenant_id_val.as_uuid()),
+            Some(*user_id.as_uuid()),
+            ip_str.as_deref(),
+            user_agent.as_deref(),
+            "failure",
+            &format!("Failed to create session entry: {e}"),
+        );
     }
 
     let response = TokenResponse::new(access_token, refresh_token, expires_in);

--- a/crates/xavyo-api-auth/src/lib.rs
+++ b/crates/xavyo-api-auth/src/lib.rs
@@ -33,9 +33,9 @@ pub use crypto::{TotpEncryption, TotpEncryptionError};
 pub use error::{ApiAuthError, ProblemDetails};
 pub use handlers::revocation_router;
 pub use middleware::{
-    api_key_auth_middleware, jwt_auth_middleware, session_activity_middleware, ApiKeyContext,
-    ApiKeyError, ApiKeyRateLimiter, EmailRateLimiter, JwtPublicKey, JwtPublicKeys, RateLimitConfig,
-    RateLimiter,
+    api_key_auth_middleware, jwt_auth_middleware, session_activity_middleware, AllowPartialToken,
+    ApiKeyContext, ApiKeyError, ApiKeyRateLimiter, EmailRateLimiter, JwtPublicKey, JwtPublicKeys,
+    RateLimitConfig, RateLimiter, TrustXff,
 };
 pub use models::{
     ForgotPasswordRequest, ForgotPasswordResponse, LoginRequest, LogoutRequest, RefreshRequest,

--- a/crates/xavyo-api-auth/src/middleware/mod.rs
+++ b/crates/xavyo-api-auth/src/middleware/mod.rs
@@ -9,7 +9,10 @@ pub mod session_activity;
 
 pub use api_key::{api_key_auth_middleware, ApiKeyContext, ApiKeyError};
 pub use ip_filter::{check_org_ip_restriction, extract_client_ip, ip_filter_middleware};
-pub use jwt_auth::{jwt_auth_middleware, JwtPublicKey, JwtPublicKeys, ServiceAccountMarker};
+pub use jwt_auth::{
+    jwt_auth_middleware, AllowPartialToken, JwtPublicKey, JwtPublicKeys, ServiceAccountMarker,
+    TrustXff,
+};
 pub use permission_guard::{
     check_resource_scope, is_super_admin, permission_guard_layer, permission_guard_middleware,
     require_permission, require_scope, require_super_admin_middleware, PermissionGuard,

--- a/crates/xavyo-api-auth/src/services/security_audit.rs
+++ b/crates/xavyo-api-auth/src/services/security_audit.rs
@@ -18,6 +18,8 @@ pub enum SecurityEventType {
     CorsRejected,
     RateLimited,
     CsrfFailed,
+    RefreshTokenIpChange,
+    SessionCreationFailed,
 }
 
 impl std::fmt::Display for SecurityEventType {
@@ -31,6 +33,8 @@ impl std::fmt::Display for SecurityEventType {
             Self::CorsRejected => write!(f, "cors_rejected"),
             Self::RateLimited => write!(f, "rate_limited"),
             Self::CsrfFailed => write!(f, "csrf_failed"),
+            Self::RefreshTokenIpChange => write!(f, "refresh_token_ip_change"),
+            Self::SessionCreationFailed => write!(f, "session_creation_failed"),
         }
     }
 }
@@ -84,6 +88,14 @@ mod tests {
         assert_eq!(SecurityEventType::CorsRejected.to_string(), "cors_rejected");
         assert_eq!(SecurityEventType::RateLimited.to_string(), "rate_limited");
         assert_eq!(SecurityEventType::CsrfFailed.to_string(), "csrf_failed");
+        assert_eq!(
+            SecurityEventType::RefreshTokenIpChange.to_string(),
+            "refresh_token_ip_change"
+        );
+        assert_eq!(
+            SecurityEventType::SessionCreationFailed.to_string(),
+            "session_creation_failed"
+        );
     }
 
     #[test]

--- a/crates/xavyo-api-governance/src/handlers/power_of_attorney.rs
+++ b/crates/xavyo-api-governance/src/handlers/power_of_attorney.rs
@@ -405,7 +405,9 @@ pub async fn assume_identity(
     let ip_address: Option<String> = None;
     let user_agent: Option<String> = None;
 
-    let (session, donor_id) = state
+    // SECURITY: The service computes role intersection (donor_roles ∩ attorney_roles)
+    // to prevent privilege escalation. The attorney cannot gain roles they don't already have.
+    let (session, donor_id, effective_roles, roles_restricted) = state
         .poa_service
         .assume_identity(
             tenant_id,
@@ -421,6 +423,7 @@ pub async fn assume_identity(
     // - acting_as_user_id: donor_id
     // - acting_as_poa_id: poa_id
     // - acting_as_session_id: session.id
+    // - roles: effective_roles (intersection, NOT donor_roles)
     // For now, we return a placeholder token
     let access_token = format!("assumed_token_{}", session.id);
 
@@ -431,6 +434,8 @@ pub async fn assume_identity(
         donor_name: None, // Would be populated from user lookup
         donor_email: None,
         scope: None,
+        effective_roles: Some(effective_roles),
+        roles_restricted: Some(roles_restricted),
     }))
 }
 

--- a/crates/xavyo-api-governance/src/models/power_of_attorney.rs
+++ b/crates/xavyo-api-governance/src/models/power_of_attorney.rs
@@ -208,6 +208,15 @@ pub struct AssumeIdentityResponse {
     /// Scope restrictions (if any).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<PoaScopeResponse>,
+
+    /// Effective roles for the assumed identity session (intersection of donor and attorney roles).
+    /// The attorney cannot gain roles they don't already possess.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_roles: Option<Vec<String>>,
+
+    /// True if any donor roles were restricted because the attorney lacks them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roles_restricted: Option<bool>,
 }
 
 /// Response for dropping an assumed identity.

--- a/crates/xavyo-api-governance/src/services/mod.rs
+++ b/crates/xavyo-api-governance/src/services/mod.rs
@@ -328,7 +328,7 @@ pub use persona_validation_service::{
 };
 
 // Power of Attorney exports (F-061)
-pub use poa_service::PoaService;
+pub use poa_service::{compute_role_intersection, PoaService, RoleIntersection};
 
 // Semi-manual Resources exports (F064)
 pub use manual_task_service::ManualTaskService;


### PR DESCRIPTION
## Summary
- **SIEM encryption key**: Remove hardcoded dev fallback — fail-closed if `XAVYO_SIEM_ENCRYPTION_KEY` not set
- **MFA partial token bypass**: `AllowPartialToken` marker rejects `purpose:mfa_verification` tokens on non-MFA routes
- **PoA privilege escalation**: Role intersection prevents attorney gaining donor-only roles via `compute_role_intersection()` (9 tests)
- **Refresh token IP logging**: Structured `SecurityAudit` event on IP change during token refresh
- **Session creation failure**: Upgraded `warn!` to `SecurityAudit::emit(SessionCreationFailed)`
- **X-Forwarded-For proxy trust**: `TRUSTED_PROXY_CIDRS` config + `TrustXff` marker — single consistent pattern
- **Body size limits**: Idempotency middleware — 1MB request / 8MB response (was `usize::MAX`)

## Test plan
- [x] `cargo clippy --all -D warnings` — clean
- [x] `cargo test --all` — 8579 passed, 0 failed
- [x] PoA role intersection: 9 new tests covering escalation, partial overlap, empty roles, super_admin
- [x] Proxy config: 7 deterministic tests (no env var mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)