### PR TITLE
feat: SAML SLO, OIDC end session, OpenAPI updates, README rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8515,6 +8515,7 @@ dependencies = [
  "flate2",
  "openssl",
  "quick-xml",
+ "reqwest",
  "serde",
  "serde_json",
  "sqlx",

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 </p>
 
 <p align="center">
-  <a href="#-quick-start">Quick Start</a> •
-  <a href="#-features">Features</a> •
-  <a href="#-why-xavyo">Why xavyo</a> •
-  <a href="#-documentation">Docs</a> •
-  <a href="#-contributing">Contributing</a>
+  <a href="#quick-start">Quick Start</a> •
+  <a href="#features">Features</a> •
+  <a href="#why-xavyo">Why xavyo</a> •
+  <a href="#documentation">Docs</a> •
+  <a href="#contributing">Contributing</a>
 </p>
 
 ---
@@ -42,14 +42,14 @@ Traditional IAM solutions weren't built for this. They focus on humans, not mach
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                           xavyo                                  │
+│                           xavyo                                    │
 ├─────────────────────────────────────────────────────────────────────┤
-│  🧑 Humans          │  🤖 AI Agents        │  🖥️ Services           │
-│  ─────────────────  │  ─────────────────   │  ─────────────────     │
-│  • SSO (OIDC/SAML)  │  • Agent Identity    │  • Service Accounts    │
-│  • MFA / Passkeys   │  • Dynamic Creds     │  • API Keys            │
-│  • Social Login     │  • Tool Permissions  │  • mTLS Certificates   │
-│  • Self-Service     │  • Audit Logging     │  • Workload Identity   │
+│  Humans              │  AI Agents            │  Services            │
+│  ─────────────────   │  ─────────────────    │  ─────────────────   │
+│  • SSO (OIDC/SAML)   │  • Agent Identity     │  • Service Accounts  │
+│  • MFA / Passkeys    │  • Dynamic Creds      │  • API Keys          │
+│  • Social Login      │  • Tool Permissions   │  • mTLS Certificates │
+│  • Self-Service      │  • Audit Logging      │  • Workload Identity │
 └─────────────────────────────────────────────────────────────────────┘
                                   │
                     ┌─────────────┴─────────────┐
@@ -62,48 +62,108 @@ Traditional IAM solutions weren't built for this. They focus on humans, not mach
 
 ---
 
-## ✨ Features
+## Features
 
-### 🔐 Authentication & SSO
+### Authentication & SSO
 | Feature | Description |
 |---------|-------------|
-| **OAuth2/OIDC Provider** | Full compliance with Authorization Code + PKCE, Client Credentials, Device Code |
-| **SAML 2.0 IdP** | SP-initiated and IdP-initiated SSO for enterprise apps |
-| **Multi-Factor Auth** | TOTP, WebAuthn/Passkeys, Recovery Codes |
-| **Social Login** | Google, Microsoft, Apple — plug and play |
+| **OAuth2/OIDC Provider** | Authorization Code + PKCE, Client Credentials, Device Code, Token Exchange, Refresh Tokens |
+| **SAML 2.0 IdP** | SP-initiated and IdP-initiated SSO with signature validation and group assertions |
+| **SAML Single Logout** | SP-initiated and IdP-initiated SLO with per-SP session tracking |
+| **OIDC RP-Initiated Logout** | End Session endpoint with `id_token_hint`, `post_logout_redirect_uri`, `client_id` |
+| **Multi-Factor Auth** | TOTP, WebAuthn/Passkeys, Recovery Codes with configurable enforcement |
+| **Social Login** | Google, Microsoft, Apple — with JWKS signature verification and nonce validation |
 | **Passwordless** | Magic links and passkey-first authentication |
+| **Session Management** | Active session tracking, revocation, concurrent session limits |
+| **Security Policies** | Configurable password, session, MFA, and lockout policies per tenant |
 
-### 🤖 AI Agent Security
+### AI Agent Security (NHI — Non-Human Identity)
 | Feature | Description |
 |---------|-------------|
-| **Agent Identity** | Register, track, and manage AI agent identities |
-| **Dynamic Credentials** | Short-lived AWS STS, Azure, GCP credentials on-demand |
-| **Tool Permissions** | Fine-grained control over what tools agents can use |
-| **Workload Identity** | Cloud-native identity federation for agents |
-| **PKI Certificates** | X.509 certificates for agent mTLS authentication |
+| **Unified NHI Model** | Single identity model for agents, tools, and service accounts with type-specific extensions |
+| **Lifecycle Management** | State machine: active, inactive, suspended, deprecated, archived — with full transition audit |
+| **Dynamic Credentials** | Short-lived AWS STS, Azure, GCP credentials via OAuth2 token exchange |
+| **Tool Permissions** | Fine-grained grant/revoke of agent-to-tool and NHI-to-NHI calling permissions |
+| **User Permissions** | Control which users can use/manage/admin each NHI identity |
+| **Risk Scoring** | Per-NHI risk assessment with inactivity detection and orphan account discovery |
+| **Certifications** | Certification campaigns for periodic NHI review and attestation |
+| **SoD Rules** | Segregation of Duties enforcement for NHI identities |
+| **MCP Discovery** | Model Context Protocol tool discovery endpoint for AI agent integration |
+| **A2A Protocol** | Agent-to-Agent communication with agent card discovery and webhook delivery |
+| **Workload Identity** | Cloud-native identity federation (AWS, Azure, GCP) |
+| **PKI Certificates** | X.509 certificate issuance for agent mTLS authentication |
 
-### 🏢 Enterprise & Governance
+### Identity Governance & Administration (IGA)
 | Feature | Description |
 |---------|-------------|
-| **Multi-Tenant** | Full tenant isolation with PostgreSQL Row-Level Security |
-| **SCIM 2.0** | Automated provisioning from Azure AD, Okta, etc. |
-| **Access Workflows** | Request → Approve → Provision with escalation |
-| **Segregation of Duties** | Prevent toxic combinations automatically |
-| **Connectors** | LDAP, Active Directory, databases, REST APIs |
+| **Roles & Entitlements** | RBAC with application-scoped entitlements and role-entitlement mappings |
+| **Role Inducements** | Automatic role grants — when a parent role is assigned, induced roles are automatically granted |
+| **Role Inheritance** | Hierarchical role structures with inheritance blocks |
+| **Role Mining** | Analytics-driven role discovery from existing access patterns |
+| **Access Requests** | Self-service request catalog with configurable approval workflows and escalation |
+| **Segregation of Duties** | SoD rule enforcement with exemptions and violation detection |
+| **Access Certifications** | Periodic review campaigns with micro-certification support |
+| **GDPR Compliance** | Data protection classification on entitlements, GDPR compliance reports, per-user data protection summaries |
+| **Lifecycle Workflows** | Joiner/mover/leaver automation with birthright policies and state machines |
+| **Risk Assessment** | Multi-factor risk scoring with alerts, thresholds, and peer group analysis |
+| **Outlier Detection** | Statistical detection of anomalous access patterns |
+| **Power of Attorney** | Delegated administration with time-bounded authority |
+| **Identity Archetypes** | Template-based identity provisioning (Employee, Contractor, etc.) |
+| **Personas** | Multiple persona management per identity |
+| **Meta-Roles & Parametric Roles** | Dynamic role generation and parameter-driven role assignment |
+| **Bulk Actions** | Batch operations for mass assignment, revocation, and lifecycle transitions |
+| **Object Templates** | Reusable templates for governance objects |
+| **Policy Simulation** | What-if analysis for access changes before applying them |
 
-### 💻 CLI (`xavyo-cli`)
+### Provisioning & Connectors
 | Feature | Description |
 |---------|-------------|
-| **32 Commands** | Full API coverage — agents, users, groups, governance, connectors, and more |
-| **Setup Wizard** | Interactive onboarding: signup → email verification → tenant creation |
-| **Email Verification** | `verify status` and `verify resend` with session-aware defaults |
+| **Connector Framework** | Pluggable architecture for target system integration |
+| **Built-in Connectors** | LDAP, Active Directory, REST APIs, Databases, Microsoft Entra ID |
+| **SCIM 2.0 Server** | Inbound provisioning from Azure AD, Okta, Google Workspace |
+| **SCIM 2.0 Client** | Outbound provisioning to SCIM-compliant targets |
+| **Reconciliation** | Scheduled reconciliation with conflict detection and resolution |
+| **Provisioning Jobs** | Job tracking with dead-letter queue and retry logic |
+| **Import/Export** | Bulk CSV import and declarative YAML export for users, groups, applications |
+
+### Enterprise Features
+| Feature | Description |
+|---------|-------------|
+| **Multi-Tenant** | Full tenant isolation with PostgreSQL Row-Level Security on every table |
+| **Tenant Settings** | Per-tenant configuration for branding, session policies, and features |
+| **User Invitations** | Email-based invitation flow with role preservation |
+| **API Keys** | Scoped API keys with usage statistics and introspection |
+| **Webhooks** | Event-driven notifications with circuit breaker, DLQ, and retry |
+| **SIEM Integration** | Structured audit events for security monitoring |
+| **Audit Logging** | Comprehensive audit trail for all operations |
+| **Correlation Engine** | Cross-system identity correlation and matching |
+| **Token Delegation** | OAuth2 token exchange for on-behalf-of and delegation flows |
+| **Ext-AuthZ Gateway** | External authorization service for API gateway integration |
+
+### OIDC Federation
+| Feature | Description |
+|---------|-------------|
+| **Identity Providers** | Configure external OIDC identity providers for federated login |
+| **Attribute Mapping** | Map external claims to internal user attributes |
+| **JIT Provisioning** | Just-in-time user creation from federated logins |
+| **JWKS Verification** | Full signature verification of ID tokens via JWKS |
+
+### CLI (`xavyo`)
+| Feature | Description |
+|---------|-------------|
+| **31 Commands** | Full API coverage — agents, users, groups, governance, NHI, connectors, and more |
+| **Setup Wizard** | Interactive onboarding: signup, email verification, tenant creation |
 | **Multi-Tenant Switching** | `tenant switch` to change context between organizations |
+| **Declarative Config** | `apply` and `export` for GitOps workflows |
+| **Watch Mode** | `watch` a YAML config file and auto-apply changes |
+| **Templates** | Pre-configured templates for quick setup |
 | **JSON Output** | `--json` flag on all commands for scripting and CI pipelines |
 | **Shell Completions** | Bash, Zsh, Fish, PowerShell via `completions` command |
+| **Doctor** | Connection and configuration diagnostics |
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Docker (recommended)
 
@@ -142,7 +202,7 @@ cp .env.example .env
 cargo run -p idp-api
 ```
 
-📖 **Swagger UI**: `http://localhost:8080/docs/`
+Swagger UI: `http://localhost:8080/docs/`
 
 ### Using the CLI
 
@@ -175,27 +235,61 @@ curl -X POST http://localhost:8080/auth/login \
 
 ---
 
-## 🎯 Why xavyo?
+## Why xavyo?
 
 | | xavyo | Traditional IAM | DIY |
 |---|:---:|:---:|:---:|
-| **AI Agent Identity** | ✅ Native | ❌ Bolt-on | 🔧 Build it |
-| **Dynamic Cloud Credentials** | ✅ Built-in | ❌ Separate tool | 🔧 Complex |
-| **Multi-Tenant by Design** | ✅ RLS isolation | ⚠️ Varies | 🔧 Hard |
-| **Open Source** | ✅ BSL 1.1 | ❌ Proprietary | ✅ |
-| **Performance** | ✅ Rust/Axum | ⚠️ JVM overhead | ⚠️ Varies |
-| **Self-Hosted** | ✅ Full control | ⚠️ Limited | ✅ |
+| **AI Agent Identity** | Native | Bolt-on | Build it |
+| **NHI Lifecycle Management** | Built-in | N/A | Complex |
+| **Dynamic Cloud Credentials** | Built-in | Separate tool | Complex |
+| **IGA (Governance)** | Full suite | Separate product | Enormous effort |
+| **Multi-Tenant by Design** | RLS isolation | Varies | Hard |
+| **SAML + OIDC + Social** | All built-in | Usually one | Build each |
+| **Open Source** | BSL 1.1 | Proprietary | Yes |
+| **Performance** | Rust/Axum | JVM overhead | Varies |
+| **Self-Hosted** | Full control | Limited | Yes |
 
 ### Built for Scale
 
 - **Rust** — Memory-safe, no GC pauses, predictable latency
-- **Axum** — Async-first, tower middleware ecosystem
-- **PostgreSQL RLS** — Tenant isolation at the database level
-- **149 migrations** — Battle-tested schema
+- **Axum** — Async-first HTTP framework with Tower middleware
+- **PostgreSQL RLS** — Tenant isolation enforced at the database level
+- **32 crates** — Modular architecture, each crate independently testable
+- **198 SQL migrations** — Battle-tested, production-grade schema
+- **665K lines of Rust** — Comprehensive implementation, not a prototype
+- **7,400+ tests** — 5,576 unit/integration + 1,907 functional tests across 14 batches
 
 ---
 
-## 📚 Documentation
+## API Surface
+
+xavyo exposes a comprehensive REST API with full OpenAPI/Swagger documentation.
+
+| Domain | Endpoints | Description |
+|--------|-----------|-------------|
+| **Authentication** | `/auth/*` | Login, logout, register, MFA, password reset, email verification |
+| **OAuth2/OIDC** | `/oauth/*` | Authorize, token, userinfo, JWKS, discovery, end session, introspect |
+| **SAML 2.0** | `/saml/*` | SSO, SLO, metadata, certificate management, SP configuration |
+| **Users & Groups** | `/users/*`, `/groups/*` | CRUD, role assignments, group memberships, password management |
+| **Sessions** | `/sessions/*` | Active session listing, revocation, concurrent limits |
+| **NHI (Non-Human)** | `/nhi/*` | Unified CRUD, lifecycle transitions, permissions, risk, certifications |
+| **Governance** | `/governance/*` | Roles, entitlements, access requests, SoD, certifications, GDPR |
+| **Connectors** | `/connectors/*` | Configuration, reconciliation, provisioning jobs, DLQ |
+| **SCIM 2.0** | `/scim/*` | Users, groups, service provider config, schemas |
+| **Webhooks** | `/webhooks/*` | Subscriptions, DLQ, circuit breaker |
+| **Social Login** | `/social/*` | Google, Microsoft, Apple federation |
+| **OIDC Federation** | `/federation/*` | External IdP configuration and metadata |
+| **Tenants** | `/tenants/*` | Multi-tenant management, settings, invitations |
+| **Import** | `/import/*` | Bulk CSV import with validation |
+| **API Keys** | `/api-keys/*` | Scoped key management, usage stats, introspection |
+| **Authorization** | `/authorization/*` | Policy evaluation, external authz |
+| **Audit** | `/audit/*` | Event log querying |
+| **Security Policies** | `/policies/*` | Password, session, MFA, lockout configuration |
+| **Operations** | `/operations/*` | Provisioning operation tracking |
+
+---
+
+## Documentation
 
 | Resource | Description |
 |----------|-------------|
@@ -210,42 +304,73 @@ Each crate has a standardized `CRATE.md` file at its root (e.g., [`crates/xavyo-
 
 ---
 
-## 🏗️ Architecture
+## Architecture
 
 ```
 xavyo/
 ├── apps/
 │   ├── idp-api/           # Main API service (Axum)
 │   ├── gateway/           # API Gateway
-│   └── xavyo-cli/         # CLI tool (32 commands)
+│   ├── ext-authz/         # External Authorization service
+│   └── xavyo-cli/         # CLI tool (31 commands)
 │
-├── crates/
-│   ├── xavyo-core/        # Shared types & errors
-│   ├── xavyo-auth/        # JWT, passwords, MFA
-│   ├── xavyo-db/          # PostgreSQL + 149 migrations
-│   ├── xavyo-tenant/      # Multi-tenant middleware
-│   ├── xavyo-events/      # Kafka event bus
-│   ├── xavyo-api-auth/    # Auth endpoints
-│   ├── xavyo-api-oauth/   # OAuth2/OIDC provider
-│   ├── xavyo-api-agents/  # AI Agent platform
-│   ├── xavyo-api-scim/    # SCIM provisioning
-│   ├── xavyo-connector/   # Connector framework
-│   └── xavyo-governance/  # IGA engine
+├── crates/                # 32 Rust crates
+│   ├── Core
+│   │   ├── xavyo-core/        # Shared types (TenantId, UserId, errors)
+│   │   ├── xavyo-auth/        # JWT, passwords, MFA, passkeys
+│   │   ├── xavyo-db/          # PostgreSQL + 198 migrations
+│   │   ├── xavyo-tenant/      # Multi-tenant middleware
+│   │   └── xavyo-events/      # Kafka event bus
+│   │
+│   ├── API Layer
+│   │   ├── xavyo-api-auth/         # Authentication endpoints
+│   │   ├── xavyo-api-oauth/        # OAuth2/OIDC provider
+│   │   ├── xavyo-api-saml/         # SAML 2.0 IdP + SLO
+│   │   ├── xavyo-api-social/       # Social login (Google, MS, Apple)
+│   │   ├── xavyo-api-users/        # User & group management
+│   │   ├── xavyo-api-scim/         # SCIM 2.0 server
+│   │   ├── xavyo-api-governance/   # IGA engine (40+ endpoints)
+│   │   ├── xavyo-api-nhi/          # Non-Human Identity API
+│   │   ├── xavyo-api-connectors/   # Connector & job management
+│   │   ├── xavyo-api-import/       # Bulk import
+│   │   ├── xavyo-api-tenants/      # Tenant & API key management
+│   │   ├── xavyo-api-authorization/# Policy evaluation
+│   │   └── xavyo-api-oidc-federation/ # External IdP federation
+│   │
+│   ├── Services
+│   │   ├── xavyo-governance/       # Governance business logic
+│   │   ├── xavyo-authorization/    # Authorization engine
+│   │   ├── xavyo-nhi/              # NHI domain logic
+│   │   ├── xavyo-provisioning/     # Provisioning orchestration
+│   │   ├── xavyo-webhooks/         # Webhook delivery + DLQ
+│   │   ├── xavyo-siem/             # SIEM integration
+│   │   ├── xavyo-secrets/          # Secret management
+│   │   └── xavyo-scim-client/      # Outbound SCIM client
+│   │
+│   └── Connectors
+│       ├── xavyo-connector/          # Connector trait framework
+│       ├── xavyo-connector-ldap/     # LDAP/AD connector
+│       ├── xavyo-connector-entra/    # Microsoft Entra ID connector
+│       ├── xavyo-connector-rest/     # Generic REST connector
+│       ├── xavyo-connector-database/ # Database connector
+│       └── xavyo-ext-authz/         # External authorization
 │
-└── docker/                # Docker & development environment
+├── docker/                # Docker & development environment
+├── tests/functional/      # 1,907 functional tests (14 batches)
+└── specs/                 # Feature specifications
 ```
 
-**32 Rust crates** | **149 SQL migrations** | **1,400+ source files**
+**32 crates** | **198 SQL migrations** | **1,739 source files** | **665K lines of Rust**
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
 We'd love your help making xavyo better!
 
 ### Good First Issues
 
-Look for issues tagged [`good first issue`](https://github.com/xavyo/xavyo/labels/good%20first%20issue) — these are great starting points.
+Look for issues tagged [`good first issue`](https://github.com/xavyo/xavyo/labels/good%20first%20issue).
 
 ### How to Contribute
 
@@ -274,27 +399,27 @@ cargo fmt --all
 
 ---
 
-## 🗺️ Roadmap
+## Roadmap
 
 - [ ] **Kubernetes Operator** — Deploy xavyo on K8s with CRDs
 - [ ] **Agent SDK** — Python, TypeScript, Go SDKs for agents
 - [ ] **Policy Engine** — OPA/Rego integration for fine-grained policies
 - [ ] **Terraform Provider** — Infrastructure as Code support
-- [ ] **Web Console** — Admin UI (API-first, UI second)
+- [ ] **Web Console** — Admin UI (SvelteKit, in development)
 
 Have ideas? [Open a discussion](https://github.com/xavyo/xavyo/discussions)!
 
 ---
 
-## 📜 License
+## License
 
 **Business Source License 1.1 (BSL 1.1)**
 
-- ✅ **Self-hosted deployment** — permitted
-- ✅ **Internal use** — permitted
-- ✅ **Modifications** — permitted
-- ❌ **Hosted service** — requires commercial license
-- 🔄 **Converts to Apache 2.0** on 2030-02-01
+- **Self-hosted deployment** — permitted
+- **Internal use** — permitted
+- **Modifications** — permitted
+- **Hosted service** — requires commercial license
+- **Converts to Apache 2.0** on 2030-02-01
 
 See [LICENSE](LICENSE) for full terms.
 
@@ -302,10 +427,10 @@ See [LICENSE](LICENSE) for full terms.
 
 Need to run xavyo as a hosted service? Contact us:
 
-📧 **pascal@heartbit.ai**
+pascal@heartbit.ai
 
 ---
 
 <p align="center">
-  <sub>Built with ❤️ by <a href="https://heartbit.ai">Hearbit Inc.</a></sub>
+  <sub>Built with care by <a href="https://heartbit.ai">Heartbit Inc.</a></sub>
 </p>

--- a/apps/idp-api/src/openapi.rs
+++ b/apps/idp-api/src/openapi.rs
@@ -229,7 +229,15 @@ impl Modify for SecurityAddon {
         (name = "Governance - NHI Certification", description = "Governance NHI certification campaigns, items, and decisions"),
         (name = "Governance - NHI Requests", description = "Governance NHI access request workflow"),
         (name = "Governance - NHI Risk", description = "Governance NHI risk scoring and batch calculation"),
-        (name = "Governance - NHI Usage", description = "Governance NHI usage tracking and summary")
+        (name = "Governance - NHI Usage", description = "Governance NHI usage tracking and summary"),
+        // GDPR Data Protection (F200)
+        (name = "Governance - GDPR", description = "GDPR data protection compliance reporting and per-user data protection summaries"),
+        // Role Inducements (F196)
+        (name = "Governance - Role Inducements", description = "Role inducement management — automatic role grants when a parent role is assigned"),
+        // SAML Single Logout (SLO)
+        (name = "SAML SLO", description = "SAML Single Logout — SP-initiated and IdP-initiated SLO"),
+        // OIDC End Session
+        (name = "OIDC", description = "OpenID Connect RP-Initiated Logout (end session)")
     ),
     paths(
         // Health
@@ -321,6 +329,8 @@ impl Modify for SecurityAddon {
         xavyo_api_oauth::handlers::discovery::discovery_handler,
         xavyo_api_oauth::handlers::discovery::jwks_handler,
         xavyo_api_oauth::handlers::userinfo::userinfo_handler,
+        // OIDC End Session (RP-Initiated Logout)
+        xavyo_api_oauth::handlers::logout::end_session_handler,
         // OAuth2 Device Code (RFC 8628)
         xavyo_api_oauth::handlers::device::device_authorization_handler,
         // OAuth2 Admin
@@ -373,6 +383,9 @@ impl Modify for SecurityAddon {
         xavyo_api_saml::handlers::admin::certificates::list_certificates,
         xavyo_api_saml::handlers::admin::certificates::upload_certificate,
         xavyo_api_saml::handlers::admin::certificates::activate_certificate,
+        // SAML SLO
+        xavyo_api_saml::handlers::slo::slo_post,
+        xavyo_api_saml::handlers::slo::slo_initiate,
         // SCIM
         xavyo_api_scim::handlers::users::list_users,
         xavyo_api_scim::handlers::users::create_user,
@@ -407,6 +420,9 @@ impl Modify for SecurityAddon {
         xavyo_api_governance::handlers::entitlements::create_entitlement,
         xavyo_api_governance::handlers::entitlements::update_entitlement,
         xavyo_api_governance::handlers::entitlements::delete_entitlement,
+        // Governance - GDPR Data Protection (F200)
+        xavyo_api_governance::handlers::entitlements::gdpr_report,
+        xavyo_api_governance::handlers::entitlements::user_data_protection,
         // Governance - Assignments (F033)
         xavyo_api_governance::handlers::assignments::list_assignments,
         xavyo_api_governance::handlers::assignments::get_assignment,
@@ -555,6 +571,14 @@ impl Modify for SecurityAddon {
         xavyo_api_governance::handlers::role_inheritance_blocks::list_inheritance_blocks,
         xavyo_api_governance::handlers::role_inheritance_blocks::add_inheritance_block,
         xavyo_api_governance::handlers::role_inheritance_blocks::remove_inheritance_block,
+        // Governance - Role Inducements (F196)
+        xavyo_api_governance::handlers::role_inducements::list_role_inducements,
+        xavyo_api_governance::handlers::role_inducements::get_role_inducement,
+        xavyo_api_governance::handlers::role_inducements::create_role_inducement,
+        xavyo_api_governance::handlers::role_inducements::delete_role_inducement,
+        xavyo_api_governance::handlers::role_inducements::enable_role_inducement,
+        xavyo_api_governance::handlers::role_inducements::disable_role_inducement,
+        xavyo_api_governance::handlers::role_inducements::get_induced_roles,
         // Governance - Lifecycle Events (F037)
         xavyo_api_governance::handlers::lifecycle_events::list_events,
         xavyo_api_governance::handlers::lifecycle_events::get_event,
@@ -1572,6 +1596,10 @@ impl Modify for SecurityAddon {
         xavyo_api_governance::models::EntitlementListResponse,
         xavyo_api_governance::models::CreateEntitlementRequest,
         xavyo_api_governance::models::UpdateEntitlementRequest,
+        // GDPR Data Protection schemas
+        xavyo_api_governance::models::GdprReport,
+        xavyo_api_governance::models::ClassifiedEntitlementDetail,
+        xavyo_api_governance::models::UserDataProtectionSummary,
         xavyo_api_governance::models::SetOwnerRequest,
         xavyo_api_governance::models::AssignmentResponse,
         xavyo_api_governance::models::AssignmentListResponse,
@@ -2525,6 +2553,11 @@ impl Modify for SecurityAddon {
         xavyo_api_governance::handlers::role_inheritance_blocks::AddInheritanceBlockRequest,
         xavyo_api_governance::handlers::role_inheritance_blocks::InheritanceBlockDetailsResponse,
         xavyo_api_governance::handlers::role_inheritance_blocks::InheritanceBlockResponse,
+        // Role Inducement schemas
+        xavyo_api_governance::models::role_inducement::CreateInducementRequest,
+        xavyo_api_governance::models::role_inducement::InducementResponse,
+        xavyo_api_governance::models::role_inducement::InducementListResponse,
+        xavyo_api_governance::models::role_inducement::InducedRoleInfoResponse,
         xavyo_api_governance::handlers::script_testing::RawDryRunRequest,
         xavyo_api_governance::handlers::ticketing_webhook::SingleTicketSyncResponse,
         xavyo_api_governance::handlers::ticketing_webhook::TicketSyncResponse,

--- a/crates/xavyo-api-nhi/src/handlers/provision.rs
+++ b/crates/xavyo-api-nhi/src/handlers/provision.rs
@@ -395,6 +395,7 @@ pub async fn provision_agent(
                 request.name
             )),
             nhi_id: Some(nhi_id),
+            post_logout_redirect_uris: vec![],
         };
 
         match state

--- a/crates/xavyo-api-oauth/src/handlers/logout.rs
+++ b/crates/xavyo-api-oauth/src/handlers/logout.rs
@@ -1,0 +1,476 @@
+//! OIDC RP-Initiated Logout 1.0 handler.
+//!
+//! Implements the `end_session_endpoint` per the OIDC RP-Initiated Logout specification.
+//!
+//! - `GET /oauth/logout` or `POST /oauth/logout` — initiates logout.
+//! - Accepts `id_token_hint`, `post_logout_redirect_uri`, `state`, and `client_id` params.
+//! - Validates the `id_token_hint` JWT signature (expired tokens accepted per spec).
+//! - Validates `post_logout_redirect_uri` against the client's registered URIs.
+//! - Revokes the user's sessions.
+//! - Redirects to `post_logout_redirect_uri` (303) or returns JSON success (200).
+
+use crate::error::OAuthError;
+use crate::router::OAuthState;
+use crate::services::token::IdTokenClaims;
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Redirect, Response},
+    Form, Json,
+};
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Parameters for the OIDC RP-Initiated Logout endpoint.
+///
+/// Accepted via query string (GET) or form body (POST).
+#[derive(Debug, Deserialize)]
+pub struct EndSessionParams {
+    /// Previously issued ID token passed as a hint about the end-user's
+    /// current authenticated session. The token MAY be expired.
+    pub id_token_hint: Option<String>,
+
+    /// URI to which the RP is requesting that the end-user's user-agent
+    /// be redirected after logout has been performed.
+    pub post_logout_redirect_uri: Option<String>,
+
+    /// Opaque value used by the RP to maintain state between the logout
+    /// request and the callback to the `post_logout_redirect_uri`.
+    pub state: Option<String>,
+
+    /// OAuth 2.0 client identifier of the RP. Used to identify the client
+    /// when `id_token_hint` is not provided.
+    pub client_id: Option<String>,
+}
+
+/// Response body returned when no post-logout redirect URI is provided.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct LogoutResponse {
+    /// Success message.
+    pub message: String,
+}
+
+/// Decoded identity from a validated `id_token_hint`.
+struct IdTokenIdentity {
+    /// The user's subject identifier (user ID).
+    user_id: Uuid,
+    /// The tenant identifier.
+    tenant_id: Option<Uuid>,
+    /// The audience (client_id) from the token.
+    client_id: String,
+}
+
+/// OIDC RP-Initiated Logout 1.0 endpoint.
+///
+/// Accepts both GET (query params) and POST (form body). The handler:
+///
+/// 1. Validates `id_token_hint` if provided (signature verification, issuer check).
+/// 2. Validates `post_logout_redirect_uri` against the client's registered URIs.
+/// 3. Revokes all user sessions if the user is identified.
+/// 4. Redirects to `post_logout_redirect_uri` (303) or returns 200 JSON.
+#[utoipa::path(
+    get,
+    path = "/oauth/logout",
+    params(
+        ("id_token_hint" = Option<String>, Query, description = "Previously issued ID token (may be expired)"),
+        ("post_logout_redirect_uri" = Option<String>, Query, description = "URI to redirect after logout"),
+        ("state" = Option<String>, Query, description = "Opaque state value for the RP"),
+        ("client_id" = Option<String>, Query, description = "OAuth2 client identifier"),
+    ),
+    responses(
+        (status = 200, description = "Logged out successfully (no redirect URI)", body = LogoutResponse),
+        (status = 303, description = "Redirect to post-logout URI"),
+        (status = 400, description = "Invalid request"),
+    ),
+    tag = "OIDC"
+)]
+pub async fn end_session_handler(
+    State(state): State<OAuthState>,
+    headers: HeaderMap,
+    query_params: Option<Query<EndSessionParams>>,
+    form_params: Option<Form<EndSessionParams>>,
+) -> Result<Response, OAuthError> {
+    // Merge GET query params and POST form params (POST takes precedence).
+    let params = match (form_params, query_params) {
+        (Some(Form(p)), _) => p,
+        (_, Some(Query(p))) => p,
+        (None, None) => EndSessionParams {
+            id_token_hint: None,
+            post_logout_redirect_uri: None,
+            state: None,
+            client_id: None,
+        },
+    };
+
+    let tenant_uuid = super::client_auth::extract_tenant_from_header(&headers)?;
+
+    // Input length validation to prevent abuse.
+    if let Some(ref hint) = params.id_token_hint {
+        if hint.len() > 8192 {
+            return Err(OAuthError::InvalidRequest(
+                "id_token_hint too large".to_string(),
+            ));
+        }
+    }
+    if let Some(ref state_val) = params.state {
+        if state_val.len() > 512 {
+            return Err(OAuthError::InvalidRequest(
+                "state parameter too large".to_string(),
+            ));
+        }
+    }
+    if let Some(ref uri) = params.post_logout_redirect_uri {
+        if uri.len() > 2048 {
+            return Err(OAuthError::InvalidRequest(
+                "post_logout_redirect_uri too large".to_string(),
+            ));
+        }
+    }
+
+    // Step 1: Validate id_token_hint if provided.
+    let identity = if let Some(ref id_token_hint) = params.id_token_hint {
+        match validate_id_token_hint(&state, id_token_hint) {
+            Ok(id) => Some(id),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "id_token_hint validation failed, proceeding without identity"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // Step 2: Determine the effective client_id.
+    // Per OIDC RP-Initiated Logout §2.1: if both id_token_hint and client_id
+    // are supplied, they MUST match. Reject mismatches.
+    let effective_client_id = match (
+        identity.as_ref().map(|id| id.client_id.clone()),
+        params.client_id.clone(),
+    ) {
+        (Some(token_aud), Some(explicit_id)) if token_aud != explicit_id => {
+            tracing::warn!(
+                token_aud = %token_aud,
+                explicit_client_id = %explicit_id,
+                "client_id parameter does not match id_token_hint audience"
+            );
+            return Err(OAuthError::InvalidRequest(
+                "client_id does not match id_token_hint audience".to_string(),
+            ));
+        }
+        (Some(token_aud), _) => Some(token_aud),
+        (None, explicit) => explicit,
+    };
+
+    // Step 3: Validate post_logout_redirect_uri if provided.
+    let validated_redirect_uri = if let Some(ref redirect_uri) = params.post_logout_redirect_uri {
+        validate_post_logout_redirect_uri(
+            &state,
+            tenant_uuid,
+            effective_client_id.as_deref(),
+            redirect_uri,
+        )
+        .await
+    } else {
+        None
+    };
+
+    // Step 4: Revoke user sessions and refresh tokens if user is identified.
+    if let Some(ref id) = identity {
+        // Use the tenant_id from the id_token_hint if available, otherwise
+        // fall back to the tenant_id from the request extension.
+        let session_tenant = id.tenant_id.unwrap_or(tenant_uuid);
+        if let Err(e) = revoke_user_sessions(&state, session_tenant, id.user_id).await {
+            tracing::error!(
+                user_id = %id.user_id,
+                tenant_id = %session_tenant,
+                error = %e,
+                "Failed to revoke user sessions during logout"
+            );
+        }
+        // Also revoke all OAuth2 refresh tokens for this user
+        if let Err(e) = state
+            .token_service
+            .revoke_user_tokens(session_tenant, id.user_id)
+            .await
+        {
+            tracing::error!(
+                user_id = %id.user_id,
+                tenant_id = %session_tenant,
+                error = %e,
+                "Failed to revoke refresh tokens during logout"
+            );
+        }
+    }
+
+    // Step 5: Build response.
+    if let Some(redirect_uri) = validated_redirect_uri {
+        // Build the redirect URL, appending state if present.
+        // Use proper URL parsing to handle fragments and existing query params correctly.
+        let redirect_url = if let Some(ref state_value) = params.state {
+            let mut parsed = url::Url::parse(&redirect_uri).map_err(|_| {
+                OAuthError::InvalidRequest("Invalid post_logout_redirect_uri".to_string())
+            })?;
+            parsed.query_pairs_mut().append_pair("state", state_value);
+            parsed.to_string()
+        } else {
+            redirect_uri
+        };
+
+        tracing::info!(
+            redirect_uri = %redirect_url,
+            user_id = ?identity.as_ref().map(|id| id.user_id),
+            "OIDC RP-Initiated Logout: redirecting"
+        );
+
+        Ok(Redirect::to(&redirect_url).into_response())
+    } else {
+        tracing::info!(
+            user_id = ?identity.as_ref().map(|id| id.user_id),
+            "OIDC RP-Initiated Logout: no redirect URI"
+        );
+
+        Ok((
+            StatusCode::OK,
+            Json(LogoutResponse {
+                message: "Logged out successfully".to_string(),
+            }),
+        )
+            .into_response())
+    }
+}
+
+/// Validate the `id_token_hint` JWT.
+///
+/// Decodes the JWT header to find the `kid`, locates the matching signing key,
+/// and verifies the signature. Per OIDC RP-Initiated Logout, expired tokens
+/// are accepted (`validate_exp = false`).
+///
+/// Validates that `iss` matches the configured issuer.
+fn validate_id_token_hint(
+    state: &OAuthState,
+    id_token_hint: &str,
+) -> Result<IdTokenIdentity, OAuthError> {
+    // Decode the JWT header to extract the kid.
+    let header = decode_header(id_token_hint).map_err(|e| {
+        OAuthError::InvalidRequest(format!(
+            "Invalid id_token_hint: failed to decode header: {e}"
+        ))
+    })?;
+
+    // Find the matching public key by kid.
+    let public_key_pem = if let Some(ref kid) = header.kid {
+        if let Some(key) = state.find_key_by_kid(kid) {
+            key.public_key_pem.as_bytes().to_vec()
+        } else {
+            // SECURITY: Do not fall back to the active key when kid is provided
+            // but not found. This could allow forged tokens signed with a different
+            // key to be accepted if the active key happens to match.
+            return Err(OAuthError::InvalidRequest(format!(
+                "Invalid id_token_hint: unknown key ID '{kid}'"
+            )));
+        }
+    } else {
+        // No kid in the token header; use the active public key.
+        state.public_key.clone()
+    };
+
+    // Build validation: accept expired tokens, validate issuer, skip audience.
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.algorithms = vec![Algorithm::RS256];
+    validation.validate_exp = false;
+    validation.set_issuer(&[&state.issuer]);
+    // Audience is not validated here because we extract it as the client_id.
+    validation.validate_aud = false;
+
+    let decoding_key = DecodingKey::from_rsa_pem(&public_key_pem).map_err(|e| {
+        tracing::error!(error = %e, "Failed to create decoding key from public key PEM");
+        OAuthError::Internal("Failed to create decoding key".to_string())
+    })?;
+
+    let token_data =
+        decode::<IdTokenClaims>(id_token_hint, &decoding_key, &validation).map_err(|e| {
+            OAuthError::InvalidRequest(format!(
+                "Invalid id_token_hint: signature verification failed: {e}"
+            ))
+        })?;
+
+    let claims = token_data.claims;
+
+    // Extract user_id from sub.
+    let user_id = claims.sub.parse::<Uuid>().map_err(|_| {
+        OAuthError::InvalidRequest("Invalid id_token_hint: sub is not a valid UUID".to_string())
+    })?;
+
+    Ok(IdTokenIdentity {
+        user_id,
+        tenant_id: claims.tid,
+        client_id: claims.aud,
+    })
+}
+
+/// Validate a `post_logout_redirect_uri` against the client's registered URIs.
+///
+/// Returns `Some(uri)` if the URI is valid, `None` otherwise.
+/// Per the OIDC spec, invalid URIs are silently ignored (no error returned).
+async fn validate_post_logout_redirect_uri(
+    state: &OAuthState,
+    tenant_id: Uuid,
+    effective_client_id: Option<&str>,
+    redirect_uri: &str,
+) -> Option<String> {
+    // The client_id must be identifiable to validate the redirect URI.
+    let client_id = match effective_client_id {
+        Some(id) => id,
+        None => {
+            tracing::debug!(
+                "post_logout_redirect_uri provided but no client_id identifiable; ignoring redirect"
+            );
+            return None;
+        }
+    };
+
+    // Look up the client.
+    let client = match state
+        .client_service
+        .get_client_by_client_id(tenant_id, client_id)
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(
+                client_id = %client_id,
+                error = %e,
+                "Failed to look up client for post_logout_redirect_uri validation; ignoring redirect"
+            );
+            return None;
+        }
+    };
+
+    // Inactive clients should not participate in logout redirects.
+    if !client.is_active {
+        tracing::debug!(
+            client_id = %client_id,
+            "Client is inactive; ignoring post_logout_redirect_uri"
+        );
+        return None;
+    }
+
+    // Check if the requested URI is in the client's registered list.
+    // Use URL-parsed comparison for case-insensitive host matching and port normalization,
+    // consistent with redirect_uri validation in the authorize endpoint.
+    let normalized_request = url::Url::parse(redirect_uri).ok().map(|u| u.to_string());
+    let matched = normalized_request.as_ref().and_then(|norm_req| {
+        client
+            .post_logout_redirect_uris
+            .iter()
+            .find(|uri| url::Url::parse(uri).ok().map(|u| u.to_string()).as_ref() == Some(norm_req))
+            .map(|_| norm_req.clone())
+    });
+
+    if matched.is_some() {
+        matched
+    } else {
+        tracing::debug!(
+            client_id = %client_id,
+            redirect_uri = %redirect_uri,
+            registered_uris = ?client.post_logout_redirect_uris,
+            "post_logout_redirect_uri not in client's registered list; ignoring redirect"
+        );
+        None
+    }
+}
+
+/// Revoke all sessions for a user within a tenant.
+///
+/// Deletes all entries from `user_sessions` for the given user and tenant,
+/// with RLS context set for tenant isolation.
+async fn revoke_user_sessions(
+    state: &OAuthState,
+    tenant_id: Uuid,
+    user_id: Uuid,
+) -> Result<u64, OAuthError> {
+    let mut conn = state.pool.acquire().await.map_err(|e| {
+        tracing::error!("Failed to acquire connection for session revocation: {e}");
+        OAuthError::Internal("Failed to acquire database connection".to_string())
+    })?;
+
+    // Set tenant context for RLS on this connection.
+    sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+        .bind(tenant_id.to_string())
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to set tenant context: {e}");
+            OAuthError::Internal("Failed to set tenant context".to_string())
+        })?;
+
+    let result = sqlx::query("DELETE FROM user_sessions WHERE tenant_id = $1 AND user_id = $2")
+        .bind(tenant_id)
+        .bind(user_id)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                user_id = %user_id,
+                tenant_id = %tenant_id,
+                error = %e,
+                "Failed to delete user sessions"
+            );
+            OAuthError::Internal("Failed to revoke user sessions".to_string())
+        })?;
+
+    let rows_deleted = result.rows_affected();
+    tracing::info!(
+        user_id = %user_id,
+        tenant_id = %tenant_id,
+        sessions_revoked = rows_deleted,
+        "User sessions revoked during OIDC logout"
+    );
+
+    Ok(rows_deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_end_session_params_deserialize_empty() {
+        let params: EndSessionParams = serde_json::from_str("{}").unwrap();
+        assert!(params.id_token_hint.is_none());
+        assert!(params.post_logout_redirect_uri.is_none());
+        assert!(params.state.is_none());
+        assert!(params.client_id.is_none());
+    }
+
+    #[test]
+    fn test_end_session_params_deserialize_full() {
+        let json = r#"{
+            "id_token_hint": "eyJ...",
+            "post_logout_redirect_uri": "https://example.com/logout-callback",
+            "state": "abc123",
+            "client_id": "my-client"
+        }"#;
+        let params: EndSessionParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.id_token_hint.unwrap(), "eyJ...");
+        assert_eq!(
+            params.post_logout_redirect_uri.unwrap(),
+            "https://example.com/logout-callback"
+        );
+        assert_eq!(params.state.unwrap(), "abc123");
+        assert_eq!(params.client_id.unwrap(), "my-client");
+    }
+
+    #[test]
+    fn test_logout_response_serialization() {
+        let response = LogoutResponse {
+            message: "Logged out successfully".to_string(),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"message\":\"Logged out successfully\""));
+    }
+}

--- a/crates/xavyo-api-oauth/src/handlers/mod.rs
+++ b/crates/xavyo-api-oauth/src/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod device;
 pub mod device_login;
 pub mod discovery;
 pub mod introspection;
+pub mod logout;
 pub mod revocation;
 pub mod token;
 pub mod userinfo;
@@ -39,6 +40,7 @@ pub use device_login::{
 };
 pub use discovery::{discovery_handler, jwks_handler};
 pub use introspection::introspect_token_handler;
+pub use logout::end_session_handler;
 pub use revocation::revoke_token_handler;
 pub use token::token_handler;
 pub use userinfo::userinfo_handler;

--- a/crates/xavyo-api-oauth/src/lib.rs
+++ b/crates/xavyo-api-oauth/src/lib.rs
@@ -52,6 +52,7 @@ pub mod services;
 pub mod utils;
 
 pub use error::OAuthError;
+pub use handlers::end_session_handler;
 pub use middleware::{
     clear_session_cookie, create_session_cookie, extract_session_cookie, set_session_cookie,
     SESSION_COOKIE_MAX_AGE, SESSION_COOKIE_NAME,

--- a/crates/xavyo-api-oauth/src/models/client.rs
+++ b/crates/xavyo-api-oauth/src/models/client.rs
@@ -57,6 +57,9 @@ pub struct CreateClientRequest {
     /// When set, client_credentials tokens use this NHI ID as the JWT subject.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nhi_id: Option<Uuid>,
+    /// Allowed post-logout redirect URIs (OIDC RP-Initiated Logout).
+    #[serde(default)]
+    pub post_logout_redirect_uris: Vec<String>,
 }
 
 /// Request to update an `OAuth2` client.
@@ -76,6 +79,8 @@ pub struct UpdateClientRequest {
     pub logo_url: Option<String>,
     /// Client description (shown on consent page).
     pub description: Option<String>,
+    /// Allowed post-logout redirect URIs (OIDC RP-Initiated Logout).
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 /// `OAuth2` client response.
@@ -104,6 +109,8 @@ pub struct ClientResponse {
     /// Bound NHI identity (if any).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nhi_id: Option<Uuid>,
+    /// Allowed post-logout redirect URIs (OIDC RP-Initiated Logout).
+    pub post_logout_redirect_uris: Vec<String>,
     /// Creation timestamp.
     pub created_at: DateTime<Utc>,
     /// Last update timestamp.

--- a/crates/xavyo-api-oauth/src/models/discovery.rs
+++ b/crates/xavyo-api-oauth/src/models/discovery.rs
@@ -35,6 +35,9 @@ pub struct OpenIdConfiguration {
     pub code_challenge_methods_supported: Vec<String>,
     /// Supported claims.
     pub claims_supported: Vec<String>,
+    /// End session endpoint (OIDC RP-Initiated Logout).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_session_endpoint: Option<String>,
 }
 
 use super::token::DEVICE_CODE_GRANT_TYPE;
@@ -90,6 +93,7 @@ impl OpenIdConfiguration {
                 "family_name".to_string(),
                 "act".to_string(),
             ],
+            end_session_endpoint: Some(format!("{issuer}/oauth/logout")),
         }
     }
 }

--- a/crates/xavyo-api-oauth/src/router.rs
+++ b/crates/xavyo-api-oauth/src/router.rs
@@ -18,9 +18,10 @@ use crate::handlers::{
     device_authorization_handler, device_authorize_handler, device_confirm_handler,
     device_login_handler, device_login_page_handler, device_mfa_handler, device_mfa_page_handler,
     device_resend_confirmation_handler, device_verification_page_handler,
-    device_verify_code_handler, discovery_handler, get_client_handler, introspect_token_handler,
-    jwks_handler, list_active_sessions_handler, list_clients_handler, regenerate_secret_handler,
-    revoke_token_handler, token_handler, update_client_handler, userinfo_handler,
+    device_verify_code_handler, discovery_handler, end_session_handler, get_client_handler,
+    introspect_token_handler, jwks_handler, list_active_sessions_handler, list_clients_handler,
+    regenerate_secret_handler, revoke_token_handler, token_handler, update_client_handler,
+    userinfo_handler,
 };
 use crate::services::{
     AuthorizationService, DeviceConfirmationService, DeviceRiskService, OAuth2ClientService,
@@ -307,6 +308,11 @@ pub fn oauth_router(state: OAuthState) -> Router {
         .route("/introspect", post(introspect_token_handler))
         // F096: RFC 8628 Device Authorization endpoint
         .route("/device/code", post(device_authorization_handler))
+        // OIDC RP-Initiated Logout 1.0
+        .route(
+            "/logout",
+            get(end_session_handler).post(end_session_handler),
+        )
         .with_state(state)
 }
 

--- a/crates/xavyo-api-oauth/src/services/token.rs
+++ b/crates/xavyo-api-oauth/src/services/token.rs
@@ -75,6 +75,10 @@ pub struct IdTokenClaims {
     /// Access token hash (for hybrid flows).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub at_hash: Option<String>,
+
+    /// Session ID (OIDC RP-Initiated Logout).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sid: Option<String>,
 }
 
 impl IdTokenClaims {
@@ -97,6 +101,7 @@ pub struct IdTokenClaimsBuilder {
     nonce: Option<String>,
     tid: Option<Uuid>,
     at_hash: Option<String>,
+    sid: Option<String>,
 }
 
 impl IdTokenClaimsBuilder {
@@ -156,6 +161,13 @@ impl IdTokenClaimsBuilder {
         self
     }
 
+    /// Set the session ID (OIDC RP-Initiated Logout).
+    #[must_use]
+    pub fn sid(mut self, sid: impl Into<String>) -> Self {
+        self.sid = Some(sid.into());
+        self
+    }
+
     /// Build the ID token claims.
     #[must_use]
     pub fn build(self) -> IdTokenClaims {
@@ -171,6 +183,7 @@ impl IdTokenClaimsBuilder {
             nonce: self.nonce,
             tid: self.tid,
             at_hash: self.at_hash,
+            sid: self.sid,
         }
     }
 }

--- a/crates/xavyo-api-saml/Cargo.toml
+++ b/crates/xavyo-api-saml/Cargo.toml
@@ -57,6 +57,7 @@ xavyo-db = { path = "../xavyo-db" }
 xavyo-auth = { path = "../xavyo-auth" }
 xavyo-tenant = { path = "../xavyo-tenant" }
 xml-canonicalization = "0.1.0"
+reqwest = { version = "0.12", features = ["json"] }
 
 [dev-dependencies]
 tokio-test.workspace = true

--- a/crates/xavyo-api-saml/src/handlers/mod.rs
+++ b/crates/xavyo-api-saml/src/handlers/mod.rs
@@ -3,8 +3,10 @@
 pub mod admin;
 pub mod initiate;
 pub mod metadata;
+pub mod slo;
 pub mod sso;
 
 pub use initiate::initiate_sso;
 pub use metadata::get_metadata;
+pub use slo::{slo_initiate, slo_post};
 pub use sso::{sso_post, sso_redirect};

--- a/crates/xavyo-api-saml/src/handlers/slo.rs
+++ b/crates/xavyo-api-saml/src/handlers/slo.rs
@@ -1,0 +1,180 @@
+//! SAML Single Logout handlers
+
+use crate::error::{SamlError, SamlResult};
+use crate::handlers::metadata::SamlState;
+use crate::services::logout_parser;
+use crate::services::signature_validator::SignatureValidator;
+use crate::services::slo_service::{SloResult, SloService};
+use crate::services::SpService;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Extension, Form, Json,
+};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::Deserialize;
+use uuid::Uuid;
+use xavyo_auth::JwtClaims;
+use xavyo_core::TenantId;
+
+/// Form data for incoming SLO POST
+#[derive(Debug, Deserialize)]
+pub struct SloPostForm {
+    /// Base64-encoded SAML LogoutRequest
+    #[serde(rename = "SAMLRequest")]
+    pub saml_request: Option<String>,
+    /// RelayState (optional)
+    #[serde(rename = "RelayState")]
+    pub relay_state: Option<String>,
+}
+
+/// SP sends LogoutRequest to IdP (back-channel or browser POST)
+///
+/// POST /saml/slo
+#[utoipa::path(
+    post,
+    path = "/saml/slo",
+    request_body = SloPostForm,
+    responses(
+        (status = 200, description = "LogoutResponse"),
+        (status = 400, description = "Invalid LogoutRequest"),
+    ),
+    tag = "SAML SLO"
+)]
+pub async fn slo_post(
+    State(state): State<SamlState>,
+    Extension(tenant_id): Extension<TenantId>,
+    Form(form): Form<SloPostForm>,
+) -> Response {
+    match handle_slo_post(&state, *tenant_id.as_uuid(), form).await {
+        Ok(response) => response,
+        Err(e) => {
+            tracing::error!(error = %e, "SLO POST failed");
+            e.into_response()
+        }
+    }
+}
+
+async fn handle_slo_post(
+    state: &SamlState,
+    tenant_id: Uuid,
+    form: SloPostForm,
+) -> SamlResult<Response> {
+    let saml_request_b64 = form.saml_request.ok_or_else(|| {
+        SamlError::InvalidLogoutRequest("Missing SAMLRequest parameter".to_string())
+    })?;
+
+    // Size check before decode
+    if saml_request_b64.len() > 512 * 1024 {
+        return Err(SamlError::InvalidLogoutRequest(
+            "LogoutRequest too large".to_string(),
+        ));
+    }
+
+    // Base64 decode to get raw XML (needed for signature validation)
+    let decoded_bytes = STANDARD
+        .decode(&saml_request_b64)
+        .map_err(|e| SamlError::InvalidLogoutRequest(format!("Base64 decode failed: {e}")))?;
+    let xml = String::from_utf8(decoded_bytes)
+        .map_err(|e| SamlError::InvalidLogoutRequest(format!("Invalid UTF-8: {e}")))?;
+
+    // Parse the LogoutRequest XML
+    let parsed = logout_parser::parse_logout_request_xml(&xml)?;
+
+    tracing::info!(
+        tenant_id = %tenant_id,
+        issuer = %parsed.issuer,
+        request_id = %parsed.id,
+        "SAML LogoutRequest received"
+    );
+
+    // Look up the SP by issuer to get certificate and validate_signatures flag
+    let sp_service = SpService::new(state.pool.clone());
+    let sp = sp_service
+        .get_sp_by_entity_id(tenant_id, &parsed.issuer)
+        .await?;
+
+    if !sp.enabled {
+        return Err(SamlError::DisabledServiceProvider(sp.entity_id.clone()));
+    }
+
+    // SECURITY: Validate LogoutRequest signature if SP requires it
+    if sp.validate_signatures {
+        let sp_cert = sp.certificate.as_deref().ok_or_else(|| {
+            SamlError::SignatureValidationFailed(
+                "SP requires signature validation but has no certificate configured".to_string(),
+            )
+        })?;
+        SignatureValidator::validate_post_signature(&xml, sp_cert, Some(&parsed.id))?;
+        tracing::debug!(
+            sp_entity_id = %sp.entity_id,
+            "LogoutRequest signature validated"
+        );
+    } else if xml.contains("<ds:Signature") || xml.contains("<Signature") {
+        tracing::warn!(
+            sp_entity_id = %sp.entity_id,
+            "LogoutRequest contains signature but SP has validate_signatures=false"
+        );
+    }
+
+    // Process the logout (SP already looked up, pass sp_id directly)
+    let slo_service = SloService::new(state.pool.clone());
+    let result = slo_service
+        .process_sp_logout_for_sp(state, tenant_id, &sp, &parsed)
+        .await?;
+
+    tracing::info!(
+        tenant_id = %tenant_id,
+        user_id = %result.user_id,
+        "SP-initiated SLO completed"
+    );
+
+    // Return the LogoutResponse as form-encoded body for back-channel.
+    // SECURITY: URL-encode the base64 value (base64 contains +/= which are
+    // significant in form encoding).
+    Ok((
+        StatusCode::OK,
+        [(
+            "content-type",
+            "application/x-www-form-urlencoded; charset=UTF-8",
+        )],
+        format!("SAMLResponse={}", urlencoding::encode(&result.response_xml)),
+    )
+        .into_response())
+}
+
+/// IdP-initiated SLO: authenticated user triggers logout of all SPs
+///
+/// POST /saml/slo/initiate
+#[utoipa::path(
+    post,
+    path = "/saml/slo/initiate",
+    responses(
+        (status = 200, description = "SLO dispatch result", body = SloResult),
+        (status = 401, description = "Not authenticated"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "SAML SLO"
+)]
+pub async fn slo_initiate(
+    State(state): State<SamlState>,
+    Extension(tenant_id): Extension<TenantId>,
+    Extension(claims): Extension<JwtClaims>,
+) -> Result<Json<SloResult>, SamlError> {
+    let user_id = Uuid::parse_str(&claims.sub).map_err(|_| SamlError::NotAuthenticated)?;
+    let tid = *tenant_id.as_uuid();
+
+    tracing::info!(
+        tenant_id = %tid,
+        user_id = %user_id,
+        "IdP-initiated SLO requested"
+    );
+
+    let slo_service = SloService::new(state.pool.clone());
+    let result = slo_service
+        .dispatch_logout_to_sps(&state, tid, user_id)
+        .await?;
+
+    Ok(Json(result))
+}

--- a/crates/xavyo-api-saml/src/lib.rs
+++ b/crates/xavyo-api-saml/src/lib.rs
@@ -18,6 +18,12 @@ pub mod session;
 
 pub use error::{SamlError, SamlResult};
 pub use handlers::metadata::SamlState;
+pub use handlers::slo::{slo_initiate, slo_post};
 #[allow(deprecated)]
 pub use router::{create_saml_state, saml_admin_router, saml_public_router, saml_router};
-pub use session::{AuthnRequestSession, InMemorySessionStore, PostgresSessionStore, SessionStore};
+pub use services::assertion_builder::SamlResponseOutput;
+pub use services::slo_builder::SloBuilder;
+pub use session::{
+    AuthnRequestSession, InMemorySessionStore, InMemorySpSessionStore, PostgresSessionStore,
+    PostgresSpSessionStore, SessionStore, SpSession, SpSessionStore,
+};

--- a/crates/xavyo-api-saml/src/models/responses.rs
+++ b/crates/xavyo-api-saml/src/models/responses.rs
@@ -56,6 +56,8 @@ pub struct ServiceProviderResponse {
     pub assertion_validity_seconds: i32,
     pub enabled: bool,
     pub metadata_url: Option<String>,
+    pub slo_url: Option<String>,
+    pub slo_binding: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -75,6 +77,8 @@ impl From<xavyo_db::models::SamlServiceProvider> for ServiceProviderResponse {
             assertion_validity_seconds: sp.assertion_validity_seconds,
             enabled: sp.enabled,
             metadata_url: sp.metadata_url,
+            slo_url: sp.slo_url,
+            slo_binding: sp.slo_binding,
             created_at: sp.created_at,
             updated_at: sp.updated_at,
         }

--- a/crates/xavyo-api-saml/src/router.rs
+++ b/crates/xavyo-api-saml/src/router.rs
@@ -7,7 +7,7 @@ use crate::handlers::{
         get_service_provider, list_certificates, list_service_providers, update_service_provider,
         upload_certificate,
     },
-    get_metadata, initiate_sso, sso_post, sso_redirect,
+    get_metadata, initiate_sso, slo_initiate, slo_post, sso_post, sso_redirect,
 };
 use axum::{
     routing::{get, post},
@@ -21,8 +21,12 @@ pub fn saml_public_router(state: SamlState) -> Router {
         // Public SAML endpoints
         .route("/saml/metadata", get(get_metadata))
         .route("/saml/sso", get(sso_redirect).post(sso_post))
+        // SLO endpoint (SP-initiated logout)
+        .route("/saml/slo", post(slo_post))
         // IdP-initiated SSO (requires auth - handled by calling code)
         .route("/saml/initiate/:sp_id", post(initiate_sso))
+        // IdP-initiated SLO (requires auth - handled by calling code)
+        .route("/saml/slo/initiate", post(slo_initiate))
         .with_state(state)
 }
 
@@ -95,10 +99,13 @@ pub fn create_saml_state(
 ) -> SamlState {
     let session_store =
         std::sync::Arc::new(crate::session::PostgresSessionStore::new(pool.clone()));
+    let sp_session_store =
+        std::sync::Arc::new(crate::session::PostgresSpSessionStore::new(pool.clone()));
     SamlState {
         pool,
         base_url,
         encryption_key: std::sync::Arc::new(encryption_key),
         session_store,
+        sp_session_store,
     }
 }

--- a/crates/xavyo-api-saml/src/services/logout_parser.rs
+++ b/crates/xavyo-api-saml/src/services/logout_parser.rs
@@ -1,0 +1,190 @@
+//! Parse incoming SAML LogoutRequest XML
+
+use crate::error::{SamlError, SamlResult};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+
+/// Parsed LogoutRequest data
+#[derive(Debug, Clone)]
+pub struct ParsedLogoutRequest {
+    pub id: String,
+    pub issuer: String,
+    pub name_id: String,
+    pub name_id_format: String,
+    pub session_index: Option<String>,
+}
+
+/// Parse a base64-encoded SAML LogoutRequest
+pub fn parse_logout_request(encoded: &str) -> SamlResult<ParsedLogoutRequest> {
+    // Size check before decode
+    if encoded.len() > 512 * 1024 {
+        return Err(SamlError::InvalidLogoutRequest(
+            "LogoutRequest too large".to_string(),
+        ));
+    }
+
+    let decoded = STANDARD
+        .decode(encoded)
+        .map_err(|e| SamlError::InvalidLogoutRequest(format!("Base64 decode failed: {e}")))?;
+    let xml = String::from_utf8(decoded)
+        .map_err(|e| SamlError::InvalidLogoutRequest(format!("Invalid UTF-8: {e}")))?;
+
+    parse_logout_request_xml(&xml)
+}
+
+/// Parse LogoutRequest from raw XML
+pub fn parse_logout_request_xml(xml: &str) -> SamlResult<ParsedLogoutRequest> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut id = None;
+    let mut issuer = None;
+    let mut name_id = None;
+    let mut name_id_format = String::new();
+    let mut session_index = None;
+    let mut current_element = String::new();
+
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = String::from_utf8_lossy(e.local_name().into_inner()).to_string();
+                current_element = local.clone();
+
+                if local == "LogoutRequest" {
+                    for attr in e.attributes().flatten() {
+                        let key =
+                            String::from_utf8_lossy(attr.key.local_name().into_inner()).to_string();
+                        if key == "ID" {
+                            id = Some(String::from_utf8_lossy(&attr.value).to_string());
+                        }
+                    }
+                } else if local == "NameID" {
+                    for attr in e.attributes().flatten() {
+                        let key =
+                            String::from_utf8_lossy(attr.key.local_name().into_inner()).to_string();
+                        if key == "Format" {
+                            name_id_format = String::from_utf8_lossy(&attr.value).to_string();
+                        }
+                    }
+                }
+            }
+            Ok(Event::Text(ref e)) => {
+                let text = e.unescape().unwrap_or_default().to_string();
+                match current_element.as_str() {
+                    "Issuer" => issuer = Some(text),
+                    "NameID" => name_id = Some(text),
+                    "SessionIndex" => session_index = Some(text),
+                    _ => {}
+                }
+            }
+            Ok(Event::End(_)) => {
+                current_element.clear();
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(SamlError::InvalidLogoutRequest(format!(
+                    "XML parse error: {e}"
+                )));
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    let id =
+        id.ok_or_else(|| SamlError::InvalidLogoutRequest("Missing LogoutRequest ID".to_string()))?;
+    let issuer =
+        issuer.ok_or_else(|| SamlError::InvalidLogoutRequest("Missing Issuer".to_string()))?;
+    let name_id =
+        name_id.ok_or_else(|| SamlError::InvalidLogoutRequest("Missing NameID".to_string()))?;
+
+    // Validate lengths
+    if id.len() > 256 {
+        return Err(SamlError::InvalidLogoutRequest(
+            "ID too long (max 256)".to_string(),
+        ));
+    }
+    if issuer.len() > 1024 {
+        return Err(SamlError::InvalidLogoutRequest(
+            "Issuer too long (max 1024)".to_string(),
+        ));
+    }
+    if name_id.len() > 4096 {
+        return Err(SamlError::InvalidLogoutRequest(
+            "NameID too long (max 4096)".to_string(),
+        ));
+    }
+    if let Some(ref si) = session_index {
+        if si.len() > 256 {
+            return Err(SamlError::InvalidLogoutRequest(
+                "SessionIndex too long (max 256)".to_string(),
+            ));
+        }
+    }
+
+    Ok(ParsedLogoutRequest {
+        id,
+        issuer,
+        name_id,
+        name_id_format,
+        session_index,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_logout_request() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    ID="_lr_test123" Version="2.0" IssueInstant="2026-02-21T10:00:00Z"
+    Destination="https://idp.example.com/saml/slo">
+    <saml:Issuer>https://sp.example.com</saml:Issuer>
+    <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">user@example.com</saml:NameID>
+    <samlp:SessionIndex>_session_abc123</samlp:SessionIndex>
+</samlp:LogoutRequest>"#;
+
+        let result = parse_logout_request_xml(xml).unwrap();
+        assert_eq!(result.id, "_lr_test123");
+        assert_eq!(result.issuer, "https://sp.example.com");
+        assert_eq!(result.name_id, "user@example.com");
+        assert_eq!(
+            result.name_id_format,
+            "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+        );
+        assert_eq!(result.session_index, Some("_session_abc123".to_string()));
+    }
+
+    #[test]
+    fn test_parse_logout_request_without_session_index() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    ID="_lr_test456" Version="2.0" IssueInstant="2026-02-21T10:00:00Z">
+    <saml:Issuer>https://sp.example.com</saml:Issuer>
+    <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">user@example.com</saml:NameID>
+</samlp:LogoutRequest>"#;
+
+        let result = parse_logout_request_xml(xml).unwrap();
+        assert_eq!(result.id, "_lr_test456");
+        assert!(result.session_index.is_none());
+    }
+
+    #[test]
+    fn test_parse_logout_request_missing_issuer() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    ID="_lr_test789" Version="2.0">
+    <saml:NameID>user@example.com</saml:NameID>
+</samlp:LogoutRequest>"#;
+
+        let result = parse_logout_request_xml(xml);
+        assert!(result.is_err());
+    }
+}

--- a/crates/xavyo-api-saml/src/services/mod.rs
+++ b/crates/xavyo-api-saml/src/services/mod.rs
@@ -2,14 +2,19 @@
 
 pub mod assertion_builder;
 pub mod group_service;
+pub mod logout_parser;
 pub mod metadata_generator;
 pub mod request_parser;
 pub mod signature_validator;
+pub mod slo_builder;
+pub mod slo_service;
 pub mod sp_service;
 
-pub use assertion_builder::AssertionBuilder;
+pub use assertion_builder::{AssertionBuilder, SamlResponseOutput};
 pub use group_service::GroupService;
 pub use metadata_generator::MetadataGenerator;
 pub use request_parser::RequestParser;
 pub use signature_validator::SignatureValidator;
+pub use slo_builder::SloBuilder;
+pub use slo_service::SloService;
 pub use sp_service::SpService;

--- a/crates/xavyo-api-saml/src/services/slo_builder.rs
+++ b/crates/xavyo-api-saml/src/services/slo_builder.rs
@@ -1,0 +1,202 @@
+//! SAML LogoutRequest and LogoutResponse builder
+
+use crate::error::{SamlError, SamlResult};
+use crate::saml::SigningCredentials;
+use base64::{engine::general_purpose::STANDARD, Engine};
+use uuid::Uuid;
+use xml_canonicalization::Canonicalizer;
+
+/// Builder for SAML LogoutRequest and LogoutResponse messages
+pub struct SloBuilder {
+    idp_entity_id: String,
+    credentials: SigningCredentials,
+}
+
+impl SloBuilder {
+    /// Create a new SLO builder
+    #[must_use]
+    pub fn new(idp_entity_id: String, credentials: SigningCredentials) -> Self {
+        Self {
+            idp_entity_id,
+            credentials,
+        }
+    }
+
+    /// Build a signed LogoutRequest XML (base64 encoded) to send to an SP.
+    pub fn build_logout_request(
+        &self,
+        destination: &str,
+        name_id: &str,
+        name_id_format: &str,
+        session_index: &str,
+    ) -> SamlResult<String> {
+        let request_id = format!("_lr_{}", Uuid::new_v4());
+        let issue_instant = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+        let mut xml = String::new();
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.push_str("<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\"\n");
+        xml.push_str("    xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\"\n");
+        xml.push_str("    ID=\"");
+        xml.push_str(&xml_escape(&request_id));
+        xml.push_str("\"\n    Version=\"2.0\"\n    IssueInstant=\"");
+        xml.push_str(&issue_instant);
+        xml.push_str("\"\n    Destination=\"");
+        xml.push_str(&xml_escape(destination));
+        xml.push_str("\">\n    <saml:Issuer>");
+        xml.push_str(&xml_escape(&self.idp_entity_id));
+        xml.push_str("</saml:Issuer>\n    <saml:NameID Format=\"");
+        xml.push_str(&xml_escape(name_id_format));
+        xml.push_str("\">");
+        xml.push_str(&xml_escape(name_id));
+        xml.push_str("</saml:NameID>\n    <samlp:SessionIndex>");
+        xml.push_str(&xml_escape(session_index));
+        xml.push_str("</samlp:SessionIndex>\n</samlp:LogoutRequest>");
+
+        let signed_xml = self.sign_xml(&xml, "LogoutRequest", &request_id)?;
+        Ok(STANDARD.encode(signed_xml.as_bytes()))
+    }
+
+    /// Build a signed LogoutResponse XML (base64 encoded) to send back to an SP.
+    pub fn build_logout_response(
+        &self,
+        in_response_to: &str,
+        destination: &str,
+        success: bool,
+    ) -> SamlResult<String> {
+        let response_id = format!("_lresp_{}", Uuid::new_v4());
+        let issue_instant = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+        let status_value = if success {
+            "urn:oasis:names:tc:SAML:2.0:status:Success"
+        } else {
+            "urn:oasis:names:tc:SAML:2.0:status:Responder"
+        };
+
+        let mut xml = String::new();
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.push_str(
+            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\"\n",
+        );
+        xml.push_str("    xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\"\n");
+        xml.push_str("    ID=\"");
+        xml.push_str(&xml_escape(&response_id));
+        xml.push_str("\"\n    Version=\"2.0\"\n    IssueInstant=\"");
+        xml.push_str(&issue_instant);
+        xml.push_str("\"\n    Destination=\"");
+        xml.push_str(&xml_escape(destination));
+        xml.push_str("\"\n    InResponseTo=\"");
+        xml.push_str(&xml_escape(in_response_to));
+        xml.push_str("\">\n    <saml:Issuer>");
+        xml.push_str(&xml_escape(&self.idp_entity_id));
+        xml.push_str("</saml:Issuer>\n    <samlp:Status>\n        <samlp:StatusCode Value=\"");
+        xml.push_str(status_value);
+        xml.push_str("\"/>\n    </samlp:Status>\n</samlp:LogoutResponse>");
+
+        // Sign the LogoutResponse for integrity
+        let signed_xml = self.sign_xml(&xml, "LogoutResponse", &response_id)?;
+        Ok(STANDARD.encode(signed_xml.as_bytes()))
+    }
+
+    /// Sign a SAML XML message by injecting an enveloped signature after the Issuer element.
+    fn sign_xml(&self, xml: &str, element_name: &str, element_id: &str) -> SamlResult<String> {
+        let issuer_end = xml.find("</saml:Issuer>").ok_or_else(|| {
+            SamlError::InternalError(format!("Cannot find Issuer in {element_name}"))
+        })?;
+        let after_issuer = issuer_end + "</saml:Issuer>".len();
+
+        // Find the root element for digest
+        let element_tag = format!("<samlp:{element_name}");
+        let request_start = xml.find(&element_tag).ok_or_else(|| {
+            SamlError::InternalError(format!("Cannot find {element_name} element"))
+        })?;
+        let request_content = &xml[request_start..xml.len()];
+
+        let canonicalized = canonicalize_xml(request_content)?;
+
+        let digest = openssl::hash::hash(
+            openssl::hash::MessageDigest::sha256(),
+            canonicalized.as_bytes(),
+        )
+        .map_err(|e| SamlError::InternalError(format!("Digest failed: {e}")))?;
+        let digest_b64 = STANDARD.encode(digest);
+
+        let mut signed_info = String::new();
+        signed_info.push_str("<ds:SignedInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">");
+        signed_info.push_str(
+            "<ds:CanonicalizationMethod Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/>",
+        );
+        signed_info.push_str(
+            "<ds:SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\"/>",
+        );
+        signed_info.push_str("<ds:Reference URI=\"#");
+        signed_info.push_str(element_id);
+        signed_info.push_str("\">");
+        signed_info.push_str("<ds:Transforms>");
+        signed_info.push_str(
+            "<ds:Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/>",
+        );
+        signed_info
+            .push_str("<ds:Transform Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/>");
+        signed_info.push_str("</ds:Transforms>");
+        signed_info
+            .push_str("<ds:DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\"/>");
+        signed_info.push_str("<ds:DigestValue>");
+        signed_info.push_str(&digest_b64);
+        signed_info.push_str("</ds:DigestValue>");
+        signed_info.push_str("</ds:Reference>");
+        signed_info.push_str("</ds:SignedInfo>");
+
+        let canonicalized_signed_info = canonicalize_xml(&signed_info)?;
+        let signature = self
+            .credentials
+            .sign_sha256(canonicalized_signed_info.as_bytes())?;
+        let signature_b64 = STANDARD.encode(&signature);
+
+        let certificate_base64 = self.credentials.certificate_base64_der()?;
+
+        let mut sig_xml = String::new();
+        sig_xml.push_str(
+            "\n    <ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">\n        ",
+        );
+        sig_xml.push_str(&signed_info);
+        sig_xml.push_str("\n        <ds:SignatureValue>");
+        sig_xml.push_str(&signature_b64);
+        sig_xml.push_str("</ds:SignatureValue>\n        <ds:KeyInfo>\n            <ds:X509Data>\n                <ds:X509Certificate>");
+        sig_xml.push_str(&certificate_base64);
+        sig_xml.push_str("</ds:X509Certificate>\n            </ds:X509Data>\n        </ds:KeyInfo>\n    </ds:Signature>");
+
+        let mut result = String::with_capacity(xml.len() + sig_xml.len());
+        result.push_str(&xml[..after_issuer]);
+        result.push_str(&sig_xml);
+        result.push_str(&xml[after_issuer..]);
+
+        Ok(result)
+    }
+}
+
+fn canonicalize_xml(xml: &str) -> SamlResult<String> {
+    let mut output = Vec::new();
+    Canonicalizer::read_from_str(xml)
+        .write_to_writer(&mut output)
+        .canonicalize(false)
+        .map_err(|e| SamlError::InternalError(format!("XML canonicalization failed: {e}")))?;
+
+    String::from_utf8(output)
+        .map_err(|e| SamlError::InternalError(format!("Canonicalized XML is not valid UTF-8: {e}")))
+}
+
+fn xml_escape(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => result.push_str("&amp;"),
+            '<' => result.push_str("&lt;"),
+            '>' => result.push_str("&gt;"),
+            '"' => result.push_str("&quot;"),
+            '\'' => result.push_str("&apos;"),
+            _ => result.push(c),
+        }
+    }
+    result
+}

--- a/crates/xavyo-api-saml/src/services/slo_service.rs
+++ b/crates/xavyo-api-saml/src/services/slo_service.rs
@@ -1,0 +1,474 @@
+//! SAML Single Logout orchestration service
+
+use crate::error::{SamlError, SamlResult};
+use crate::handlers::metadata::SamlState;
+use crate::services::logout_parser::ParsedLogoutRequest;
+use crate::services::slo_builder::SloBuilder;
+use crate::services::SpService;
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+use xavyo_db::models::SamlServiceProvider;
+
+/// Result of an IdP-initiated SLO dispatch
+#[derive(Debug, Clone, Serialize)]
+pub struct SloResult {
+    /// Total number of SPs with active sessions
+    pub total: usize,
+    /// Number of SPs successfully notified
+    pub succeeded: usize,
+    /// Number of SPs where notification failed
+    pub failed: usize,
+    /// Number of SPs with no SLO URL configured
+    pub no_slo_url: usize,
+}
+
+/// Result of processing an SP-initiated LogoutRequest
+pub struct SpLogoutResult {
+    /// Base64-encoded LogoutResponse XML
+    pub response_xml: String,
+    /// The user ID whose sessions were revoked
+    pub user_id: Uuid,
+}
+
+/// Service for SAML Single Logout orchestration
+pub struct SloService {
+    pool: PgPool,
+    http_client: reqwest::Client,
+}
+
+impl SloService {
+    /// Create a new SLO service
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        let http_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            // Explicitly enforce TLS verification (default, but being explicit)
+            .danger_accept_invalid_certs(false)
+            .build()
+            .unwrap_or_default();
+
+        Self { pool, http_client }
+    }
+
+    /// IdP-initiated SLO: send LogoutRequests to all SPs with active sessions.
+    ///
+    /// Uses back-channel POST with a 10s timeout per SP. Failures are logged
+    /// but non-blocking — we revoke sessions regardless of SP response.
+    pub async fn dispatch_logout_to_sps(
+        &self,
+        state: &SamlState,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> SamlResult<SloResult> {
+        // Get all active SP sessions for the user
+        let sessions = state
+            .sp_session_store
+            .get_active_for_user(tenant_id, user_id)
+            .await
+            .map_err(|e| SamlError::SpSessionError(format!("Failed to get SP sessions: {e}")))?;
+
+        if sessions.is_empty() {
+            // Revoke sessions anyway (in case there are stale ones)
+            let _ = state
+                .sp_session_store
+                .revoke_all_for_user(tenant_id, user_id)
+                .await;
+
+            return Ok(SloResult {
+                total: 0,
+                succeeded: 0,
+                failed: 0,
+                no_slo_url: 0,
+            });
+        }
+
+        let sp_service = SpService::new(self.pool.clone());
+
+        // Get IdP signing credentials
+        let cert = sp_service.get_active_certificate(tenant_id).await?;
+        let key_pem = sp_service
+            .decrypt_private_key(&cert.private_key_encrypted, state.encryption_key.as_ref())?;
+        let credentials = crate::saml::SigningCredentials::from_pem(&cert.certificate, &key_pem)?;
+        let idp_entity_id = format!("{}/saml/metadata?tenant={}", state.base_url, tenant_id);
+        let builder = SloBuilder::new(idp_entity_id, credentials);
+
+        let total = sessions.len();
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+        let mut no_slo_url = 0usize;
+
+        // Group sessions by SP to avoid sending duplicate requests
+        let mut seen_sps = std::collections::HashSet::new();
+
+        for session in &sessions {
+            if !seen_sps.insert(session.sp_id) {
+                continue; // Already sent to this SP
+            }
+
+            let sp = match sp_service.get_sp(tenant_id, session.sp_id).await {
+                Ok(sp) => sp,
+                Err(e) => {
+                    tracing::warn!(
+                        sp_id = %session.sp_id,
+                        error = %e,
+                        "Failed to look up SP for SLO dispatch"
+                    );
+                    failed += 1;
+                    continue;
+                }
+            };
+
+            let slo_url = match &sp.slo_url {
+                Some(url) if !url.is_empty() => url.clone(),
+                _ => {
+                    tracing::debug!(
+                        sp_id = %sp.id,
+                        sp_entity_id = %sp.entity_id,
+                        "SP has no SLO URL configured, skipping"
+                    );
+                    no_slo_url += 1;
+                    continue;
+                }
+            };
+
+            // Validate SLO URL scheme (HTTPS required for non-localhost)
+            if !is_safe_slo_url(&slo_url) {
+                tracing::warn!(
+                    sp_id = %sp.id,
+                    slo_url = %slo_url,
+                    "SLO URL is not safe (must be HTTPS or localhost), skipping"
+                );
+                failed += 1;
+                continue;
+            }
+
+            // Build LogoutRequest for this SP
+            let encoded_request = match builder.build_logout_request(
+                &slo_url,
+                &session.name_id,
+                &session.name_id_format,
+                &session.session_index,
+            ) {
+                Ok(req) => req,
+                Err(e) => {
+                    tracing::error!(
+                        sp_id = %sp.id,
+                        error = %e,
+                        "Failed to build LogoutRequest"
+                    );
+                    failed += 1;
+                    continue;
+                }
+            };
+
+            // Send back-channel POST
+            match self
+                .http_client
+                .post(&slo_url)
+                .form(&[("SAMLRequest", &encoded_request)])
+                .send()
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    tracing::info!(
+                        sp_id = %sp.id,
+                        sp_entity_id = %sp.entity_id,
+                        slo_url = %slo_url,
+                        "LogoutRequest sent successfully"
+                    );
+                    succeeded += 1;
+                }
+                Ok(resp) => {
+                    tracing::warn!(
+                        sp_id = %sp.id,
+                        sp_entity_id = %sp.entity_id,
+                        status = %resp.status(),
+                        "LogoutRequest received non-success response"
+                    );
+                    failed += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        sp_id = %sp.id,
+                        sp_entity_id = %sp.entity_id,
+                        error = %e,
+                        "Failed to send LogoutRequest"
+                    );
+                    failed += 1;
+                }
+            }
+        }
+
+        // Revoke all SP sessions for this user regardless of SP responses
+        let revoked = state
+            .sp_session_store
+            .revoke_all_for_user(tenant_id, user_id)
+            .await
+            .map_err(|e| SamlError::SpSessionError(format!("Failed to revoke sessions: {e}")))?;
+
+        tracing::info!(
+            tenant_id = %tenant_id,
+            user_id = %user_id,
+            total = total,
+            succeeded = succeeded,
+            failed = failed,
+            no_slo_url = no_slo_url,
+            revoked = revoked,
+            "SLO dispatch completed"
+        );
+
+        Ok(SloResult {
+            total,
+            succeeded,
+            failed,
+            no_slo_url,
+        })
+    }
+
+    /// SP-initiated SLO: process incoming LogoutRequest from an SP.
+    ///
+    /// The SP has already been looked up and signature validated by the handler.
+    /// This method identifies the user from the NameID, revokes sessions
+    /// (honoring SessionIndex if provided), and returns a signed LogoutResponse.
+    pub async fn process_sp_logout_for_sp(
+        &self,
+        state: &SamlState,
+        tenant_id: Uuid,
+        sp: &SamlServiceProvider,
+        request: &ParsedLogoutRequest,
+    ) -> SamlResult<SpLogoutResult> {
+        let sp_service = SpService::new(self.pool.clone());
+
+        // Find the user by NameID — look through active SP sessions
+        let user_id = self
+            .find_user_by_name_id(tenant_id, sp.id, &request.name_id)
+            .await?;
+
+        // Honor SessionIndex: if provided, only revoke that specific session.
+        // If not provided, revoke all sessions for the user (per SAML 2.0 Core §3.7.1).
+        if let Some(ref session_index) = request.session_index {
+            let revoked = self
+                .revoke_session_by_index(tenant_id, user_id, session_index)
+                .await?;
+            tracing::info!(
+                tenant_id = %tenant_id,
+                user_id = %user_id,
+                session_index = %session_index,
+                revoked = revoked,
+                "SP-initiated SLO: specific session revoked"
+            );
+        } else {
+            let revoked = state
+                .sp_session_store
+                .revoke_all_for_user(tenant_id, user_id)
+                .await
+                .map_err(|e| {
+                    SamlError::SpSessionError(format!("Failed to revoke sessions: {e}"))
+                })?;
+            tracing::info!(
+                tenant_id = %tenant_id,
+                user_id = %user_id,
+                sp_entity_id = %sp.entity_id,
+                revoked = revoked,
+                "SP-initiated SLO: all sessions revoked"
+            );
+        }
+
+        // Build signed LogoutResponse — use SP's SLO URL as Destination.
+        // If no SLO URL is configured, use the first ACS URL as fallback.
+        let slo_url = sp
+            .slo_url
+            .as_deref()
+            .or_else(|| sp.acs_urls.first().map(String::as_str))
+            .ok_or_else(|| {
+                SamlError::InternalError(
+                    "SP has no SLO URL or ACS URL configured for LogoutResponse Destination"
+                        .to_string(),
+                )
+            })?;
+
+        let cert = sp_service.get_active_certificate(tenant_id).await?;
+        let key_pem = sp_service
+            .decrypt_private_key(&cert.private_key_encrypted, state.encryption_key.as_ref())?;
+        let credentials = crate::saml::SigningCredentials::from_pem(&cert.certificate, &key_pem)?;
+        let idp_entity_id = format!("{}/saml/metadata?tenant={}", state.base_url, tenant_id);
+        let builder = SloBuilder::new(idp_entity_id, credentials);
+
+        let response_xml = builder.build_logout_response(&request.id, slo_url, true)?;
+
+        Ok(SpLogoutResult {
+            response_xml,
+            user_id,
+        })
+    }
+
+    /// Revoke a specific SP session by session_index.
+    async fn revoke_session_by_index(
+        &self,
+        tenant_id: Uuid,
+        user_id: Uuid,
+        session_index: &str,
+    ) -> SamlResult<u64> {
+        let mut conn =
+            self.pool.acquire().await.map_err(|e| {
+                SamlError::InternalError(format!("Failed to acquire connection: {e}"))
+            })?;
+
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(tenant_id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| SamlError::InternalError(format!("Failed to set tenant context: {e}")))?;
+
+        let result = sqlx::query(
+            r"
+            UPDATE saml_sp_sessions
+            SET revoked_at = NOW()
+            WHERE tenant_id = $1 AND user_id = $2 AND session_index = $3 AND revoked_at IS NULL
+            ",
+        )
+        .bind(tenant_id)
+        .bind(user_id)
+        .bind(session_index)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| SamlError::InternalError(format!("Failed to revoke session by index: {e}")))?;
+
+        Ok(result.rows_affected())
+    }
+
+    /// Find a user by NameID from active SP sessions
+    async fn find_user_by_name_id(
+        &self,
+        tenant_id: Uuid,
+        sp_id: Uuid,
+        name_id: &str,
+    ) -> SamlResult<Uuid> {
+        // Query the saml_sp_sessions table for matching name_id
+        let mut conn =
+            self.pool.acquire().await.map_err(|e| {
+                SamlError::InternalError(format!("Failed to acquire connection: {e}"))
+            })?;
+
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(tenant_id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| SamlError::InternalError(format!("Failed to set tenant context: {e}")))?;
+
+        let user_id: Option<Uuid> = sqlx::query_scalar(
+            r"
+            SELECT user_id FROM saml_sp_sessions
+            WHERE tenant_id = $1 AND sp_id = $2 AND name_id = $3
+              AND revoked_at IS NULL AND expires_at > NOW()
+            ORDER BY created_at DESC
+            LIMIT 1
+            ",
+        )
+        .bind(tenant_id)
+        .bind(sp_id)
+        .bind(name_id)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(|e| SamlError::InternalError(format!("Failed to find user by NameID: {e}")))?;
+
+        // Fallback: look up user by email if NameID is email format
+        if let Some(uid) = user_id {
+            return Ok(uid);
+        }
+
+        // Try looking up by email in the users table (same connection, RLS already set)
+        let user_id: Option<Uuid> = sqlx::query_scalar(
+            r"SELECT id FROM users WHERE tenant_id = $1 AND LOWER(email) = LOWER($2)",
+        )
+        .bind(tenant_id)
+        .bind(name_id)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(|e| SamlError::InternalError(format!("Failed to look up user by email: {e}")))?;
+
+        // SECURITY: Do not include the NameID in error messages to prevent user enumeration
+        user_id.ok_or_else(|| {
+            tracing::warn!(
+                tenant_id = %tenant_id,
+                sp_id = %sp_id,
+                "No active session or user found for provided NameID"
+            );
+            SamlError::InvalidLogoutRequest(
+                "No active session found for the provided identity".to_string(),
+            )
+        })
+    }
+}
+
+/// Validate that an SLO URL is safe (HTTPS, no internal IPs).
+fn is_safe_slo_url(url: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+
+    let scheme = parsed.scheme();
+    let host = parsed.host_str().unwrap_or("");
+
+    // Allow HTTP only for localhost (development)
+    if scheme == "http" {
+        return host == "localhost" || host == "127.0.0.1" || host == "[::1]";
+    }
+
+    // Must be HTTPS
+    if scheme != "https" {
+        return false;
+    }
+
+    // Block internal/private IP ranges to prevent SSRF
+    match parsed.host() {
+        Some(url::Host::Ipv4(ip)) => {
+            if ip.is_loopback() || ip.is_private() || ip.is_link_local() {
+                return false;
+            }
+            // Block 169.254.x.x (link-local / cloud metadata)
+            let octets = ip.octets();
+            if octets[0] == 169 && octets[1] == 254 {
+                return false;
+            }
+        }
+        Some(url::Host::Ipv6(ip)) => {
+            // Block IPv6 loopback (::1), link-local (fe80::/10), and
+            // IPv4-mapped private addresses (::ffff:10.x.x.x, etc.)
+            if ip.is_loopback() {
+                return false;
+            }
+            let segments = ip.segments();
+            // fe80::/10 — link-local
+            if segments[0] & 0xffc0 == 0xfe80 {
+                return false;
+            }
+            // fc00::/7 — unique local addresses (private)
+            if segments[0] & 0xfe00 == 0xfc00 {
+                return false;
+            }
+            // ::ffff:0:0/96 — IPv4-mapped, check the embedded IPv4
+            if segments[0] == 0
+                && segments[1] == 0
+                && segments[2] == 0
+                && segments[3] == 0
+                && segments[4] == 0
+                && segments[5] == 0xffff
+            {
+                let ip4 = std::net::Ipv4Addr::new(
+                    (segments[6] >> 8) as u8,
+                    segments[6] as u8,
+                    (segments[7] >> 8) as u8,
+                    segments[7] as u8,
+                );
+                if ip4.is_loopback() || ip4.is_private() || ip4.is_link_local() {
+                    return false;
+                }
+            }
+        }
+        _ => {}
+    }
+
+    true
+}

--- a/crates/xavyo-api-saml/src/session/mod.rs
+++ b/crates/xavyo-api-saml/src/session/mod.rs
@@ -33,9 +33,13 @@
 //! // Use session.request_id as InResponseTo in SAMLResponse
 //! ```
 
+pub mod sp_session;
 mod store;
 mod types;
 
+pub use sp_session::{
+    InMemorySpSessionStore, PostgresSpSessionStore, SpSession, SpSessionError, SpSessionStore,
+};
 pub use store::{InMemorySessionStore, PostgresSessionStore, SessionStore};
 pub use types::{
     AuthnRequestSession, SessionError, CLOCK_SKEW_GRACE_SECONDS, DEFAULT_SESSION_TTL_SECONDS,

--- a/crates/xavyo-api-saml/src/session/sp_session.rs
+++ b/crates/xavyo-api-saml/src/session/sp_session.rs
@@ -1,0 +1,398 @@
+//! SAML SP session tracking for Single Logout
+//!
+//! Tracks which Service Providers have active sessions for each user,
+//! enabling the IdP to send LogoutRequests to all relevant SPs during SLO.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+/// Represents an active session between a user and a Service Provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpSession {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
+    pub sp_id: Uuid,
+    pub session_index: String,
+    pub name_id: String,
+    pub name_id_format: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+/// SP session store error
+#[derive(Debug, thiserror::Error)]
+pub enum SpSessionError {
+    #[error("Storage error: {0}")]
+    StorageError(String),
+}
+
+/// Trait for SP session storage
+#[async_trait]
+pub trait SpSessionStore: Send + Sync {
+    /// Record a new SP session after assertion issuance
+    async fn record(&self, session: SpSession) -> Result<(), SpSessionError>;
+
+    /// Get all active (non-revoked, non-expired) sessions for a user
+    async fn get_active_for_user(
+        &self,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<SpSession>, SpSessionError>;
+
+    /// Revoke all sessions for a user (returns count of revoked sessions)
+    async fn revoke_all_for_user(
+        &self,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<u64, SpSessionError>;
+
+    /// Clean up expired/revoked sessions for a specific tenant (returns count of deleted sessions)
+    async fn cleanup_expired(&self, tenant_id: Uuid) -> Result<u64, SpSessionError>;
+}
+
+/// PostgreSQL-backed SP session store for production
+pub struct PostgresSpSessionStore {
+    pool: PgPool,
+}
+
+impl PostgresSpSessionStore {
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl SpSessionStore for PostgresSpSessionStore {
+    async fn record(&self, session: SpSession) -> Result<(), SpSessionError> {
+        let mut conn = self.pool.acquire().await.map_err(|e| {
+            SpSessionError::StorageError(format!("Failed to acquire connection: {e}"))
+        })?;
+
+        // Set tenant context for RLS
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(session.tenant_id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| {
+                SpSessionError::StorageError(format!("Failed to set tenant context: {e}"))
+            })?;
+
+        sqlx::query(
+            r"
+            INSERT INTO saml_sp_sessions (
+                id, tenant_id, user_id, sp_id, session_index,
+                name_id, name_id_format, created_at, expires_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (tenant_id, user_id, sp_id, session_index) DO UPDATE
+            SET name_id = EXCLUDED.name_id,
+                name_id_format = EXCLUDED.name_id_format,
+                expires_at = EXCLUDED.expires_at,
+                revoked_at = NULL
+            ",
+        )
+        .bind(session.id)
+        .bind(session.tenant_id)
+        .bind(session.user_id)
+        .bind(session.sp_id)
+        .bind(&session.session_index)
+        .bind(&session.name_id)
+        .bind(&session.name_id_format)
+        .bind(session.created_at)
+        .bind(session.expires_at)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| SpSessionError::StorageError(format!("Failed to record SP session: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn get_active_for_user(
+        &self,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<SpSession>, SpSessionError> {
+        let mut conn = self.pool.acquire().await.map_err(|e| {
+            SpSessionError::StorageError(format!("Failed to acquire connection: {e}"))
+        })?;
+
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(tenant_id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| {
+                SpSessionError::StorageError(format!("Failed to set tenant context: {e}"))
+            })?;
+
+        let rows = sqlx::query_as::<_, SpSessionRow>(
+            r"
+            SELECT id, tenant_id, user_id, sp_id, session_index,
+                   name_id, name_id_format, created_at, expires_at, revoked_at
+            FROM saml_sp_sessions
+            WHERE tenant_id = $1 AND user_id = $2
+              AND revoked_at IS NULL AND expires_at > NOW()
+            ORDER BY created_at DESC
+            ",
+        )
+        .bind(tenant_id)
+        .bind(user_id)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| SpSessionError::StorageError(format!("Failed to get active sessions: {e}")))?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn revoke_all_for_user(
+        &self,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<u64, SpSessionError> {
+        let mut conn = self.pool.acquire().await.map_err(|e| {
+            SpSessionError::StorageError(format!("Failed to acquire connection: {e}"))
+        })?;
+
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(tenant_id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| {
+                SpSessionError::StorageError(format!("Failed to set tenant context: {e}"))
+            })?;
+
+        let result = sqlx::query(
+            r"
+            UPDATE saml_sp_sessions
+            SET revoked_at = NOW()
+            WHERE tenant_id = $1 AND user_id = $2 AND revoked_at IS NULL
+            ",
+        )
+        .bind(tenant_id)
+        .bind(user_id)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| SpSessionError::StorageError(format!("Failed to revoke sessions: {e}")))?;
+
+        Ok(result.rows_affected())
+    }
+
+    async fn cleanup_expired(&self, tenant_id: Uuid) -> Result<u64, SpSessionError> {
+        let mut conn = self.pool.acquire().await.map_err(|e| {
+            SpSessionError::StorageError(format!("Failed to acquire connection: {e}"))
+        })?;
+
+        // Set tenant context for RLS
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(tenant_id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| {
+                SpSessionError::StorageError(format!("Failed to set tenant context: {e}"))
+            })?;
+
+        let result = sqlx::query(
+            r"DELETE FROM saml_sp_sessions WHERE tenant_id = $1 AND (expires_at < NOW() OR revoked_at IS NOT NULL)",
+        )
+        .bind(tenant_id)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| {
+            SpSessionError::StorageError(format!("Failed to cleanup expired sessions: {e}"))
+        })?;
+
+        Ok(result.rows_affected())
+    }
+}
+
+/// SQLx row type for SP sessions
+#[derive(sqlx::FromRow)]
+struct SpSessionRow {
+    id: Uuid,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    sp_id: Uuid,
+    session_index: String,
+    name_id: String,
+    name_id_format: String,
+    created_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+    revoked_at: Option<DateTime<Utc>>,
+}
+
+impl From<SpSessionRow> for SpSession {
+    fn from(row: SpSessionRow) -> Self {
+        Self {
+            id: row.id,
+            tenant_id: row.tenant_id,
+            user_id: row.user_id,
+            sp_id: row.sp_id,
+            session_index: row.session_index,
+            name_id: row.name_id,
+            name_id_format: row.name_id_format,
+            created_at: row.created_at,
+            expires_at: row.expires_at,
+            revoked_at: row.revoked_at,
+        }
+    }
+}
+
+/// In-memory SP session store for testing
+#[derive(Debug, Default)]
+pub struct InMemorySpSessionStore {
+    sessions: Arc<RwLock<HashMap<Uuid, SpSession>>>,
+}
+
+impl InMemorySpSessionStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl SpSessionStore for InMemorySpSessionStore {
+    async fn record(&self, session: SpSession) -> Result<(), SpSessionError> {
+        let mut sessions = self.sessions.write().await;
+        sessions.insert(session.id, session);
+        Ok(())
+    }
+
+    async fn get_active_for_user(
+        &self,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<SpSession>, SpSessionError> {
+        let sessions = self.sessions.read().await;
+        let now = Utc::now();
+        Ok(sessions
+            .values()
+            .filter(|s| {
+                s.tenant_id == tenant_id
+                    && s.user_id == user_id
+                    && s.revoked_at.is_none()
+                    && s.expires_at > now
+            })
+            .cloned()
+            .collect())
+    }
+
+    async fn revoke_all_for_user(
+        &self,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<u64, SpSessionError> {
+        let mut sessions = self.sessions.write().await;
+        let now = Utc::now();
+        let mut count = 0u64;
+        for session in sessions.values_mut() {
+            if session.tenant_id == tenant_id
+                && session.user_id == user_id
+                && session.revoked_at.is_none()
+            {
+                session.revoked_at = Some(now);
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    async fn cleanup_expired(&self, tenant_id: Uuid) -> Result<u64, SpSessionError> {
+        let mut sessions = self.sessions.write().await;
+        let now = Utc::now();
+        let before = sessions.len();
+        sessions.retain(|_, s| {
+            // Only clean up sessions for the specified tenant
+            !(s.tenant_id == tenant_id && (s.expires_at <= now || s.revoked_at.is_some()))
+        });
+        Ok((before - sessions.len()) as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_session(tenant_id: Uuid, user_id: Uuid, sp_id: Uuid) -> SpSession {
+        SpSession {
+            id: Uuid::new_v4(),
+            tenant_id,
+            user_id,
+            sp_id,
+            session_index: format!("_session_{}", Uuid::new_v4()),
+            name_id: "user@example.com".to_string(),
+            name_id_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress".to_string(),
+            created_at: Utc::now(),
+            expires_at: Utc::now() + chrono::Duration::seconds(300),
+            revoked_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_record_and_get() {
+        let store = InMemorySpSessionStore::new();
+        let tid = Uuid::new_v4();
+        let uid = Uuid::new_v4();
+        let sp_id = Uuid::new_v4();
+
+        let session = make_session(tid, uid, sp_id);
+        store.record(session).await.unwrap();
+
+        let active = store.get_active_for_user(tid, uid).await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].sp_id, sp_id);
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_revoke_all() {
+        let store = InMemorySpSessionStore::new();
+        let tid = Uuid::new_v4();
+        let uid = Uuid::new_v4();
+
+        store
+            .record(make_session(tid, uid, Uuid::new_v4()))
+            .await
+            .unwrap();
+        store
+            .record(make_session(tid, uid, Uuid::new_v4()))
+            .await
+            .unwrap();
+
+        let revoked = store.revoke_all_for_user(tid, uid).await.unwrap();
+        assert_eq!(revoked, 2);
+
+        let active = store.get_active_for_user(tid, uid).await.unwrap();
+        assert_eq!(active.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_tenant_isolation() {
+        let store = InMemorySpSessionStore::new();
+        let tid1 = Uuid::new_v4();
+        let tid2 = Uuid::new_v4();
+        let uid = Uuid::new_v4();
+
+        store
+            .record(make_session(tid1, uid, Uuid::new_v4()))
+            .await
+            .unwrap();
+        store
+            .record(make_session(tid2, uid, Uuid::new_v4()))
+            .await
+            .unwrap();
+
+        let active_t1 = store.get_active_for_user(tid1, uid).await.unwrap();
+        assert_eq!(active_t1.len(), 1);
+
+        let active_t2 = store.get_active_for_user(tid2, uid).await.unwrap();
+        assert_eq!(active_t2.len(), 1);
+    }
+}

--- a/crates/xavyo-db/migrations/0197_saml_slo.sql
+++ b/crates/xavyo-db/migrations/0197_saml_slo.sql
@@ -1,0 +1,31 @@
+-- Add SLO URL to service providers
+ALTER TABLE saml_service_providers
+  ADD COLUMN IF NOT EXISTS slo_url TEXT,
+  ADD COLUMN IF NOT EXISTS slo_binding TEXT NOT NULL DEFAULT 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST';
+
+-- Track which SPs have active sessions per user (for SLO dispatch)
+CREATE TABLE IF NOT EXISTS saml_sp_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  sp_id UUID NOT NULL REFERENCES saml_service_providers(id) ON DELETE CASCADE,
+  session_index TEXT NOT NULL,
+  name_id TEXT NOT NULL,
+  name_id_format TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  CONSTRAINT uq_saml_sp_session UNIQUE (tenant_id, user_id, sp_id, session_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saml_sp_sessions_user ON saml_sp_sessions(tenant_id, user_id) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_saml_sp_sessions_expires ON saml_sp_sessions(expires_at) WHERE revoked_at IS NULL;
+
+-- RLS
+ALTER TABLE saml_sp_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE saml_sp_sessions FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_saml_sp_sessions ON saml_sp_sessions;
+CREATE POLICY tenant_isolation_saml_sp_sessions ON saml_sp_sessions
+  FOR ALL
+  USING (tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid)
+  WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant', true), '')::uuid);

--- a/crates/xavyo-db/migrations/0198_oidc_end_session.sql
+++ b/crates/xavyo-db/migrations/0198_oidc_end_session.sql
@@ -1,0 +1,3 @@
+-- Add post-logout redirect URIs to OAuth clients for OIDC RP-Initiated Logout
+ALTER TABLE oauth_clients
+  ADD COLUMN IF NOT EXISTS post_logout_redirect_uris TEXT[] NOT NULL DEFAULT '{}';

--- a/crates/xavyo-db/src/bootstrap/system_tenant.rs
+++ b/crates/xavyo-db/src/bootstrap/system_tenant.rs
@@ -230,7 +230,7 @@ pub async fn create_cli_oauth_client(pool: &PgPool) -> Result<bool, BootstrapErr
             NOW(),
             NOW()
         )
-        ON CONFLICT (client_id) DO NOTHING
+        ON CONFLICT (tenant_id, client_id) DO NOTHING
         ",
     )
     .bind(CLI_OAUTH_CLIENT_UUID)

--- a/crates/xavyo-db/src/models/oauth_client.rs
+++ b/crates/xavyo-db/src/models/oauth_client.rs
@@ -85,6 +85,9 @@ pub struct OAuth2Client {
 
     /// When the client was last updated.
     pub updated_at: DateTime<Utc>,
+
+    /// Allowed post-logout redirect URIs (OIDC RP-Initiated Logout).
+    pub post_logout_redirect_uris: Vec<String>,
 }
 
 impl OAuth2Client {

--- a/crates/xavyo-db/src/models/saml_service_provider.rs
+++ b/crates/xavyo-db/src/models/saml_service_provider.rs
@@ -42,6 +42,12 @@ pub struct SamlServiceProvider {
     /// Base DN for DN format
     #[serde(default)]
     pub group_dn_base: Option<String>,
+    /// Single Logout URL for this SP
+    #[serde(default)]
+    pub slo_url: Option<String>,
+    /// Single Logout binding (default: HTTP-POST)
+    #[serde(default = "default_slo_binding")]
+    pub slo_binding: String,
 }
 
 /// Request to create a new Service Provider
@@ -65,6 +71,10 @@ pub struct CreateServiceProviderRequest {
     pub assertion_validity_seconds: i32,
     #[serde(default)]
     pub metadata_url: Option<String>,
+    #[serde(default)]
+    pub slo_url: Option<String>,
+    #[serde(default = "default_slo_binding")]
+    pub slo_binding: String,
 }
 
 /// Request to update a Service Provider
@@ -81,6 +91,8 @@ pub struct UpdateServiceProviderRequest {
     pub assertion_validity_seconds: Option<i32>,
     pub enabled: Option<bool>,
     pub metadata_url: Option<String>,
+    pub slo_url: Option<String>,
+    pub slo_binding: Option<String>,
 }
 
 /// Attribute mapping configuration
@@ -119,6 +131,10 @@ fn default_true() -> bool {
 
 fn default_assertion_validity() -> i32 {
     300
+}
+
+fn default_slo_binding() -> String {
+    "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST".to_string()
 }
 
 fn default_name_id_source() -> String {


### PR DESCRIPTION
## Summary
- **SAML Single Logout**: SP-initiated (`POST /saml/slo`) and IdP-initiated (`POST /saml/slo/initiate`) with per-SP session tracking, LogoutRequest/LogoutResponse XML building and parsing
- **OIDC RP-Initiated Logout**: `GET/POST /oauth/logout` with `id_token_hint`, `post_logout_redirect_uri`, `client_id` support per RFC spec
- **OAuth client**: add `post_logout_redirect_uris` field to model and API
- **SAML SP**: add `slo_url` and `slo_binding` fields to model and API
- **OpenAPI/Swagger**: add 4 new tags (GDPR, Role Inducements, SAML SLO, OIDC), 10 new endpoint paths, 7 new schema types — now 141 tags, 736 paths total
- **README**: comprehensive rewrite reflecting full capability inventory (32 crates, 198 migrations, 665K LoC, 7400+ tests)
- **DB migrations**: 0197 (SAML SLO session tables), 0198 (OIDC end session `post_logout_redirect_uris` column)
- **Bootstrap fix**: `ON CONFLICT (tenant_id, client_id)` instead of `ON CONFLICT (client_id)`

## Test plan
- [x] `cargo check -p idp-api` — clean compile
- [x] Swagger UI verified via Chrome DevTools — all 141 tags and 736 paths render
- [x] Backend serves updated OpenAPI JSON at `/api-doc/openapi.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)