### PR TITLE
feat(governance): emit CAEP token-claims-change on role assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8682,6 +8682,7 @@ dependencies = [
  "xavyo-nhi",
  "xavyo-provisioning",
  "xavyo-siem",
+ "xavyo-ssf",
  "xavyo-tenant",
  "xavyo-webhooks",
 ]

--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -1014,7 +1014,7 @@ async fn main() {
 
     // Governance routes (F033 - IGA Entitlement Management)
     // F113: Support both API key and JWT authentication for programmatic access
-    let governance_routes = governance_router(pool.clone())
+    let governance_routes = governance_router(pool.clone(), ssf_emitter.clone())
         .layer(axum::middleware::from_fn(admin_guard))
         .layer(axum::middleware::from_fn(jwt_auth_middleware))
         .layer(axum::middleware::from_fn(api_key_auth_middleware))

--- a/crates/xavyo-api-governance/Cargo.toml
+++ b/crates/xavyo-api-governance/Cargo.toml
@@ -20,6 +20,7 @@ xavyo-api-auth = { path = "../xavyo-api-auth" }
 xavyo-db = { path = "../xavyo-db" }
 xavyo-tenant = { path = "../xavyo-tenant" }
 xavyo-governance = { path = "../xavyo-governance" }
+xavyo-ssf = { path = "../xavyo-ssf" }
 xavyo-events = { path = "../xavyo-events", optional = true }
 xavyo-webhooks = { path = "../xavyo-webhooks" }
 xavyo-nhi = { path = "../xavyo-nhi" }

--- a/crates/xavyo-api-governance/src/router.rs
+++ b/crates/xavyo-api-governance/src/router.rs
@@ -685,14 +685,26 @@ impl GovernanceState {
             gdpr_report_service: Arc::new(GdprReportService::new(pool)),
         })
     }
+
+    /// Attach a CAEP emitter so role assignment/revocation broadcasts
+    /// `token-claims-change` Shared Signals (CAEP 1.0). Rebuilds
+    /// `role_assignment_service` with the emitter; pass the same
+    /// `Arc<dyn CaepEmitter>` used by the auth/SSF transmitter layer.
+    #[must_use]
+    pub fn with_caep_emitter(mut self, emitter: Arc<dyn xavyo_ssf::CaepEmitter>) -> Self {
+        self.role_assignment_service =
+            Arc::new(RoleAssignmentService::new(self.pool.clone()).with_emitter(emitter));
+        self
+    }
 }
 
 /// Create the governance API router.
 ///
 /// All routes are prefixed with `/governance` and require authentication.
-pub fn governance_router(pool: PgPool) -> Router {
+pub fn governance_router(pool: PgPool, caep_emitter: Arc<dyn xavyo_ssf::CaepEmitter>) -> Router {
     let state = GovernanceState::new(pool)
-        .expect("Failed to initialize GovernanceState (check XAVYO_SIEM_ENCRYPTION_KEY)");
+        .expect("Failed to initialize GovernanceState (check XAVYO_SIEM_ENCRYPTION_KEY)")
+        .with_caep_emitter(caep_emitter);
 
     Router::new()
         // Applications

--- a/crates/xavyo-api-governance/src/services/role_assignment_service.rs
+++ b/crates/xavyo-api-governance/src/services/role_assignment_service.rs
@@ -11,6 +11,7 @@
 use chrono::Utc;
 use sqlx::PgPool;
 use std::collections::HashSet;
+use std::sync::Arc;
 use uuid::Uuid;
 
 use xavyo_db::models::{
@@ -18,6 +19,7 @@ use xavyo_db::models::{
     GovRole, GovRoleEntitlement,
 };
 use xavyo_governance::error::{GovernanceError, Result};
+use xavyo_ssf::{CaepEmitter, NoopEmitter};
 
 use crate::services::{AssignmentService, InducementTriggerService};
 
@@ -52,6 +54,8 @@ pub struct RoleAssignmentService {
     pool: PgPool,
     assignment_service: AssignmentService,
     inducement_trigger_service: InducementTriggerService,
+    /// CAEP sink for `token-claims-change` signals (Noop unless SSF is wired).
+    emitter: Arc<dyn CaepEmitter>,
 }
 
 impl RoleAssignmentService {
@@ -62,7 +66,18 @@ impl RoleAssignmentService {
             assignment_service: AssignmentService::new(pool.clone()),
             inducement_trigger_service: InducementTriggerService::new(pool.clone()),
             pool,
+            emitter: Arc::new(NoopEmitter),
         }
+    }
+
+    /// Attach a CAEP emitter so role assignment/revocation broadcasts a
+    /// `token-claims-change` Shared Signal (RFC 8417 SET / CAEP 1.0). The user's
+    /// effective entitlements — and thus token claims — change on assignment, so
+    /// relying parties should re-evaluate access.
+    #[must_use]
+    pub fn with_emitter(mut self, emitter: Arc<dyn CaepEmitter>) -> Self {
+        self.emitter = emitter;
+        self
     }
 
     /// Assign a role to a user.
@@ -181,6 +196,15 @@ impl RoleAssignmentService {
             "Role assigned with constructions triggered"
         );
 
+        // CAEP (Shared Signals): the user's effective entitlements changed, so
+        // their token claims will differ on next issuance — broadcast a
+        // token-claims-change signal. Fire-and-forget.
+        self.emitter.token_claims_change(
+            tenant_id,
+            user_id,
+            serde_json::json!({ "role_id": role_id, "role": role.name, "change": "assigned" }),
+        );
+
         Ok(RoleAssignmentResult {
             role_id,
             user_id,
@@ -294,6 +318,15 @@ impl RoleAssignmentService {
             deprovisioning_count = deprovisioning_operation_ids.len(),
             revoked_by = ?revoked_by,
             "Role revoked with deprovisioning triggered"
+        );
+
+        // CAEP (Shared Signals): entitlements were revoked, so the user's token
+        // claims will shrink on next issuance — broadcast a token-claims-change
+        // signal. Fire-and-forget.
+        self.emitter.token_claims_change(
+            tenant_id,
+            user_id,
+            serde_json::json!({ "role_id": role_id, "role": role.name, "change": "revoked" }),
         );
 
         Ok(RoleRevocationResult {


### PR DESCRIPTION
## What

Wires the **CAEP `token-claims-change`** Shared Signal (CAEP 1.0 / RFC 8417 SET) into the IGA role lifecycle — task #54 item 7. The emitter trait method existed with a working `SsfStreamEmitter` impl, but nothing called it. Now a **role assignment or revocation broadcasts a `token-claims-change` SET**, so relying parties re-evaluate access immediately instead of waiting for token expiry — SOTA continuous access evaluation for the workforce/agent case.

## Hook point (recommended)

Emission lives in `RoleAssignmentService::assign_role` / `revoke_role`, **after the DB change succeeds** — so *every* caller (route handlers, bulk actions, birthright/lifecycle automation) emits, not just one endpoint. Payload: `{ role_id, role, change: "assigned"|"revoked" }`. Fire-and-forget; `Noop` unless SSF is configured.

## Wiring (mirrors the existing api-auth pattern exactly)

- `RoleAssignmentService` gains `Arc<dyn CaepEmitter>` (default `NoopEmitter`) + `with_emitter`.
- `GovernanceState::with_caep_emitter` rebuilds `role_assignment_service` with the emitter — the same shape as api-auth's `with_caep_emitter` rebuilding `password_policy_service`.
- `governance_router(pool, caep_emitter)` threads it; `idp-api` passes the same shared `ssf_emitter` already used by the auth/session/SSF transmitter layer.

## Verification

- `cargo +1.95.0 clippy -p xavyo-api-governance -p idp-api --all-targets -- -D warnings` clean.
- Full `xavyo-api-governance` test suite passes; `idp-api` compiles.
- Live SET-delivery integration tests are part of task #54 item 8 (needs a test DB + mock receiver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)