### PR TITLE
fix(dpop): make the proof-replay-cache vacuum actually run + prune

### DIFF
--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -1604,6 +1604,36 @@ async fn main() {
         });
     }
 
+    // Spawn background vacuum for the DPoP proof-replay cache (RFC 9449 §11.1).
+    // Rows are only useful for the ~120s proof-acceptance window; expired rows
+    // are pruned by migration 0215's permissive expiry policy.
+    {
+        let cleanup_pool = pool.clone();
+        tokio::spawn(async move {
+            let interval = Duration::from_secs(15 * 60); // 15 minutes
+            loop {
+                tokio::time::sleep(interval).await;
+                match xavyo_db::models::DpopProofJti::cleanup_expired(&cleanup_pool).await {
+                    Ok(count) if count > 0 => {
+                        tracing::info!(
+                            target: "security",
+                            deleted = count,
+                            "Vacuumed expired DPoP proof-replay records"
+                        );
+                    }
+                    Ok(_) => {} // Nothing to clean
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "security",
+                            error = %e,
+                            "Failed to vacuum expired DPoP proof-replay records"
+                        );
+                    }
+                }
+            }
+        });
+    }
+
     // Spawn background cleanup task for expired passwordless tokens (F079)
     {
         let cleanup_pool = pool.clone();

--- a/crates/xavyo-db/migrations/0215_dpop_proof_jtis_cleanup_policy.sql
+++ b/crates/xavyo-db/migrations/0215_dpop_proof_jtis_cleanup_policy.sql
@@ -1,0 +1,23 @@
+-- Migration: make the DPoP replay-cache vacuum actually work under FORCE RLS.
+--
+-- dpop_proof_jtis is FORCE ROW LEVEL SECURITY with a tenant-isolation policy
+-- (USING tenant_id = current_setting('app.current_tenant', true)). The periodic
+-- vacuum (DpopProofJti::cleanup_expired) runs with NO tenant context, so under
+-- that policy `tenant_id = NULL` matches nothing and the DELETE prunes nothing —
+-- the replay cache grows unbounded.
+--
+-- Fix: add a second (permissive) DELETE policy that allows removing rows whose
+-- proof-acceptance window has already lapsed, regardless of tenant. This is
+-- safe: an EXPIRED jti carries no replay-protection value (a proof whose `iat`
+-- is past the acceptance window is independently rejected by the freshness
+-- check), so pruning expired rows — even cross-tenant — has no security effect.
+-- RLS policies are permissive (OR-combined), so tenant isolation for live rows
+-- is unchanged; only already-expired rows become deletable by the vacuum.
+
+DROP POLICY IF EXISTS expired_cleanup_policy ON dpop_proof_jtis;
+CREATE POLICY expired_cleanup_policy ON dpop_proof_jtis
+    FOR DELETE
+    USING (expires_at < now());
+
+COMMENT ON POLICY expired_cleanup_policy ON dpop_proof_jtis IS
+    'Permits the tenant-less periodic vacuum to delete already-expired replay-cache rows (expired jtis carry no replay-protection value); tenant isolation for live rows is unchanged';


### PR DESCRIPTION
## What

The DPoP proof-replay cache (`dpop_proof_jtis`) grew **unbounded** on two counts (found while scoping the SSF poll-queue TTL janitor):

1. `DpopProofJti::cleanup_expired` was **never scheduled** — no caller existed.
2. Even if called it was a **no-op**: the table is `FORCE ROW LEVEL SECURITY` with a tenant-isolation policy, and the vacuum runs with **no tenant context**, so `tenant_id = current_setting('app.current_tenant', true)` matched no rows.

## Fix

- **Migration 0215** adds a permissive `FOR DELETE USING (expires_at < now())` policy so the tenant-less vacuum can prune expired rows. **Safe**: an expired `jti` carries no replay-protection value (a proof past its acceptance window is independently rejected by the `iat` freshness check), so pruning expired rows — even cross-tenant — has no security effect. RLS policies are OR-combined, so isolation for *live* rows is unchanged.
- **idp-api** spawns a 15-minute background vacuum calling `cleanup_expired`, mirroring the existing revoked-token / passwordless cleanup tasks.

## Audit

`dpop_proof_jtis` is the **only** FORCE-RLS table with a tenant-less expiry cleanup. The other `delete_expired` tables (`revoked_tokens`, `passwordless_tokens`, `webauthn_challenges`, `connector_schemas`, `federated_auth_sessions`, `gov_generated_reports`, `siem_batch_exports`) are ENABLE-only RLS, so their owner-run vacuum already works. (The new `ssf_event_queue` is FORCE-RLS but has no janitor yet — a noted follow-up needing a cross-tenant-safe TTL approach.)

## Verification

`cargo +1.95.0 clippy -p idp-api --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)