### PR TITLE
feat(oauth): DPoP-Nonce challenge flow (RFC 9449 §8–9)

### DIFF
--- a/apps/idp-api/src/config.rs
+++ b/apps/idp-api/src/config.rs
@@ -580,6 +580,11 @@ pub struct Config {
     /// SECURITY: This MUST be generated independently of the JWT signing key.
     pub csrf_secret: [u8; 32],
 
+    /// Whether DPoP-bound requests must carry a server-issued nonce (RFC 9449
+    /// §8–9). Env `DPOP_NONCE_REQUIRED`, default `true`. FAPI clients always
+    /// require a nonce regardless of this flag.
+    pub dpop_nonce_required: bool,
+
     /// Kafka configuration (optional - only if `KAFKA_BOOTSTRAP_SERVERS` is set)
     pub kafka: Option<KafkaConfig>,
 
@@ -772,6 +777,12 @@ impl Config {
             }),
         )?;
 
+        // DPoP-Nonce requirement (RFC 9449 §8–9). Default on; FAPI clients always
+        // require a nonce regardless. Set DPOP_NONCE_REQUIRED=false to disable.
+        let dpop_nonce_required = env::var("DPOP_NONCE_REQUIRED")
+            .map(|s| !matches!(s.to_lowercase().as_str(), "false" | "0" | "no"))
+            .unwrap_or(true);
+
         // Kafka configuration (optional - only enabled if KAFKA_BOOTSTRAP_SERVERS is set)
         let kafka = env::var("KAFKA_BOOTSTRAP_SERVERS")
             .ok()
@@ -835,6 +846,7 @@ impl Config {
             connector_encryption_key,
             webhook_encryption_key,
             csrf_secret,
+            dpop_nonce_required,
             kafka,
             otel,
             secret_provider: None,
@@ -1258,6 +1270,7 @@ mod tests {
             connector_encryption_key: [0x33u8; 32],
             webhook_encryption_key: [0x44u8; 32],
             csrf_secret: [0x55u8; 32],
+            dpop_nonce_required: true,
             kafka: None,
             otel: OtelConfig {
                 otlp_endpoint: None,
@@ -1310,6 +1323,7 @@ mod tests {
             connector_encryption_key: [0xDDu8; 32],
             webhook_encryption_key: [0xEEu8; 32],
             csrf_secret: [0xFFu8; 32],
+            dpop_nonce_required: true,
             kafka: None,
             otel: OtelConfig {
                 otlp_endpoint: None,

--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -737,6 +737,8 @@ async fn main() {
         // F082-US6: CSRF secret MUST be independent of JWT signing key
         config.csrf_secret.to_vec(),
     )
+    // RFC 9449 §8–9: global DPoP-Nonce requirement (FAPI clients always on).
+    .with_dpop_nonce_required(config.dpop_nonce_required)
     // F084: Share RevocationCache with OAuth2 revocation/introspection handlers
     .with_revocation_cache(revocation_cache.clone())
     // F117: Set system tenant ID for device code email confirmations

--- a/crates/xavyo-api-oauth/CRATE.md
+++ b/crates/xavyo-api-oauth/CRATE.md
@@ -62,6 +62,14 @@ pub fn well_known_router() -> Router<OAuthState>;
 | GET | `/.well-known/openid-configuration` | OIDC Discovery |
 | GET | `/.well-known/jwks.json` | JSON Web Key Set |
 
+**DPoP-Nonce (RFC 9449 §8–9):** when `OAuthState::with_dpop_nonce_required(true)`
+(default; env `DPOP_NONCE_REQUIRED`), a DPoP-bound request without a valid
+server nonce is answered with a `use_dpop_nonce` challenge carrying a fresh
+`DPoP-Nonce` header — `/oauth/token` returns 400, resource endpoints return 401
+with a `WWW-Authenticate: DPoP` challenge. FAPI clients always require a nonce.
+The nonce HMAC key is derived from the CSRF secret (independent of the signing
+key).
+
 ### Types
 
 ```rust

--- a/crates/xavyo-api-oauth/src/dpop_validation.rs
+++ b/crates/xavyo-api-oauth/src/dpop_validation.rs
@@ -75,6 +75,29 @@ pub async fn enforce_dpop(
         OAuthError::InvalidToken("invalid DPoP proof".to_string())
     })?;
 
+    // RFC 9449 §8: once the proof is cryptographically valid, require a fresh
+    // server-issued nonce when configured. Checked BEFORE the jti replay-record
+    // so a nonce-failed request never consumes a replay-cache slot, and only
+    // after full proof validation so it cannot act as an oracle for
+    // unauthenticated callers.
+    if state.dpop_nonce_required() {
+        if let xavyo_auth::NonceCheck::Challenge(nonce) = xavyo_auth::check_or_challenge(
+            state.dpop_nonce_secret(),
+            validated.nonce.as_deref(),
+            Utc::now().timestamp(),
+            xavyo_auth::DPOP_NONCE_WINDOW_SECS,
+            xavyo_auth::DPOP_NONCE_ALLOWED_AGE_WINDOWS,
+        ) {
+            tracing::info!(
+                target: "security",
+                event_type = "dpop_nonce_challenge",
+                endpoint = "resource",
+                "issued DPoP-Nonce challenge"
+            );
+            return Err(OAuthError::UseDpopNonceResource { nonce });
+        }
+    }
+
     // Replay check, tenant-scoped (tenant from the presented access token).
     let tenant_id = claims
         .tid

--- a/crates/xavyo-api-oauth/src/error.rs
+++ b/crates/xavyo-api-oauth/src/error.rs
@@ -391,7 +391,9 @@ mod tests {
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         assert_eq!(
-            resp.headers().get("dpop-nonce").and_then(|v| v.to_str().ok()),
+            resp.headers()
+                .get("dpop-nonce")
+                .and_then(|v| v.to_str().ok()),
             Some("test-nonce-value")
         );
         // The token form does NOT carry a WWW-Authenticate challenge.
@@ -408,7 +410,9 @@ mod tests {
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(
-            resp.headers().get("dpop-nonce").and_then(|v| v.to_str().ok()),
+            resp.headers()
+                .get("dpop-nonce")
+                .and_then(|v| v.to_str().ok()),
             Some("resource-nonce")
         );
         let www = resp

--- a/crates/xavyo-api-oauth/src/error.rs
+++ b/crates/xavyo-api-oauth/src/error.rs
@@ -3,7 +3,10 @@
 //! Provides error types for `OAuth2` flows following RFC 6749.
 
 use axum::{
-    http::StatusCode,
+    http::{
+        header::{HeaderName, HeaderValue, WWW_AUTHENTICATE},
+        StatusCode,
+    },
     response::{IntoResponse, Response},
     Json,
 };
@@ -47,6 +50,8 @@ pub enum OAuthErrorCode {
     SlowDown,
     /// RFC 8628: The device code has expired (device code flow).
     ExpiredToken,
+    /// RFC 9449 §8–9: the request requires a server-issued DPoP nonce.
+    UseDpopNonce,
 }
 
 impl std::fmt::Display for OAuthErrorCode {
@@ -68,6 +73,7 @@ impl std::fmt::Display for OAuthErrorCode {
             Self::AuthorizationPending => "authorization_pending",
             Self::SlowDown => "slow_down",
             Self::ExpiredToken => "expired_token",
+            Self::UseDpopNonce => "use_dpop_nonce",
         };
         write!(f, "{s}")
     }
@@ -144,6 +150,24 @@ pub enum OAuthError {
     #[error("Insufficient scope: {0}")]
     InsufficientScope(String),
 
+    /// RFC 9449 §9: the token endpoint requires a DPoP nonce. The client must
+    /// retry with the carried nonce echoed in the proof's `nonce` claim. HTTP
+    /// 400 + `DPoP-Nonce` response header.
+    #[error("Use DPoP nonce")]
+    UseDpopNonceToken {
+        /// Fresh server-issued nonce for the client to echo on retry.
+        nonce: String,
+    },
+
+    /// RFC 9449 §8: a resource endpoint requires a DPoP nonce. HTTP 401 with a
+    /// `WWW-Authenticate: DPoP error="use_dpop_nonce"` challenge + `DPoP-Nonce`
+    /// response header.
+    #[error("Use DPoP nonce")]
+    UseDpopNonceResource {
+        /// Fresh server-issued nonce for the client to echo on retry.
+        nonce: String,
+    },
+
     /// RFC 8628: Authorization request is still pending.
     #[error("The authorization request is still pending")]
     AuthorizationPending,
@@ -193,6 +217,10 @@ impl OAuthError {
             Self::UnsupportedResponseType(_) => StatusCode::BAD_REQUEST,
             Self::InvalidToken(_) => StatusCode::UNAUTHORIZED,
             Self::InsufficientScope(_) => StatusCode::FORBIDDEN,
+            // RFC 9449: token-endpoint nonce challenge is 400; resource-endpoint
+            // nonce challenge is 401 (it's an access-token authorization error).
+            Self::UseDpopNonceToken { .. } => StatusCode::BAD_REQUEST,
+            Self::UseDpopNonceResource { .. } => StatusCode::UNAUTHORIZED,
             // RFC 8628 device code errors are 400 Bad Request per spec
             Self::AuthorizationPending => StatusCode::BAD_REQUEST,
             Self::SlowDown(_) => StatusCode::BAD_REQUEST,
@@ -221,6 +249,9 @@ impl OAuthError {
             Self::UnsupportedResponseType(_) => OAuthErrorCode::UnsupportedResponseType,
             Self::InvalidToken(_) => OAuthErrorCode::InvalidToken,
             Self::InsufficientScope(_) => OAuthErrorCode::InsufficientScope,
+            Self::UseDpopNonceToken { .. } | Self::UseDpopNonceResource { .. } => {
+                OAuthErrorCode::UseDpopNonce
+            }
             Self::AuthorizationPending => OAuthErrorCode::AuthorizationPending,
             Self::SlowDown(_) => OAuthErrorCode::SlowDown,
             Self::ExpiredToken(_) => OAuthErrorCode::ExpiredToken,
@@ -270,8 +301,43 @@ impl IntoResponse for OAuthError {
     fn into_response(self) -> Response {
         let status = self.status_code();
         let body = Json(self.to_response());
-        (status, body).into_response()
+
+        // RFC 9449 §8–9: a DPoP-nonce challenge carries the fresh nonce in a
+        // `DPoP-Nonce` response header; the resource-server form (§8) also sends
+        // a `WWW-Authenticate: DPoP error="use_dpop_nonce"` challenge with the
+        // accepted proof algorithms (§7.1).
+        match self {
+            Self::UseDpopNonceToken { nonce } => {
+                (status, [dpop_nonce_header(&nonce)], body).into_response()
+            }
+            Self::UseDpopNonceResource { nonce } => (
+                status,
+                [
+                    dpop_nonce_header(&nonce),
+                    (
+                        WWW_AUTHENTICATE,
+                        HeaderValue::from_static(
+                            "DPoP error=\"use_dpop_nonce\", \
+                             error_description=\"DPoP nonce required\", \
+                             algs=\"RS256 PS256 ES256\"",
+                        ),
+                    ),
+                ],
+                body,
+            )
+                .into_response(),
+            _ => (status, body).into_response(),
+        }
     }
+}
+
+/// Build the `DPoP-Nonce` response header. The nonce is base64url (RFC 9449
+/// §8.1), so it is always a valid header value; the fallback is unreachable.
+fn dpop_nonce_header(nonce: &str) -> (HeaderName, HeaderValue) {
+    (
+        HeaderName::from_static("dpop-nonce"),
+        HeaderValue::from_str(nonce).unwrap_or(HeaderValue::from_static("")),
+    )
 }
 
 #[cfg(test)]
@@ -312,5 +378,46 @@ mod tests {
             OAuthError::AccessDenied("test".into()).status_code(),
             StatusCode::FORBIDDEN
         );
+    }
+
+    #[test]
+    fn dpop_nonce_token_challenge_sets_header_and_400() {
+        // RFC 9449 §9: token-endpoint challenge is 400 with the fresh nonce in a
+        // DPoP-Nonce header. Guards the IntoResponse header plumbing.
+        let err = OAuthError::UseDpopNonceToken {
+            nonce: "test-nonce-value".to_string(),
+        };
+        assert_eq!(err.error_code().to_string(), "use_dpop_nonce");
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            resp.headers().get("dpop-nonce").and_then(|v| v.to_str().ok()),
+            Some("test-nonce-value")
+        );
+        // The token form does NOT carry a WWW-Authenticate challenge.
+        assert!(resp.headers().get(WWW_AUTHENTICATE).is_none());
+    }
+
+    #[test]
+    fn dpop_nonce_resource_challenge_sets_headers_and_401() {
+        // RFC 9449 §8: resource-endpoint challenge is 401 with both DPoP-Nonce
+        // and a WWW-Authenticate: DPoP error="use_dpop_nonce" challenge.
+        let err = OAuthError::UseDpopNonceResource {
+            nonce: "resource-nonce".to_string(),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            resp.headers().get("dpop-nonce").and_then(|v| v.to_str().ok()),
+            Some("resource-nonce")
+        );
+        let www = resp
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok())
+            .expect("WWW-Authenticate present");
+        assert!(www.starts_with("DPoP "));
+        assert!(www.contains("error=\"use_dpop_nonce\""));
+        assert!(www.contains("algs="));
     }
 }

--- a/crates/xavyo-api-oauth/src/handlers/token.rs
+++ b/crates/xavyo-api-oauth/src/handlers/token.rs
@@ -135,11 +135,8 @@ async fn handle_authorization_code_grant(
     client_id: &str,
     client_secret: Option<&str>,
 ) -> Result<Json<TokenResponse>, OAuthError> {
-    // DPoP (RFC 9449): if the client presents a proof, validate it against this
-    // token request and bind the issued token to the proof key (opportunistic
-    // binding). Clients with `require_dpop` / FAPI 2.0 (§5.3.2.1-5) MUST present
-    // one — enforced below once the client is loaded.
-    let dpop_jkt = extract_dpop_binding(state, headers)?;
+    // DPoP binding is extracted below, after the client is loaded, so the
+    // nonce requirement can honour the per-client FAPI profile.
     // Validate required parameters
     let code = request
         .code
@@ -169,6 +166,15 @@ async fn handle_authorization_code_grant(
         .client_service
         .get_client_by_id(tenant_id, client_uuid)
         .await?;
+
+    // DPoP (RFC 9449): validate any presented proof and bind the issued token to
+    // the proof key (opportunistic binding). FAPI clients always get the nonce
+    // challenge regardless of the global toggle (FAPI 2.0 §5.3).
+    let dpop_jkt = extract_dpop_binding(
+        state,
+        headers,
+        state.dpop_nonce_required() || client.fapi_profile,
+    )?;
 
     // RFC 9449 / FAPI 2.0 §5.3.2.1-5: clients that require sender-constrained
     // tokens MUST present a DPoP proof. Reject a bare (bearer) token request.
@@ -282,22 +288,45 @@ async fn handle_authorization_code_grant(
 fn extract_dpop_binding(
     state: &OAuthState,
     headers: &HeaderMap,
+    nonce_required: bool,
 ) -> Result<Option<String>, OAuthError> {
     let Some(proof) = headers.get("dpop").and_then(|v| v.to_str().ok()) else {
         return Ok(None);
     };
+    let now = chrono::Utc::now().timestamp();
     let htu = format!("{}/oauth/token", state.issuer.trim_end_matches('/'));
     let validated =
-        xavyo_auth::dpop::validate_proof(proof, "POST", &htu, chrono::Utc::now().timestamp(), None)
-            .map_err(|e| {
-                tracing::warn!(
-                    target: "security",
-                    event_type = "dpop_proof_invalid",
-                    error = %e,
-                    "DPoP proof rejected at token endpoint"
-                );
-                OAuthError::InvalidGrant("invalid DPoP proof".to_string())
-            })?;
+        xavyo_auth::dpop::validate_proof(proof, "POST", &htu, now, None).map_err(|e| {
+            tracing::warn!(
+                target: "security",
+                event_type = "dpop_proof_invalid",
+                error = %e,
+                "DPoP proof rejected at token endpoint"
+            );
+            OAuthError::InvalidGrant("invalid DPoP proof".to_string())
+        })?;
+
+    // RFC 9449 §9: after the proof is cryptographically valid, require a fresh
+    // server-issued nonce when configured. A missing/stale nonce yields a
+    // `use_dpop_nonce` challenge carrying a new nonce; the client retries.
+    if nonce_required {
+        if let xavyo_auth::NonceCheck::Challenge(nonce) = xavyo_auth::check_or_challenge(
+            state.dpop_nonce_secret(),
+            validated.nonce.as_deref(),
+            now,
+            xavyo_auth::DPOP_NONCE_WINDOW_SECS,
+            xavyo_auth::DPOP_NONCE_ALLOWED_AGE_WINDOWS,
+        ) {
+            tracing::info!(
+                target: "security",
+                event_type = "dpop_nonce_challenge",
+                endpoint = "token",
+                "issued DPoP-Nonce challenge"
+            );
+            return Err(OAuthError::UseDpopNonceToken { nonce });
+        }
+    }
+
     Ok(Some(validated.jkt))
 }
 
@@ -479,7 +508,11 @@ async fn handle_client_credentials_grant(
     // Sender-constrain the issued token to the client's DPoP key / mTLS cert
     // when presented (RFC 9449 / RFC 8705) — agent tokens shouldn't be bearer.
     // `cert_thumbprint` was extracted above for client authentication.
-    let dpop_jkt = extract_dpop_binding(state, headers)?;
+    let dpop_jkt = extract_dpop_binding(
+        state,
+        headers,
+        state.dpop_nonce_required() || client.fapi_profile,
+    )?;
 
     // Issue tokens for client credentials grant
     // If the client is bound to an NHI identity, the NHI ID becomes the JWT subject
@@ -607,14 +640,16 @@ async fn handle_refresh_token_grant(
     let tenant_id = extract_tenant_id_from_headers(headers)?;
 
     // For confidential clients, verify the secret
-    // For public clients, validate the client exists and belongs to the tenant
-    let client_internal_id = if let Some(secret) = client_secret {
+    // For public clients, validate the client exists and belongs to the tenant.
+    // Retain `fapi_profile` so the DPoP-nonce requirement below honours FAPI 2.0
+    // even when the global toggle is off.
+    let (client_internal_id, client_fapi) = if let Some(secret) = client_secret {
         // Confidential client - verify credentials
         let client = state
             .client_service
             .verify_client_credentials(tenant_id, client_id, secret)
             .await?;
-        client.id
+        (client.id, client.fapi_profile)
     } else {
         // Public client - verify the client exists in this tenant
         // R8-F2: Use the looked-up client's internal ID (not the parsed client_id string).
@@ -628,7 +663,7 @@ async fn handle_refresh_token_grant(
             .map_err(|_| {
                 OAuthError::InvalidClient("Client not found in specified tenant".to_string())
             })?;
-        client.id
+        (client.id, client.fapi_profile)
     };
 
     // Validate and rotate the refresh token
@@ -639,7 +674,8 @@ async fn handle_refresh_token_grant(
 
     // Re-bind the new access token to the DPoP key / mTLS cert presented at the
     // refresh request (RFC 9449 / RFC 8705) — sender-constraint carries forward.
-    let dpop_jkt = extract_dpop_binding(state, headers)?;
+    let dpop_jkt =
+        extract_dpop_binding(state, headers, state.dpop_nonce_required() || client_fapi)?;
     let cert_thumbprint = headers
         .get("x-client-cert-thumbprint")
         .and_then(|v| v.to_str().ok());
@@ -972,7 +1008,11 @@ async fn handle_token_exchange_grant(
 
     // Sender-constrain the delegated (agent) token to the DPoP key / mTLS cert
     // presented at the exchange (RFC 9449 / RFC 8705).
-    let dpop_jkt = extract_dpop_binding(state, headers)?;
+    let dpop_jkt = extract_dpop_binding(
+        state,
+        headers,
+        state.dpop_nonce_required() || client.fapi_profile,
+    )?;
     let cert_thumbprint = headers
         .get("x-client-cert-thumbprint")
         .and_then(|v| v.to_str().ok());

--- a/crates/xavyo-api-oauth/src/router.rs
+++ b/crates/xavyo-api-oauth/src/router.rs
@@ -107,6 +107,15 @@ pub struct OAuthState {
     /// CSRF secret for consent form protection (F082-US6).
     /// SECURITY: This MUST be independent of the JWT signing key.
     csrf_secret: Vec<u8>,
+    /// HMAC key for stateless DPoP-Nonce (RFC 9449 §8–9). Derived from
+    /// `csrf_secret` so it inherits the same independence from the JWT signing
+    /// key (which is public via JWKS) without an extra operator-provisioned
+    /// secret.
+    dpop_nonce_secret: Vec<u8>,
+    /// Whether DPoP-bound requests must carry a server-issued nonce (RFC 9449
+    /// §8–9). Global toggle (env `DPOP_NONCE_REQUIRED`, default `true`); FAPI
+    /// clients always require one regardless of this flag (FAPI 2.0 §5.3).
+    dpop_nonce_required: bool,
     /// F117: Device confirmation service for Storm-2372 remediation.
     pub device_confirmation_service: Option<Arc<DeviceConfirmationService>>,
     /// F117: Device risk service for Storm-2372 risk scoring.
@@ -192,6 +201,10 @@ impl OAuthState {
         ));
         let userinfo_service = Arc::new(UserInfoService::new(pool.clone()));
 
+        // Derive the DPoP-nonce HMAC key from the (signing-key-independent) CSRF
+        // secret before it is moved into the struct.
+        let dpop_nonce_secret = xavyo_auth::derive_dpop_nonce_secret(&csrf_secret);
+
         Self {
             pool,
             client_service,
@@ -207,6 +220,8 @@ impl OAuthState {
             signing_keys,
             revocation_cache: None,
             csrf_secret,
+            dpop_nonce_secret,
+            dpop_nonce_required: true,
             device_confirmation_service: None,
             device_risk_service: None,
             system_tenant_id: SYSTEM_TENANT_ID, // Safe default; overridable via with_system_tenant_id
@@ -262,6 +277,26 @@ impl OAuthState {
     pub fn with_frontend_url(mut self, url: String) -> Self {
         self.frontend_url = Some(url);
         self
+    }
+
+    /// Set whether DPoP-bound requests must carry a server-issued nonce
+    /// (RFC 9449 §8–9). Defaults to `true`; FAPI clients always require one.
+    #[must_use]
+    pub fn with_dpop_nonce_required(mut self, required: bool) -> Self {
+        self.dpop_nonce_required = required;
+        self
+    }
+
+    /// The HMAC key for issuing/verifying stateless DPoP nonces.
+    #[must_use]
+    pub fn dpop_nonce_secret(&self) -> &[u8] {
+        &self.dpop_nonce_secret
+    }
+
+    /// Whether a DPoP nonce is required for DPoP-bound requests (global toggle).
+    #[must_use]
+    pub fn dpop_nonce_required(&self) -> bool {
+        self.dpop_nonce_required
     }
 
     /// Set the Kafka event producer for delegation events.

--- a/crates/xavyo-auth/CRATE.md
+++ b/crates/xavyo-auth/CRATE.md
@@ -92,6 +92,22 @@ pub fn hash_password(password: &str) -> Result<String, AuthError>;
 pub fn verify_password(password: &str, hash: &str) -> Result<bool, AuthError>;
 ```
 
+DPoP-Nonce (RFC 9449 §8–9), in `dpop_nonce` — stateless `HMAC(secret, window)`
+so any node can issue/verify without shared state:
+
+```rust
+/// Derive the nonce HMAC key from a root secret (e.g. the CSRF secret), keeping
+/// it independent of the JWT signing key.
+pub fn derive_dpop_nonce_secret(root_secret: &[u8]) -> Vec<u8>;
+
+/// Issue / constant-time verify a nonce for the time window containing `now`.
+pub fn issue_dpop_nonce(secret: &[u8], now: i64, window_secs: i64) -> String;
+pub fn verify_dpop_nonce(secret: &[u8], candidate: &str, now: i64, window_secs: i64, allowed_age_windows: i64) -> bool;
+
+/// Accept a valid presented nonce or return a fresh `Challenge(nonce)`.
+pub fn check_or_challenge(secret: &[u8], presented: Option<&str>, now: i64, window_secs: i64, allowed_age_windows: i64) -> NonceCheck;
+```
+
 ## Usage Example
 
 ```rust

--- a/crates/xavyo-auth/src/dpop_nonce.rs
+++ b/crates/xavyo-auth/src/dpop_nonce.rs
@@ -64,6 +64,51 @@ pub fn verify_dpop_nonce(
     })
 }
 
+/// Derive the DPoP-nonce HMAC key from a root secret (e.g. the CSRF secret).
+///
+/// The nonce key MUST be independent of the JWT signing key (which is public via
+/// JWKS and rotated on its own schedule). Reusing the already-independent CSRF
+/// secret with a distinct domain prefix gives that independence without making
+/// operators provision yet another secret. Domain separation keeps the CSRF and
+/// nonce uses cryptographically distinct.
+#[must_use]
+pub fn derive_secret(root_secret: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(root_secret).expect("HMAC accepts any key length");
+    mac.update(b"dpop-nonce:v1:root");
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// Outcome of checking a presented DPoP `nonce` when the endpoint requires one.
+#[derive(Debug, PartialEq, Eq)]
+pub enum NonceCheck {
+    /// The proof carried a currently-valid nonce — proceed.
+    Ok,
+    /// No nonce, or a stale/forged one — challenge the client with this fresh
+    /// nonce (return it in the `DPoP-Nonce` response header).
+    Challenge(String),
+}
+
+/// Check a (possibly absent) presented nonce, issuing a fresh challenge nonce
+/// when the presented one is missing, stale, or forged.
+///
+/// Call only when a nonce is required for this request; bearer (non-DPoP)
+/// requests never reach here.
+#[must_use]
+pub fn check_or_challenge(
+    secret: &[u8],
+    presented: Option<&str>,
+    now: i64,
+    window_secs: i64,
+    allowed_age_windows: i64,
+) -> NonceCheck {
+    match presented {
+        Some(n) if verify_dpop_nonce(secret, n, now, window_secs, allowed_age_windows) => {
+            NonceCheck::Ok
+        }
+        _ => NonceCheck::Challenge(issue_dpop_nonce(secret, now, window_secs)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,5 +164,50 @@ mod tests {
         let now = 1_000_000;
         let future = issue_dpop_nonce(SECRET, now + 10 * W, W);
         assert!(!verify_dpop_nonce(SECRET, &future, now, W, 1));
+    }
+
+    #[test]
+    fn derived_secret_is_stable_independent_and_distinct() {
+        let root = b"csrf-root-secret-material";
+        let a = derive_secret(root);
+        let b = derive_secret(root);
+        assert_eq!(a, b, "derivation must be deterministic");
+        assert_ne!(a, root.to_vec(), "derived secret must differ from the root");
+        assert_ne!(
+            derive_secret(b"other-root"),
+            a,
+            "different roots must derive different secrets"
+        );
+        assert_eq!(a.len(), 32, "HMAC-SHA256 output is 32 bytes");
+    }
+
+    #[test]
+    fn check_or_challenge_accepts_valid_and_challenges_otherwise() {
+        let now = 1_000_000;
+        let good = issue_dpop_nonce(SECRET, now, W);
+
+        assert_eq!(
+            check_or_challenge(SECRET, Some(&good), now, W, 1),
+            NonceCheck::Ok
+        );
+
+        // Absent nonce → challenge with a freshly issued, verifiable nonce.
+        let NonceCheck::Challenge(fresh) = check_or_challenge(SECRET, None, now, W, 1) else {
+            panic!("absent nonce must produce a challenge");
+        };
+        assert!(verify_dpop_nonce(SECRET, &fresh, now, W, 1));
+
+        // Forged nonce → challenge.
+        assert!(matches!(
+            check_or_challenge(SECRET, Some("forged"), now, W, 1),
+            NonceCheck::Challenge(_)
+        ));
+
+        // Stale nonce (older than the allowed window) → challenge.
+        let stale = issue_dpop_nonce(SECRET, now - 5 * W, W);
+        assert!(matches!(
+            check_or_challenge(SECRET, Some(&stale), now, W, 1),
+            NonceCheck::Challenge(_)
+        ));
     }
 }

--- a/crates/xavyo-auth/src/lib.rs
+++ b/crates/xavyo-auth/src/lib.rs
@@ -57,7 +57,10 @@ pub use client_assertion::{
     CLIENT_ASSERTION_TYPE_JWT_BEARER,
 };
 pub use dpop::{compute_ath, jwk_thumbprint, verify_resource_proof, DpopError, ValidatedProof};
-pub use dpop_nonce::{issue_dpop_nonce, verify_dpop_nonce, DPOP_NONCE_WINDOW_SECS};
+pub use dpop_nonce::{
+    check_or_challenge, derive_secret as derive_dpop_nonce_secret, issue_dpop_nonce,
+    verify_dpop_nonce, NonceCheck, DPOP_NONCE_ALLOWED_AGE_WINDOWS, DPOP_NONCE_WINDOW_SECS,
+};
 pub use error::AuthError;
 pub use jsonwebtoken::Algorithm;
 pub use jwks::{JwkSet, JwksClient};


### PR DESCRIPTION
## What

Wires the stateless DPoP-nonce data path (shipped earlier) into the **token** and **resource** endpoints so the server can force DPoP-proof freshness — closing the captured-proof replay window and satisfying FAPI 2.0 §5.3. Implements task #54 item 4 per the design spec (`docs/superpowers/specs/2026-05-25-dpop-nonce-flow-design.md`, local).

A DPoP-bound request lacking a valid server nonce gets a one-time `use_dpop_nonce` challenge with a fresh `DPoP-Nonce` header; an RFC 9449-compliant client retries transparently.

## Policy (recommended options, corrected to match codebase shape)

- **Global toggle** `DPOP_NONCE_REQUIRED` (default `true`); **FAPI clients always** require a nonce (`require = global || client.fapi_profile`). No per-tenant table exists, and one column for a single bool isn't justified for v1.
- **Nonce HMAC key derived from the existing CSRF secret** (`HMAC-SHA256(csrf_secret, "dpop-nonce:v1:root")`) — independent of the JWT signing key (the F082-US6 principle) without a new operator-provisioned secret.

## Mechanics (advisor pitfalls honored)

- Token endpoint: nonce checked **after** full proof crypto validation, across all four grants (auth-code extraction moved after client-load so the FAPI flag is known).
- Resource `enforce_dpop`: nonce checked after crypto validation, **before** the `jti` replay-record (no replay slot consumed on nonce-fail; not an oracle).
- `OAuthError::UseDpopNonceToken` (400) / `UseDpopNonceResource` (401) carry the nonce via a `DPoP-Nonce` header; resource form adds `WWW-Authenticate: DPoP error="use_dpop_nonce", algs="RS256 PS256 ES256"`.

## Tests / verification

- `xavyo-auth`: 8 nonce unit tests (incl. `derive_secret`, `check_or_challenge`).
- `xavyo-api-oauth`: 2 new `IntoResponse` tests asserting status + `DPoP-Nonce`/`WWW-Authenticate` headers; full suite **216 unit + all integration files pass**, 0 failures (default-on change regresses nothing).
- `cargo +1.95.0 clippy -p xavyo-auth -p xavyo-api-oauth -p idp-api --all-targets -- -D warnings` clean; `idp-api` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)