### PR TITLE
fix(security): auth architecture review R8

### DIFF
--- a/crates/xavyo-api-auth/src/handlers/password_change.rs
+++ b/crates/xavyo-api-auth/src/handlers/password_change.rs
@@ -62,7 +62,7 @@ pub async fn password_change_handler(
         ApiAuthError::Validation(errors.join(", "))
     })?;
 
-    // Get the current user
+    // Get the current user (SELECT * needed — password_hash for verification + password_changed_at for age check)
     let user: User = sqlx::query_as("SELECT * FROM users WHERE id = $1 AND tenant_id = $2")
         .bind(user_id.as_uuid())
         .bind(tenant_id.as_uuid())

--- a/crates/xavyo-api-auth/src/middleware/api_key.rs
+++ b/crates/xavyo-api-auth/src/middleware/api_key.rs
@@ -174,6 +174,12 @@ fn is_api_key(token: &str) -> bool {
 }
 
 /// Compute the SHA-256 hash of an API key for database lookup.
+///
+/// H-1: Plain SHA-256 (without salt/HMAC) is acceptable here because API keys
+/// are high-entropy random strings (256 bits via `generate_secure_token()`).
+/// Unlike passwords, pre-computation attacks (rainbow tables) are infeasible
+/// against 256-bit random inputs. Salt is unnecessary when the input space
+/// is large enough to make brute-force impractical.
 fn compute_key_hash(api_key: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(api_key.as_bytes());
@@ -184,13 +190,32 @@ fn compute_key_hash(api_key: &str) -> String {
 ///
 /// Returns all possible path prefixes for a scope. Some resources are served
 /// at multiple paths (e.g., users at both `/admin/users` and `/users/me`).
+///
+/// H-5: Comprehensive mapping covering all API resource types.
 fn scope_prefix_to_paths(prefix: &str) -> &'static [&'static str] {
     match prefix {
         "nhi" => &["/nhi"],
         "agents" => &["/agents"],
         "users" => &["/admin/users", "/users"],
-        "groups" => &["/admin/groups"],
+        "groups" => &["/admin/groups", "/groups"],
         "audit" => &["/audit"],
+        "tenants" => &["/admin/tenants", "/tenants"],
+        "policies" => &["/admin/policies", "/policies"],
+        "sessions" => &["/admin/sessions", "/sessions"],
+        "governance" => &["/governance"],
+        "connectors" => &["/connectors"],
+        "webhooks" => &["/webhooks"],
+        "operations" => &["/operations"],
+        "scim" => &["/scim", "/admin/scim-targets"],
+        "oauth" => &["/oauth"],
+        "oidc" => &["/oidc"],
+        "saml" => &["/saml"],
+        "social" => &["/social"],
+        "invitations" => &["/invitations"],
+        "api-keys" => &["/admin/api-keys"],
+        "gdpr" => &["/gdpr"],
+        "import" => &["/import"],
+        "export" => &["/export"],
         _ => &[],
     }
 }

--- a/crates/xavyo-api-auth/src/middleware/jwt_auth.rs
+++ b/crates/xavyo-api-auth/src/middleware/jwt_auth.rs
@@ -202,19 +202,26 @@ pub async fn jwt_auth_middleware(
     // token is revoked with cascade, a sentinel `revoke-all:{user_id}:{timestamp}` is
     // inserted. We must check this sentinel to reject access tokens issued before the
     // cascade, otherwise they remain valid until natural expiry (up to 15 minutes).
+    //
+    // C-5: Validate claims.sub as UUID before using in LIKE query to prevent
+    // SQL wildcard injection (% or _ in sub could match unintended sentinels).
     if !claims.jti.is_empty() && !claims.sub.is_empty() {
         if let Some(tid) = claims.tid {
+            // C-5: Only run sentinel check if sub is a valid UUID (prevents LIKE injection)
+            let sub_is_valid_uuid = uuid::Uuid::parse_str(&claims.sub).is_ok();
             let sentinel_pool = request.extensions().get::<PgPool>().cloned();
-            if let Some(pool) = sentinel_pool {
-                let sentinel_revoked: bool = match pool.acquire().await {
-                    Ok(mut conn) => {
-                        let _ =
-                            sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
-                                .bind(tid.to_string())
-                                .execute(&mut *conn)
-                                .await;
-                        sqlx::query_scalar(
-                            r"
+            if sub_is_valid_uuid {
+                if let Some(pool) = sentinel_pool {
+                    let sentinel_revoked: bool = match pool.acquire().await {
+                        Ok(mut conn) => {
+                            let _ = sqlx::query(
+                                "SELECT set_config('app.current_tenant', $1::text, true)",
+                            )
+                            .bind(tid.to_string())
+                            .execute(&mut *conn)
+                            .await;
+                            sqlx::query_scalar(
+                                r"
                             SELECT EXISTS(
                                 SELECT 1 FROM revoked_tokens
                                 WHERE jti LIKE 'revoke-all:' || $1 || ':%'
@@ -222,33 +229,37 @@ pub async fn jwt_auth_middleware(
                                   AND created_at > to_timestamp($2)
                             )
                             ",
-                        )
-                        .bind(&claims.sub)
-                        .bind(claims.iat as f64)
-                        .bind(tid)
-                        .fetch_one(&mut *conn)
-                        .await
-                        .unwrap_or(false)
+                            )
+                            .bind(&claims.sub)
+                            .bind(claims.iat as f64)
+                            .bind(tid)
+                            .fetch_one(&mut *conn)
+                            .await
+                            .unwrap_or(false)
+                        }
+                        Err(e) => {
+                            // Fail-closed: treat connection errors as revoked
+                            tracing::error!(error = %e, "Sentinel check connection failed (fail-closed)");
+                            true
+                        }
+                    };
+                    if sentinel_revoked {
+                        tracing::warn!(jti = %claims.jti, sub = %claims.sub, "Rejected token via revoke-all sentinel");
+                        return Err(
+                            (StatusCode::UNAUTHORIZED, "Token has been revoked").into_response()
+                        );
                     }
-                    Err(e) => {
-                        // Fail-closed: treat connection errors as revoked
-                        tracing::error!(error = %e, "Sentinel check connection failed (fail-closed)");
-                        true
-                    }
-                };
-                if sentinel_revoked {
-                    tracing::warn!(jti = %claims.jti, sub = %claims.sub, "Rejected token via revoke-all sentinel");
-                    return Err(
-                        (StatusCode::UNAUTHORIZED, "Token has been revoked").into_response()
-                    );
                 }
-            }
-            // SECURITY: If PgPool is absent, sentinel check cannot run. The individual
-            // JTI check above (lines 136-189) already provides fail-closed behavior,
-            // so cascade revocations are the only gap. In practice, PgPool is always
-            // present when RevocationCache is configured. Do NOT change this to
-            // fail-open (e.g., unwrap_or(false)) — that would allow cascade-revoked
-            // tokens to bypass revocation for their remaining lifetime.
+                // SECURITY: If PgPool is absent, sentinel check cannot run. The individual
+                // JTI check above (lines 136-189) already provides fail-closed behavior,
+                // so cascade revocations are the only gap. In practice, PgPool is always
+                // present when RevocationCache is configured. Do NOT change this to
+                // fail-open (e.g., unwrap_or(false)) — that would allow cascade-revoked
+                // tokens to bypass revocation for their remaining lifetime.
+            } // end if sub_is_valid_uuid
+              // C-5: For non-UUID sub (e.g. client_credentials tokens), sentinel check
+              // is skipped — these tokens use client_id as sub, not user UUIDs, and
+              // revoke-all sentinels are keyed by user_id.
         }
     }
 


### PR DESCRIPTION
## Summary

- **C-1**: Add `tenant_id` to password reset token lookup for defense-in-depth tenant isolation
- **C-4**: Guard empty JTI in claims builder — prevents revocation bypass
- **C-5**: UUID-validate `claims.sub` before sentinel LIKE query — prevents SQL wildcard injection
- **H-1**: Document SHA-256 acceptability for high-entropy API keys (256-bit random inputs)
- **H-5**: Expand API key scope mapping from 5 to 22+ resource types (tenants, policies, sessions, governance, connectors, webhooks, operations, SCIM, OAuth, OIDC, SAML, social, invitations, api-keys, GDPR, import, export)
- **M-1**: Dummy Argon2 verify on user-not-found to prevent timing oracle email enumeration
- **MFA role fetch**: Fail with 500 instead of silently issuing downgraded token with `["user"]`
- **C-3**: Add `validate_refresh_token_with_tenant()` for tenant-filtered refresh token validation
- **SELECT \* docs**: Document intentional SELECT * usage in auth endpoints (User struct has ~30 fields)

## Test plan

- [x] `cargo check -p idp-api` — clean
- [x] `cargo clippy -p idp-api -- -D warnings` — clean
- [x] `cargo test -p xavyo-auth -p xavyo-api-auth` — 55 passed, 0 failed
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)