### PR TITLE
feat(ssf): poll-based SET delivery (RFC 8936)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8937,9 +8937,12 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "hex",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 1.0.69",
  "tokio",

--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -70,7 +70,7 @@ use xavyo_api_social::{
     SocialState,
 };
 use xavyo_api_ssf::{
-    ssf_router, ssf_well_known_router, SsfState, SsfStreamEmitter, SsfTransmitter,
+    ssf_poll_router, ssf_router, ssf_well_known_router, SsfState, SsfStreamEmitter, SsfTransmitter,
 };
 use xavyo_api_tenants::{
     api_keys_router, oauth_clients_router, suspension_check_middleware, system_admin_router,
@@ -782,7 +782,11 @@ async fn main() {
             xavyo_tenant::TenantConfig::builder()
                 .require_tenant(true)
                 .build(),
-        ));
+        ))
+        // RFC 8936 poll endpoint is receiver-facing and authenticates with the
+        // per-stream bearer token, NOT the tenant JWT — merge it AFTER the
+        // tenant-auth layers so those layers do not apply to it.
+        .merge(ssf_poll_router(ssf_state.clone()));
     let ssf_well_known_routes = ssf_well_known_router(ssf_state);
 
     // Device code verification routes (F096 - RFC 8628)

--- a/crates/xavyo-api-ssf/CRATE.md
+++ b/crates/xavyo-api-ssf/CRATE.md
@@ -16,7 +16,7 @@ api
 
 🔴 **alpha**
 
-16 unit tests (SSRF guard, model serialization, transmitter SET building). No HTTP+Postgres integration tests yet, and the receiver-side roles (poll delivery per RFC 8936, verification events) are not implemented. API will change.
+20 unit tests (SSRF guard, model serialization, transmitter SET building, poll token hashing/parsing). Push (RFC 8935) and poll (RFC 8936) delivery are both implemented; verification events (SSF §7.1.4) and a queue-TTL janitor are not. No HTTP+Postgres integration tests yet — API will change.
 
 ## Dependencies
 
@@ -44,6 +44,12 @@ api
 ///   POST      /subjects:add     add a subject to a stream
 ///   POST      /subjects:remove  remove a subject from a stream
 pub fn ssf_router() -> Router<SsfState>;
+
+/// Poll-based delivery (RFC 8936). Receiver-facing — authenticates with the
+/// per-stream bearer token, NOT the tenant JWT. Mount at `/ssf` OUTSIDE the
+/// tenant-auth middleware (e.g. `ssf_router(...).layer(auth).merge(ssf_poll_router(...))`).
+///   POST /poll   ack the prior batch + pull queued SETs (jti -> JWS)
+pub fn ssf_poll_router(state: SsfState) -> Router;
 
 /// Transmitter metadata (SSF §7). Mount at `/.well-known`.
 ///   GET /.well-known/ssf-configuration

--- a/crates/xavyo-api-ssf/Cargo.toml
+++ b/crates/xavyo-api-ssf/Cargo.toml
@@ -41,6 +41,11 @@ reqwest = { workspace = true }
 # Fire-and-forget emission (spawn delivery tasks) + delivery-time DNS resolution
 tokio = { workspace = true, features = ["rt", "macros", "net"] }
 
+# Poll-delivery (RFC 8936) per-stream bearer token: generate + SHA-256 hash.
+rand = "0.8"
+sha2 = "0.10"
+hex = "0.4"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 wiremock = "0.6"

--- a/crates/xavyo-api-ssf/src/error.rs
+++ b/crates/xavyo-api-ssf/src/error.rs
@@ -19,6 +19,11 @@ pub enum SsfApiError {
     #[error("stream not found")]
     StreamNotFound,
 
+    /// The poll bearer token was missing or did not resolve to a stream
+    /// (RFC 8936 receiver auth).
+    #[error("invalid or missing poll credentials")]
+    Unauthorized,
+
     /// A database error (sanitized in the response).
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
@@ -33,6 +38,7 @@ impl SsfApiError {
         match self {
             Self::InvalidRequest(_) => StatusCode::BAD_REQUEST,
             Self::StreamNotFound => StatusCode::NOT_FOUND,
+            Self::Unauthorized => StatusCode::UNAUTHORIZED,
             Self::Database(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/crates/xavyo-api-ssf/src/handlers.rs
+++ b/crates/xavyo-api-ssf/src/handlers.rs
@@ -13,7 +13,7 @@ use axum::{
 use sqlx::pool::PoolConnection;
 use sqlx::Postgres;
 use xavyo_core::TenantId;
-use xavyo_db::models::{CreateSsfStream, SsfStream, SsfSubject};
+use xavyo_db::models::{CreateSsfStream, SsfPollToken, SsfStream, SsfSubject};
 use xavyo_ssf::{CREDENTIAL_CHANGE_URI, SESSION_REVOKED_URI};
 
 use crate::error::SsfApiError;
@@ -35,7 +35,7 @@ pub struct SsfState {
 const SUPPORTED_EVENTS: [&str; 2] = [SESSION_REVOKED_URI, CREDENTIAL_CHANGE_URI];
 
 /// Acquire a pooled connection with the tenant RLS context set.
-async fn tenant_conn(
+pub(crate) async fn tenant_conn(
     pool: &sqlx::PgPool,
     tenant_id: uuid::Uuid,
 ) -> Result<PoolConnection<Postgres>, SsfApiError> {
@@ -60,6 +60,7 @@ pub async fn create_stream(
 ) -> Result<(StatusCode, Json<StreamResponse>), SsfApiError> {
     req.validate()?;
     let tenant = *tenant_id.as_uuid();
+    let is_poll = req.is_poll();
 
     // We deliver only the requested events we actually support.
     let events_delivered: Vec<String> = req
@@ -85,10 +86,23 @@ pub async fn create_stream(
     )
     .await?;
 
-    Ok((
-        StatusCode::CREATED,
-        Json(StreamResponse::from_stream(stream, &state.issuer)),
-    ))
+    // RFC 8936: a poll stream gets a one-time bearer token (hash stored) the
+    // receiver presents to POST /ssf/poll. Returned once in this response.
+    let response = if is_poll {
+        let token = crate::poll::generate_poll_token();
+        SsfPollToken::create(
+            &mut *conn,
+            &crate::poll::hash_poll_token(&token),
+            stream.stream_id,
+            tenant,
+        )
+        .await?;
+        StreamResponse::from_stream(stream, &state.issuer).with_poll_token(token)
+    } else {
+        StreamResponse::from_stream(stream, &state.issuer)
+    };
+
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// `GET /ssf/streams` — list the tenant's streams.

--- a/crates/xavyo-api-ssf/src/lib.rs
+++ b/crates/xavyo-api-ssf/src/lib.rs
@@ -6,11 +6,13 @@
 //! (`ssf_streams` / `ssf_subjects`). The push [`transmitter`] signs and delivers
 //! SETs (with an SSRF/DNS-rebinding guard), and [`emitter::SsfStreamEmitter`]
 //! implements `CaepEmitter` so application flows fan signals out to a tenant's
-//! streams. Receiver-side roles (RFC 8936 poll delivery, verification events)
+//! streams. Poll-based delivery (RFC 8936) is in [`poll`]; verification events
 //! are a later increment.
 //!
 //! Mount:
 //! - [`router::ssf_router`] at `/ssf` (behind auth + `Extension<TenantId>`)
+//! - [`poll::ssf_poll_router`] at `/ssf` (receiver-facing; per-stream bearer
+//!   token auth — mount OUTSIDE the tenant-auth middleware)
 //! - [`router::ssf_well_known_router`] at `/.well-known`
 
 /// `CaepEmitter` impl backed by the push transmitter.
@@ -18,6 +20,8 @@ pub mod emitter;
 pub mod error;
 pub mod handlers;
 pub mod models;
+/// Poll-based delivery (RFC 8936): per-stream bearer-token auth + poll endpoint.
+pub mod poll;
 pub mod router;
 /// SSRF guard for receiver endpoints.
 pub mod ssrf;
@@ -27,5 +31,6 @@ pub mod transmitter;
 pub use emitter::SsfStreamEmitter;
 pub use error::SsfApiError;
 pub use handlers::SsfState;
+pub use poll::ssf_poll_router;
 pub use router::{ssf_router, ssf_well_known_router};
 pub use transmitter::{DeliveryError, SsfTransmitter};

--- a/crates/xavyo-api-ssf/src/models.rs
+++ b/crates/xavyo-api-ssf/src/models.rs
@@ -8,8 +8,11 @@ use xavyo_db::models::{
     SsfStream, STREAM_STATUS_DISABLED, STREAM_STATUS_ENABLED, STREAM_STATUS_PAUSED,
 };
 
-/// Push delivery method URN (RFC 8935) — the only delivery method in v1.
+/// Push delivery method URN (RFC 8935).
 pub const PUSH_DELIVERY_METHOD: &str = "urn:ietf:rfc:8935";
+
+/// Poll delivery method URN (RFC 8936).
+pub const POLL_DELIVERY_METHOD: &str = "urn:ietf:rfc:8936";
 
 /// SSF stream `delivery` object (SSF §8.1.1).
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -39,19 +42,29 @@ pub struct CreateStreamRequest {
 }
 
 impl CreateStreamRequest {
-    /// Validate the request. v1 accepts only push delivery, and the receiver
-    /// `endpoint_url` must pass the SSRF guard (https + public host).
+    /// Validate the request. Push delivery (RFC 8935) requires the receiver
+    /// `endpoint_url` to pass the SSRF guard (https + public host); poll
+    /// delivery (RFC 8936) does not call out, so its `endpoint_url` is
+    /// informational and not SSRF-checked.
     ///
     /// # Errors
-    /// [`SsfApiError::InvalidRequest`] on unsupported delivery or an endpoint
-    /// that fails [`crate::ssrf::validate_receiver_url`].
+    /// [`SsfApiError::InvalidRequest`] on an unsupported delivery method or a
+    /// push endpoint that fails [`crate::ssrf::validate_receiver_url`].
     pub fn validate(&self) -> Result<(), SsfApiError> {
-        if self.delivery.method != PUSH_DELIVERY_METHOD {
-            return Err(SsfApiError::InvalidRequest(format!(
-                "unsupported delivery method (v1 supports only {PUSH_DELIVERY_METHOD})"
-            )));
+        match self.delivery.method.as_str() {
+            PUSH_DELIVERY_METHOD => crate::ssrf::validate_receiver_url(&self.delivery.endpoint_url),
+            POLL_DELIVERY_METHOD => Ok(()),
+            other => Err(SsfApiError::InvalidRequest(format!(
+                "unsupported delivery method '{other}' \
+                 (supported: {PUSH_DELIVERY_METHOD} push, {POLL_DELIVERY_METHOD} poll)"
+            ))),
         }
-        crate::ssrf::validate_receiver_url(&self.delivery.endpoint_url)
+    }
+
+    /// Whether this request asks for poll-based delivery (RFC 8936).
+    #[must_use]
+    pub fn is_poll(&self) -> bool {
+        self.delivery.method == POLL_DELIVERY_METHOD
     }
 }
 
@@ -75,10 +88,17 @@ pub struct StreamResponse {
     /// Optional description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// The per-stream poll bearer token (RFC 8936). Returned **once**, only on
+    /// creation of a poll-delivery stream — store it, it cannot be retrieved
+    /// again. Absent for push streams and on list/get.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub poll_token: Option<String>,
 }
 
 impl StreamResponse {
     /// Build a response from a stored stream, stamping the transmitter `iss`.
+    /// `poll_token` is `None` (set explicitly via [`Self::with_poll_token`] on
+    /// poll-stream creation).
     #[must_use]
     pub fn from_stream(stream: SsfStream, issuer: &str) -> Self {
         Self {
@@ -93,8 +113,47 @@ impl StreamResponse {
             events_delivered: stream.events_delivered,
             status: stream.status,
             description: stream.description,
+            poll_token: None,
         }
     }
+
+    /// Attach the one-time poll bearer token (poll-stream creation only).
+    #[must_use]
+    pub fn with_poll_token(mut self, token: String) -> Self {
+        self.poll_token = Some(token);
+        self
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Body for `POST /ssf/poll` — poll-based delivery (RFC 8936 §2.4).
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct PollRequest {
+    /// Maximum SETs to return in this poll (clamped server-side).
+    #[serde(default, rename = "maxEvents")]
+    pub max_events: Option<i64>,
+    /// RFC 8936: if `false` the transmitter MAY hold the request open (long
+    /// poll). v1 always returns immediately; the field is accepted for
+    /// compatibility.
+    #[serde(default = "default_true", rename = "returnImmediately")]
+    pub return_immediately: bool,
+    /// `jti`s of SETs the receiver acknowledges as delivered — removed from the
+    /// queue before the next batch is selected.
+    #[serde(default)]
+    pub ack: Vec<String>,
+}
+
+/// Response to `POST /ssf/poll` (RFC 8936 §2.4).
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct PollResponse {
+    /// Map of SET `jti` → compact JWS for the returned batch.
+    pub sets: std::collections::HashMap<String, String>,
+    /// Whether more queued SETs remain beyond this batch.
+    #[serde(rename = "moreAvailable")]
+    pub more_available: bool,
 }
 
 /// Body for `POST /ssf/status` (update stream status).
@@ -171,7 +230,10 @@ impl SsfConfigurationMetadata {
         Self {
             issuer: issuer.to_string(),
             jwks_uri: format!("{base}/.well-known/jwks.json"),
-            delivery_methods_supported: vec![PUSH_DELIVERY_METHOD.to_string()],
+            delivery_methods_supported: vec![
+                PUSH_DELIVERY_METHOD.to_string(),
+                POLL_DELIVERY_METHOD.to_string(),
+            ],
             configuration_endpoint: format!("{base}/ssf/streams"),
             status_endpoint: format!("{base}/ssf/status"),
             add_subject_endpoint: format!("{base}/ssf/subjects:add"),
@@ -197,15 +259,36 @@ mod tests {
             m.add_subject_endpoint,
             "https://idp.example.com/ssf/subjects:add"
         );
-        assert_eq!(m.delivery_methods_supported, vec![PUSH_DELIVERY_METHOD]);
+        assert_eq!(
+            m.delivery_methods_supported,
+            vec![PUSH_DELIVERY_METHOD, POLL_DELIVERY_METHOD]
+        );
     }
 
     #[test]
-    fn create_request_rejects_non_push_delivery() {
+    fn create_request_accepts_poll_delivery() {
+        // Poll delivery (RFC 8936) is now supported; endpoint_url is not
+        // SSRF-checked because poll never calls out.
         let req = CreateStreamRequest {
             aud: "https://rp".into(),
             delivery: DeliveryConfig {
-                method: "urn:ietf:rfc:8936".into(), // poll, not supported in v1
+                method: POLL_DELIVERY_METHOD.into(),
+                endpoint_url: "https://rp/poll".into(),
+            },
+            events_requested: vec![],
+            delivery_authorization_header: None,
+            description: None,
+        };
+        assert!(req.validate().is_ok());
+        assert!(req.is_poll());
+    }
+
+    #[test]
+    fn create_request_rejects_unknown_delivery() {
+        let req = CreateStreamRequest {
+            aud: "https://rp".into(),
+            delivery: DeliveryConfig {
+                method: "urn:example:carrier-pigeon".into(),
                 endpoint_url: "https://rp/ssf".into(),
             },
             events_requested: vec![],

--- a/crates/xavyo-api-ssf/src/poll.rs
+++ b/crates/xavyo-api-ssf/src/poll.rs
@@ -1,0 +1,146 @@
+//! Poll-based SET delivery (RFC 8936).
+//!
+//! A poll-delivery stream's SETs are queued (not pushed); the receiver pulls
+//! them here and acknowledges them. Unlike the stream-management API, the poll
+//! endpoint is **receiver-facing** and authenticates with a per-stream bearer
+//! token (not the tenant JWT), so it must be mounted OUTSIDE the tenant-auth
+//! middleware. The token resolves to its stream + tenant before any
+//! RLS-scoped access — the caller never supplies a tenant id.
+
+use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use xavyo_db::models::{SsfPollToken, SsfQueuedEvent};
+
+use crate::error::SsfApiError;
+use crate::handlers::{tenant_conn, SsfState};
+use crate::models::{PollRequest, PollResponse};
+
+/// Default SETs returned per poll when `maxEvents` is omitted.
+const DEFAULT_MAX_EVENTS: i64 = 100;
+/// Hard cap on a single poll response.
+const MAX_EVENTS_CAP: i64 = 500;
+
+/// Generate a new 256-bit poll bearer token (hex). Returned once to the creator;
+/// only its [`hash_poll_token`] is stored.
+#[must_use]
+pub fn generate_poll_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// SHA-256 (hex) of a poll token — what is stored and compared.
+#[must_use]
+pub fn hash_poll_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// The receiver-facing poll router. Mount OUTSIDE the tenant-auth middleware —
+/// it authenticates with the per-stream bearer token, not a tenant JWT.
+pub fn ssf_poll_router(state: SsfState) -> Router {
+    Router::new().route("/poll", post(poll)).with_state(state)
+}
+
+/// Extract a `Bearer` token from the `Authorization` header.
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+}
+
+/// `POST /ssf/poll` — poll-based SET delivery (RFC 8936 §2.4).
+///
+/// Authenticated by the per-stream poll bearer token. Acks the previous batch
+/// (deleting those `jti`s), then returns up to `maxEvents` of the oldest queued
+/// SETs and whether more remain.
+///
+/// # Errors
+/// [`SsfApiError::Unauthorized`] when the bearer token is missing or unknown;
+/// [`SsfApiError::Database`] on a storage failure.
+pub async fn poll(
+    State(state): State<SsfState>,
+    headers: HeaderMap,
+    Json(req): Json<PollRequest>,
+) -> Result<Json<PollResponse>, SsfApiError> {
+    // 1. Authenticate: hash the presented token, resolve it to stream + tenant.
+    //    The token is the capability; tenant scope comes from the resolution,
+    //    never from caller input.
+    let token = bearer_token(&headers).ok_or(SsfApiError::Unauthorized)?;
+    let resolved = SsfPollToken::resolve(&state.pool, &hash_poll_token(token))
+        .await?
+        .ok_or(SsfApiError::Unauthorized)?;
+    let (tenant_id, stream_id) = (resolved.tenant_id, resolved.stream_id);
+
+    // 2. Set the tenant RLS context for all queue access below.
+    let mut conn = tenant_conn(&state.pool, tenant_id).await?;
+
+    // 3. Ack first (RFC 8936 §2.4: an ack in a poll confirms the prior batch).
+    //    A stale jti is a no-op, so a replayed ack can't delete fresh SETs.
+    if !req.ack.is_empty() {
+        SsfQueuedEvent::ack(&mut *conn, tenant_id, stream_id, &req.ack).await?;
+    }
+
+    // 4. Return the oldest queued SETs (FIFO), bounded by maxEvents.
+    let max = req
+        .max_events
+        .unwrap_or(DEFAULT_MAX_EVENTS)
+        .clamp(1, MAX_EVENTS_CAP);
+    let queued = SsfQueuedEvent::poll(&mut *conn, tenant_id, stream_id, max).await?;
+    let total = SsfQueuedEvent::count_for_stream(&mut *conn, tenant_id, stream_id).await?;
+    let more_available = total > queued.len() as i64;
+
+    let sets = queued.into_iter().map(|e| (e.jti, e.set_jwt)).collect();
+    Ok(Json(PollResponse {
+        sets,
+        more_available,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_is_256_bit_hex_and_unique() {
+        let a = generate_poll_token();
+        let b = generate_poll_token();
+        assert_eq!(a.len(), 64, "32 bytes => 64 hex chars");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b, "tokens must be unique");
+    }
+
+    #[test]
+    fn hash_is_stable_and_differs_from_token() {
+        let token = "deadbeef";
+        let h = hash_poll_token(token);
+        assert_eq!(h, hash_poll_token(token), "hash is deterministic");
+        assert_ne!(h, token, "hash differs from the token");
+        assert_eq!(h.len(), 64, "SHA-256 => 64 hex chars");
+        assert_ne!(
+            hash_poll_token("other"),
+            h,
+            "different inputs hash differently"
+        );
+    }
+
+    #[test]
+    fn bearer_token_parsing() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(bearer_token(&headers), None);
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            "Basic xyz".parse().unwrap(),
+        );
+        assert_eq!(bearer_token(&headers), None);
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            "Bearer tok-123".parse().unwrap(),
+        );
+        assert_eq!(bearer_token(&headers), Some("tok-123"));
+    }
+}

--- a/crates/xavyo-api-ssf/src/transmitter.rs
+++ b/crates/xavyo-api-ssf/src/transmitter.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use reqwest::Client;
 use uuid::Uuid;
-use xavyo_db::models::SsfStream;
+use xavyo_db::models::{SsfQueuedEvent, SsfStream};
 use xavyo_ssf::{CaepEvent, SecurityEventToken, SubjectId};
 
 use crate::ssrf::validate_receiver_url;
@@ -41,6 +41,9 @@ pub enum DeliveryError {
     /// The receiver responded with a non-success status.
     #[error("receiver returned status {0}")]
     Status(u16),
+    /// Enqueuing a SET for poll delivery failed.
+    #[error("failed to queue SET for poll delivery: {0}")]
+    Queue(String),
 }
 
 /// Signs and pushes Security Event Tokens to stream receivers.
@@ -81,6 +84,8 @@ impl SsfTransmitter {
     }
 
     /// Build + sign a SET for `event`/`subject` addressed to `stream`'s receiver.
+    /// Returns `(jti, compact_jws)` — the `jti` is the queue/ack key for poll
+    /// delivery and the SET's identifier for push.
     ///
     /// # Errors
     /// [`DeliveryError::Signing`] if signing fails.
@@ -89,7 +94,7 @@ impl SsfTransmitter {
         stream: &SsfStream,
         subject: &SubjectId,
         event: &CaepEvent,
-    ) -> Result<String, DeliveryError> {
+    ) -> Result<(String, String), DeliveryError> {
         let set = SecurityEventToken::new(
             self.issuer.clone(),
             stream.aud.clone(),
@@ -98,8 +103,10 @@ impl SsfTransmitter {
         );
         let now = chrono::Utc::now().timestamp();
         let jti = Uuid::new_v4().to_string();
-        set.sign(&self.signing_key_pem, &self.kid, now, &jti)
-            .map_err(|e| DeliveryError::Signing(e.to_string()))
+        let jws = set
+            .sign(&self.signing_key_pem, &self.kid, now, &jti)
+            .map_err(|e| DeliveryError::Signing(e.to_string()))?;
+        Ok((jti, jws))
     }
 
     /// POST a signed SET to a receiver endpoint (pure transport — the caller
@@ -159,7 +166,14 @@ impl SsfTransmitter {
 
         let mut outcomes = Vec::with_capacity(streams.len());
         for stream in streams {
-            let outcome = self.emit_one(&stream, subject, event).await;
+            // Poll-delivery streams (RFC 8936) are enqueued for the receiver to
+            // pull; push streams (RFC 8935) are delivered now.
+            let outcome = if stream.delivery_method == crate::models::POLL_DELIVERY_METHOD {
+                self.enqueue_one(pool, tenant_id, &stream, subject, event)
+                    .await
+            } else {
+                self.emit_one(&stream, subject, event).await
+            };
             if let Err(ref e) = outcome {
                 tracing::warn!(
                     target: "ssf",
@@ -173,7 +187,7 @@ impl SsfTransmitter {
         Ok(outcomes)
     }
 
-    /// Validate, sign, and deliver a SET to one stream.
+    /// Validate, sign, and deliver a SET to one push stream.
     async fn emit_one(
         &self,
         stream: &SsfStream,
@@ -185,13 +199,39 @@ impl SsfTransmitter {
         // DNS-rebinding mitigation: a public-looking hostname could resolve to a
         // private address. Resolve now and reject if any resolved IP is non-public.
         assert_endpoint_resolves_public(&stream.endpoint_url).await?;
-        let set_jwt = self.build_set(stream, subject, event)?;
+        let (_jti, set_jwt) = self.build_set(stream, subject, event)?;
         self.deliver(
             &stream.endpoint_url,
             stream.delivery_authorization_header.as_deref(),
             &set_jwt,
         )
         .await
+    }
+
+    /// Sign and enqueue a SET for a poll-delivery stream (RFC 8936). No SSRF
+    /// check — poll delivery never calls out; the receiver pulls. Sets the
+    /// tenant context so the RLS-scoped queue insert is tenant-isolated.
+    async fn enqueue_one(
+        &self,
+        pool: &sqlx::PgPool,
+        tenant_id: Uuid,
+        stream: &SsfStream,
+        subject: &SubjectId,
+        event: &CaepEvent,
+    ) -> Result<(), DeliveryError> {
+        let (jti, set_jwt) = self.build_set(stream, subject, event)?;
+        let mut conn = pool
+            .acquire()
+            .await
+            .map_err(|e| DeliveryError::Queue(e.to_string()))?;
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(tenant_id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| DeliveryError::Queue(e.to_string()))?;
+        SsfQueuedEvent::enqueue(&mut *conn, tenant_id, stream.stream_id, &jti, &set_jwt)
+            .await
+            .map_err(|e| DeliveryError::Queue(e.to_string()))
     }
 }
 

--- a/crates/xavyo-db/migrations/0214_ssf_event_queue.sql
+++ b/crates/xavyo-db/migrations/0214_ssf_event_queue.sql
@@ -1,0 +1,53 @@
+-- Migration: Shared Signals Framework poll-based delivery (RFC 8936)
+--
+-- For poll-delivery streams (delivery_method = urn:ietf:rfc:8936), xavyo does
+-- not push SETs to a receiver endpoint — it queues them here and the receiver
+-- pulls them via POST /ssf/poll, then acknowledges (which deletes them).
+--
+-- The polling receiver authenticates with a per-stream bearer token. Because
+-- the poll request arrives with no tenant context yet, the token is resolved
+-- against `ssf_poll_tokens` (keyed by the token's SHA-256 hash) to recover the
+-- stream + tenant; the handler then sets the tenant context before touching any
+-- RLS-protected table. The lookup table holds no secrets beyond the hash and is
+-- only reachable by presenting the exact high-entropy token, so it is not
+-- RLS-scoped (it is the thing that establishes which tenant a poll belongs to).
+
+-- Per-stream poll bearer-token resolution (token hash -> stream + tenant).
+CREATE TABLE IF NOT EXISTS ssf_poll_tokens (
+    -- SHA-256 hex of the per-stream poll bearer token.
+    token_hash TEXT PRIMARY KEY,
+    stream_id UUID NOT NULL REFERENCES ssf_streams(stream_id) ON DELETE CASCADE,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ssf_poll_tokens_stream
+    ON ssf_poll_tokens(stream_id);
+
+CREATE TABLE IF NOT EXISTS ssf_event_queue (
+    -- The SET's jti — also the acknowledgement key (RFC 8936 §2.4).
+    jti TEXT PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    stream_id UUID NOT NULL REFERENCES ssf_streams(stream_id) ON DELETE CASCADE,
+    -- The signed compact JWS, served verbatim to the polling receiver.
+    set_jwt TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- FIFO poll: oldest-first within a stream.
+CREATE INDEX IF NOT EXISTS idx_ssf_event_queue_stream
+    ON ssf_event_queue(tenant_id, stream_id, created_at);
+
+-- Row-Level Security: tenant isolation on the queue (same shape as ssf_streams).
+-- (ssf_poll_tokens is intentionally NOT RLS-scoped — it is the pre-tenant-context
+--  credential-resolution table, only reachable with the exact token hash.)
+ALTER TABLE ssf_event_queue ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ssf_event_queue FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_policy ON ssf_event_queue;
+CREATE POLICY tenant_isolation_policy ON ssf_event_queue
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+COMMENT ON TABLE ssf_event_queue IS 'Queued Security Event Tokens for poll-based delivery (RFC 8936); tenant-scoped, served until acked';
+COMMENT ON TABLE ssf_poll_tokens IS 'Per-stream poll bearer-token resolution (token hash -> stream + tenant); pre-tenant-context credential lookup, not RLS-scoped';

--- a/crates/xavyo-db/src/models/mod.rs
+++ b/crates/xavyo-db/src/models/mod.rs
@@ -954,8 +954,8 @@ pub use client_assertion_jti::ClientAssertionJti;
 
 // Shared Signals Framework exports (OpenID SSF 1.0)
 pub use ssf::{
-    CreateSsfStream, SsfStream, SsfSubject, STREAM_STATUS_DISABLED, STREAM_STATUS_ENABLED,
-    STREAM_STATUS_PAUSED,
+    CreateSsfStream, SsfPollToken, SsfQueuedEvent, SsfStream, SsfSubject, STREAM_STATUS_DISABLED,
+    STREAM_STATUS_ENABLED, STREAM_STATUS_PAUSED,
 };
 
 // Pushed Authorization Requests export (RFC 9126)

--- a/crates/xavyo-db/src/models/ssf.rs
+++ b/crates/xavyo-db/src/models/ssf.rs
@@ -291,3 +291,195 @@ impl SsfSubject {
         .await
     }
 }
+
+/// A signed SET queued for poll-based delivery (RFC 8936). Rows live until the
+/// receiver acknowledges them on a subsequent poll.
+#[derive(Debug, Clone, FromRow)]
+pub struct SsfQueuedEvent {
+    /// The SET's `jti` — also the acknowledgement key.
+    pub jti: String,
+    /// Tenant isolation (RLS-enforced).
+    pub tenant_id: Uuid,
+    /// The stream this SET is queued for.
+    pub stream_id: Uuid,
+    /// The signed compact JWS, served verbatim to the receiver.
+    pub set_jwt: String,
+    /// Enqueue timestamp (FIFO ordering).
+    pub created_at: DateTime<Utc>,
+}
+
+impl SsfQueuedEvent {
+    /// Enqueue a signed SET for poll delivery. Idempotent on `jti`.
+    ///
+    /// # Errors
+    /// Propagates the underlying `sqlx` error.
+    pub async fn enqueue<'e, E>(
+        executor: E,
+        tenant_id: Uuid,
+        stream_id: Uuid,
+        jti: &str,
+        set_jwt: &str,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+    {
+        sqlx::query(
+            r"
+            INSERT INTO ssf_event_queue (jti, tenant_id, stream_id, set_jwt)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (jti) DO NOTHING
+            ",
+        )
+        .bind(jti)
+        .bind(tenant_id)
+        .bind(stream_id)
+        .bind(set_jwt)
+        .execute(executor)
+        .await?;
+        Ok(())
+    }
+
+    /// Fetch up to `max_events` oldest queued SETs for a stream (FIFO). SETs stay
+    /// queued until acked (RFC 8936 §2.4), so repeated polls without an ack
+    /// return the same batch.
+    ///
+    /// # Errors
+    /// Propagates the underlying `sqlx` error.
+    pub async fn poll<'e, E>(
+        executor: E,
+        tenant_id: Uuid,
+        stream_id: Uuid,
+        max_events: i64,
+    ) -> Result<Vec<Self>, sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+    {
+        sqlx::query_as(
+            r"
+            SELECT * FROM ssf_event_queue
+            WHERE tenant_id = $1 AND stream_id = $2
+            ORDER BY created_at
+            LIMIT $3
+            ",
+        )
+        .bind(tenant_id)
+        .bind(stream_id)
+        .bind(max_events)
+        .fetch_all(executor)
+        .await
+    }
+
+    /// Acknowledge (delete) the given `jti`s for a stream. A stale `jti` is a
+    /// no-op (a fresh SET has a new `jti`). Returns the number of rows removed.
+    ///
+    /// # Errors
+    /// Propagates the underlying `sqlx` error.
+    pub async fn ack<'e, E>(
+        executor: E,
+        tenant_id: Uuid,
+        stream_id: Uuid,
+        jtis: &[String],
+    ) -> Result<u64, sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+    {
+        if jtis.is_empty() {
+            return Ok(0);
+        }
+        let result = sqlx::query(
+            r"
+            DELETE FROM ssf_event_queue
+            WHERE tenant_id = $1 AND stream_id = $2 AND jti = ANY($3)
+            ",
+        )
+        .bind(tenant_id)
+        .bind(stream_id)
+        .bind(jtis)
+        .execute(executor)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Total queued SETs for a stream — used to compute `moreAvailable`.
+    ///
+    /// # Errors
+    /// Propagates the underlying `sqlx` error.
+    pub async fn count_for_stream<'e, E>(
+        executor: E,
+        tenant_id: Uuid,
+        stream_id: Uuid,
+    ) -> Result<i64, sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+    {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM ssf_event_queue WHERE tenant_id = $1 AND stream_id = $2",
+        )
+        .bind(tenant_id)
+        .bind(stream_id)
+        .fetch_one(executor)
+        .await?;
+        Ok(row.0)
+    }
+}
+
+/// Resolves a poll bearer token (by its hash) to the stream + tenant it grants
+/// access to. This is the pre-tenant-context credential lookup for RFC 8936
+/// polls: the receiver presents a token, this recovers the tenant, then the
+/// handler sets the tenant context for the RLS-scoped queue access.
+#[derive(Debug, Clone, FromRow)]
+pub struct SsfPollToken {
+    /// SHA-256 hex of the per-stream poll bearer token.
+    pub token_hash: String,
+    /// The stream this token grants poll access to.
+    pub stream_id: Uuid,
+    /// The tenant the stream belongs to.
+    pub tenant_id: Uuid,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+impl SsfPollToken {
+    /// Register a poll token hash for a stream (called at poll-stream creation).
+    ///
+    /// # Errors
+    /// Propagates the underlying `sqlx` error.
+    pub async fn create<'e, E>(
+        executor: E,
+        token_hash: &str,
+        stream_id: Uuid,
+        tenant_id: Uuid,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+    {
+        sqlx::query(
+            r"
+            INSERT INTO ssf_poll_tokens (token_hash, stream_id, tenant_id)
+            VALUES ($1, $2, $3)
+            ",
+        )
+        .bind(token_hash)
+        .bind(stream_id)
+        .bind(tenant_id)
+        .execute(executor)
+        .await?;
+        Ok(())
+    }
+
+    /// Resolve a presented token hash to its stream + tenant. No tenant context
+    /// is required (this table is not RLS-scoped — it is the resolution itself).
+    /// Returns `None` for an unknown token.
+    ///
+    /// # Errors
+    /// Propagates the underlying `sqlx` error.
+    pub async fn resolve<'e, E>(executor: E, token_hash: &str) -> Result<Option<Self>, sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+    {
+        sqlx::query_as("SELECT * FROM ssf_poll_tokens WHERE token_hash = $1")
+            .bind(token_hash)
+            .fetch_optional(executor)
+            .await
+    }
+}

--- a/docs/crates/maturity-matrix.md
+++ b/docs/crates/maturity-matrix.md
@@ -94,7 +94,7 @@ Criteria:
 | xavyo-api-import | 🟢 stable | 92+ | 45+ | Full integration test coverage |
 | xavyo-api-oidc-federation | 🟡 beta | 13 | 16 | Insufficient coverage |
 | xavyo-api-nhi | 🟢 stable | 77 | 33 | Complete with risk scoring, F-047 & F-048 |
-| xavyo-api-ssf | 🔴 alpha | 16 | 43 | SSF transmitter + SSRF guard, no integration tests |
+| xavyo-api-ssf | 🔴 alpha | 20 | 50 | SSF push + poll (RFC 8936) delivery + SSRF guard, no integration tests |
 
 ---
 


### PR DESCRIPTION
## What

Adds the firewall-friendly half of the SSF transport — **poll-based SET delivery (RFC 8936)**. Receivers that can't host an inbound push endpoint (most enterprise RPs) pull queued Security Event Tokens instead. Completes task #54 item 3 per the design spec (`docs/superpowers/specs/2026-05-25-ssf-poll-delivery-design.md`).

**Flow:** a CAEP event for a poll-delivery stream (`delivery_method = urn:ietf:rfc:8936`) enqueues the signed SET rather than pushing it; the receiver `POST`s `/ssf/poll` to ack the prior batch and pull the next, until acked.

## Security (the key design decision)

The poll endpoint is **receiver-facing** and authenticates with a **per-stream bearer token**, not the tenant JWT:
- Token minted once at poll-stream creation (256-bit, returned once); only its **SHA-256 hash** is stored.
- A dedicated **`ssf_poll_tokens`** table resolves `token → (stream, tenant)` *before* any tenant context is set — solving the RLS chicken-and-egg (you can't read the RLS-scoped `ssf_streams` without a tenant, and you don't have one until you resolve the token). Tenant scope is derived from the resolved stream, **never from caller input**.
- The poll router is `.merge()`d **after** the tenant-auth layers, so those layers don't apply to it.
- **Ack-first** ordering (RFC 8936 §2.4); a stale `jti` ack is a no-op, so a replayed ack can't delete fresh SETs.

## Changes

- **xavyo-db**: migration `0214` (`ssf_event_queue` RLS-scoped + `ssf_poll_tokens` resolution table); `SsfQueuedEvent` (enqueue/poll/ack/count) + `SsfPollToken` (create/resolve) — runtime queries, no `.sqlx` regen.
- **xavyo-api-ssf**: `poll` module (token gen/hash, `POST /ssf/poll`, `ssf_poll_router`); transmitter branches push vs. enqueue; `build_set` → `(jti, jws)`; `create_stream` mints the token; well-known config advertises poll; `SsfApiError::Unauthorized` (401).
- **idp-api**: poll router merged into `/ssf` after the tenant-auth layers.

## Verification

- `cargo +1.95.0 clippy -p xavyo-db -p xavyo-api-ssf -p idp-api --all-targets -- -D warnings` clean.
- 20 api-ssf unit tests pass (token hashing/parsing, validation, metadata).
- Live SET-delivery integration tests → task #54 item 8 (needs a test DB). Long-poll (`returnImmediately=false`) + a queue-TTL janitor are noted follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)