### PR TITLE
feat(ssf): bound the poll-delivery queue with an enqueue-time TTL

### DIFF
--- a/crates/xavyo-api-ssf/src/transmitter.rs
+++ b/crates/xavyo-api-ssf/src/transmitter.rs
@@ -26,6 +26,12 @@ const SET_CONTENT_TYPE: &str = "application/secevent+jwt";
 /// Per-delivery HTTP timeout.
 const DELIVERY_TIMEOUT_SECS: u64 = 10;
 
+/// TTL for queued poll-delivery SETs (RFC 8936). A receiver that stops polling
+/// leaves its queue to accumulate; pruning at enqueue bounds growth so an
+/// abandoned stream cannot grow without limit. 7 days is generous for a receiver
+/// that is merely offline for a while.
+const QUEUE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+
 /// Errors from SET delivery.
 #[derive(Debug, thiserror::Error)]
 pub enum DeliveryError {
@@ -231,7 +237,35 @@ impl SsfTransmitter {
             .map_err(|e| DeliveryError::Queue(e.to_string()))?;
         SsfQueuedEvent::enqueue(&mut *conn, tenant_id, stream.stream_id, &jti, &set_jwt)
             .await
-            .map_err(|e| DeliveryError::Queue(e.to_string()))
+            .map_err(|e| DeliveryError::Queue(e.to_string()))?;
+
+        // TTL safety net: bound the queue for a stream whose receiver has stopped
+        // polling. Best-effort — the SET is already enqueued, so a prune failure
+        // must not fail the emit; just log it.
+        let cutoff = chrono::Utc::now() - chrono::Duration::seconds(QUEUE_TTL_SECS);
+        match SsfQueuedEvent::prune_stream_older_than(
+            &mut *conn,
+            tenant_id,
+            stream.stream_id,
+            cutoff,
+        )
+        .await
+        {
+            Ok(n) if n > 0 => tracing::info!(
+                target: "ssf",
+                stream_id = %stream.stream_id,
+                pruned = n,
+                "pruned expired queued SETs"
+            ),
+            Ok(_) => {}
+            Err(e) => tracing::warn!(
+                target: "ssf",
+                stream_id = %stream.stream_id,
+                error = %e,
+                "failed to prune expired queued SETs (non-fatal)"
+            ),
+        }
+        Ok(())
     }
 }
 

--- a/crates/xavyo-db/src/models/ssf.rs
+++ b/crates/xavyo-db/src/models/ssf.rs
@@ -400,6 +400,36 @@ impl SsfQueuedEvent {
         Ok(result.rows_affected())
     }
 
+    /// Prune a stream's queued SETs older than `cutoff` (a TTL safety net for
+    /// abandoned streams the receiver stops polling). Tenant-scoped: the caller
+    /// has the tenant RLS context set, so this only touches the given stream.
+    /// Returns the number of rows removed.
+    ///
+    /// # Errors
+    /// Propagates the underlying `sqlx` error.
+    pub async fn prune_stream_older_than<'e, E>(
+        executor: E,
+        tenant_id: Uuid,
+        stream_id: Uuid,
+        cutoff: DateTime<Utc>,
+    ) -> Result<u64, sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+    {
+        let result = sqlx::query(
+            r"
+            DELETE FROM ssf_event_queue
+            WHERE tenant_id = $1 AND stream_id = $2 AND created_at < $3
+            ",
+        )
+        .bind(tenant_id)
+        .bind(stream_id)
+        .bind(cutoff)
+        .execute(executor)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     /// Total queued SETs for a stream — used to compute `moreAvailable`.
     ///
     /// # Errors


### PR DESCRIPTION
## What

Closes the unbounded-growth gap noted in the SSF poll-delivery work (#89): a poll-delivery stream whose receiver stops polling would let its queued SETs accumulate without limit.

## Approach (the clean, RLS-safe one)

Prune at **enqueue time**, where the tenant RLS context is already set — so:
- **No background sweep** and **no cross-tenant RLS-maintenance problem.** A tenant-less janitor on the FORCE-RLS `ssf_event_queue` would prune nothing (same class of bug just fixed for `dpop_proof_jtis` in #90), and a permissive expiry policy would risk one tenant deleting another's *undelivered* SETs (data loss, unlike harmless expired replay-cache rows). Enqueue-time pruning sidesteps both.

After enqueuing a SET, prune that stream's entries older than a **7-day TTL** (`SsfQueuedEvent::prune_stream_older_than`). Best-effort: the SET is already queued, so a prune failure is logged, not surfaced. Active streams self-prune on each enqueue; an abandoned stream stops growing (no further enqueues) — so the queue is bounded either way.

## Verification

- `cargo +1.95.0 clippy -p xavyo-db -p xavyo-api-ssf --all-targets -- -D warnings` clean.
- 20 api-ssf unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)