### PR TITLE
feat(ssf): stream verification event (SSF §7.1.4)

### DIFF
--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -370,7 +370,7 @@ async fn main() {
         .expect("failed to build SSF transmitter"),
     );
     let ssf_emitter = Arc::new(SsfStreamEmitter::new(
-        ssf_transmitter,
+        ssf_transmitter.clone(),
         pool.clone(),
         config.issuer_url.clone(),
     ));
@@ -774,6 +774,7 @@ async fn main() {
     let ssf_state = SsfState {
         pool: pool.clone(),
         issuer: config.issuer_url.clone(),
+        transmitter: ssf_transmitter.clone(),
     };
     let ssf_routes = ssf_router(ssf_state.clone())
         .layer(axum::middleware::from_fn(jwt_auth_middleware))

--- a/crates/xavyo-api-ssf/CRATE.md
+++ b/crates/xavyo-api-ssf/CRATE.md
@@ -16,7 +16,7 @@ api
 
 🔴 **alpha**
 
-20 unit tests (SSRF guard, model serialization, transmitter SET building, poll token hashing/parsing). Push (RFC 8935) and poll (RFC 8936) delivery are both implemented; verification events (SSF §7.1.4) and a queue-TTL janitor are not. No HTTP+Postgres integration tests yet — API will change.
+20 unit tests (SSRF guard, model serialization, transmitter SET building, poll token hashing/parsing). Push (RFC 8935) + poll (RFC 8936) delivery, the poll-queue TTL bound, and stream-verification events (SSF §7.1.4) are all implemented (the verification event payload is tested in `xavyo-ssf`). No HTTP+Postgres integration tests yet — API will change.
 
 ## Dependencies
 
@@ -43,6 +43,7 @@ api
 ///   GET/POST  /status           stream status
 ///   POST      /subjects:add     add a subject to a stream
 ///   POST      /subjects:remove  remove a subject from a stream
+///   POST      /verify           request a stream-verification event (SSF §7.1.4)
 pub fn ssf_router() -> Router<SsfState>;
 
 /// Poll-based delivery (RFC 8936). Receiver-facing — authenticates with the

--- a/crates/xavyo-api-ssf/src/handlers.rs
+++ b/crates/xavyo-api-ssf/src/handlers.rs
@@ -14,12 +14,12 @@ use sqlx::pool::PoolConnection;
 use sqlx::Postgres;
 use xavyo_core::TenantId;
 use xavyo_db::models::{CreateSsfStream, SsfPollToken, SsfStream, SsfSubject};
-use xavyo_ssf::{CREDENTIAL_CHANGE_URI, SESSION_REVOKED_URI};
+use xavyo_ssf::{CaepEvent, SubjectId, CREDENTIAL_CHANGE_URI, SESSION_REVOKED_URI};
 
 use crate::error::SsfApiError;
 use crate::models::{
     CreateStreamRequest, SsfConfigurationMetadata, StatusResponse, StreamIdQuery, StreamResponse,
-    SubjectRequest, UpdateStatusRequest,
+    SubjectRequest, UpdateStatusRequest, VerifyRequest,
 };
 
 /// Shared state for the SSF API.
@@ -29,6 +29,9 @@ pub struct SsfState {
     pub pool: sqlx::PgPool,
     /// Transmitter issuer identifier (stamped into metadata + responses).
     pub issuer: String,
+    /// SET signer/deliverer — used to send stream-verification events (SSF
+    /// §7.1.4) on demand (the CAEP fan-out uses its own emitter copy).
+    pub transmitter: std::sync::Arc<crate::transmitter::SsfTransmitter>,
 }
 
 /// CAEP event types this transmitter can actually deliver (v1).
@@ -103,6 +106,35 @@ pub async fn create_stream(
     };
 
     Ok((StatusCode::CREATED, Json(response)))
+}
+
+/// `POST /ssf/verify` — request a stream-verification event (SSF §7.1.4).
+///
+/// Admin-triggered via the tenant-authed management API: sends a verification
+/// SET to the stream (pushed for RFC 8935 streams, queued for RFC 8936), which
+/// the receiver echoes back to confirm it can receive and process SETs.
+pub async fn verify_stream(
+    State(state): State<SsfState>,
+    Extension(tenant_id): Extension<TenantId>,
+    Json(req): Json<VerifyRequest>,
+) -> Result<StatusCode, SsfApiError> {
+    let tenant = *tenant_id.as_uuid();
+    let stream = {
+        let mut conn = tenant_conn(&state.pool, tenant).await?;
+        SsfStream::get(&mut *conn, tenant, req.stream_id)
+            .await?
+            .ok_or(SsfApiError::StreamNotFound)?
+    };
+
+    let subject = SubjectId::iss_sub(state.issuer.clone(), stream.stream_id.to_string());
+    let event = CaepEvent::Verification { state: req.state };
+    state
+        .transmitter
+        .send_one(&state.pool, tenant, &stream, &subject, &event)
+        .await
+        .map_err(|e| SsfApiError::Internal(e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// `GET /ssf/streams` — list the tenant's streams.

--- a/crates/xavyo-api-ssf/src/models.rs
+++ b/crates/xavyo-api-ssf/src/models.rs
@@ -156,6 +156,16 @@ pub struct PollResponse {
     pub more_available: bool,
 }
 
+/// Body for `POST /ssf/verify` — request a stream-verification event (SSF §7.1.4).
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct VerifyRequest {
+    /// The stream to send the verification event to.
+    pub stream_id: Uuid,
+    /// Optional opaque value the receiver echoes back to correlate the check.
+    #[serde(default)]
+    pub state: Option<String>,
+}
+
 /// Body for `POST /ssf/status` (update stream status).
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateStatusRequest {
@@ -220,6 +230,8 @@ pub struct SsfConfigurationMetadata {
     pub add_subject_endpoint: String,
     /// Remove-subject endpoint.
     pub remove_subject_endpoint: String,
+    /// Stream-verification endpoint (SSF §7.1.4).
+    pub verification_endpoint: String,
 }
 
 impl SsfConfigurationMetadata {
@@ -238,6 +250,7 @@ impl SsfConfigurationMetadata {
             status_endpoint: format!("{base}/ssf/status"),
             add_subject_endpoint: format!("{base}/ssf/subjects:add"),
             remove_subject_endpoint: format!("{base}/ssf/subjects:remove"),
+            verification_endpoint: format!("{base}/ssf/verify"),
         }
     }
 }

--- a/crates/xavyo-api-ssf/src/router.rs
+++ b/crates/xavyo-api-ssf/src/router.rs
@@ -11,7 +11,7 @@ use axum::{
 
 use crate::handlers::{
     add_subject, create_stream, delete_stream, get_status, get_stream, list_streams,
-    remove_subject, ssf_configuration, update_status, SsfState,
+    remove_subject, ssf_configuration, update_status, verify_stream, SsfState,
 };
 
 /// Stream-management router. Mount at `/ssf` behind auth + `Extension<TenantId>`.
@@ -20,6 +20,7 @@ use crate::handlers::{
 /// - `GET /ssf/stream?stream_id=…` read · `DELETE /ssf/stream?stream_id=…` delete
 /// - `GET /ssf/status?stream_id=…` · `POST /ssf/status` (update)
 /// - `POST /ssf/subjects:add` · `POST /ssf/subjects:remove`
+/// - `POST /ssf/verify` request a stream-verification event (SSF §7.1.4)
 pub fn ssf_router(state: SsfState) -> Router {
     Router::new()
         .route("/streams", post(create_stream).get(list_streams))
@@ -27,6 +28,7 @@ pub fn ssf_router(state: SsfState) -> Router {
         .route("/status", get(get_status).post(update_status))
         .route("/subjects:add", post(add_subject))
         .route("/subjects:remove", post(remove_subject))
+        .route("/verify", post(verify_stream))
         .with_state(state)
 }
 

--- a/crates/xavyo-api-ssf/src/transmitter.rs
+++ b/crates/xavyo-api-ssf/src/transmitter.rs
@@ -172,14 +172,9 @@ impl SsfTransmitter {
 
         let mut outcomes = Vec::with_capacity(streams.len());
         for stream in streams {
-            // Poll-delivery streams (RFC 8936) are enqueued for the receiver to
-            // pull; push streams (RFC 8935) are delivered now.
-            let outcome = if stream.delivery_method == crate::models::POLL_DELIVERY_METHOD {
-                self.enqueue_one(pool, tenant_id, &stream, subject, event)
-                    .await
-            } else {
-                self.emit_one(&stream, subject, event).await
-            };
+            let outcome = self
+                .send_one(pool, tenant_id, &stream, subject, event)
+                .await;
             if let Err(ref e) = outcome {
                 tracing::warn!(
                     target: "ssf",
@@ -191,6 +186,30 @@ impl SsfTransmitter {
             outcomes.push((stream.stream_id, outcome));
         }
         Ok(outcomes)
+    }
+
+    /// Deliver one SET to one stream, choosing transport by the stream's
+    /// delivery method: push (RFC 8935) delivers now; poll (RFC 8936) enqueues
+    /// for the receiver to pull. Used by the CAEP fan-out ([`Self::emit`]) and
+    /// the verification path.
+    ///
+    /// # Errors
+    /// [`DeliveryError`] on a blocked endpoint, signing, transport, or queue
+    /// failure for this stream.
+    pub async fn send_one(
+        &self,
+        pool: &sqlx::PgPool,
+        tenant_id: Uuid,
+        stream: &SsfStream,
+        subject: &SubjectId,
+        event: &CaepEvent,
+    ) -> Result<(), DeliveryError> {
+        if stream.delivery_method == crate::models::POLL_DELIVERY_METHOD {
+            self.enqueue_one(pool, tenant_id, stream, subject, event)
+                .await
+        } else {
+            self.emit_one(stream, subject, event).await
+        }
     }
 
     /// Validate, sign, and deliver a SET to one push stream.

--- a/crates/xavyo-ssf/CRATE.md
+++ b/crates/xavyo-ssf/CRATE.md
@@ -16,7 +16,7 @@ domain
 
 🔴 **alpha**
 
-15 unit tests covering event payloads, subject-identifier serialization, and SET signing. The API will change as receiver-side integration (poll delivery, verification events) lands. Don't depend on signatures yet.
+16 unit tests covering event payloads (incl. the SSF `verification` event), subject-identifier serialization, and SET signing. Don't depend on signatures yet — the API will still change.
 
 ## Dependencies
 

--- a/crates/xavyo-ssf/src/events.rs
+++ b/crates/xavyo-ssf/src/events.rs
@@ -2,9 +2,11 @@
 //!
 //! Each event is carried in the SET's `events` claim as a single-entry map
 //! `{ "<type-uri>": { <payload> } }`. Every CAEP event payload carries an
-//! `event_timestamp` (NumericDate, seconds — CAEP §3.1). v1 ships the two
-//! events xavyo can emit from existing flows: `session-revoked` and
-//! `credential-change`.
+//! `event_timestamp` (NumericDate, seconds — CAEP §3.1).
+//!
+//! Note: [`CaepEvent`] also carries the SSF management event `Verification`
+//! (SSF §7.1.4), which is not a CAEP event and has no `event_timestamp`; the
+//! enum name predates SSF support. Renaming is a follow-up.
 
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +29,11 @@ pub const ASSURANCE_LEVEL_CHANGE_URI: &str =
 /// CAEP `device-compliance-change` event type URI.
 pub const DEVICE_COMPLIANCE_CHANGE_URI: &str =
     "https://schemas.openid.net/secevent/caep/event-type/device-compliance-change";
+
+/// SSF `verification` event type URI (SSF §7.1.4) — a stream-health check, not
+/// a CAEP event.
+pub const VERIFICATION_URI: &str =
+    "https://schemas.openid.net/secevent/ssf/event-type/verification";
 
 /// The kind of credential change (CAEP §3.4 `change_type`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -90,6 +97,13 @@ pub enum CaepEvent {
         /// Prior status, if known.
         previous_status: Option<String>,
     },
+    /// SSF §7.1.4 — a stream-health verification event. The receiver echoes the
+    /// optional `state` back, confirming it can receive and process SETs. Not a
+    /// CAEP event: it carries no `event_timestamp`.
+    Verification {
+        /// Opaque value the receiver echoes back to correlate the check.
+        state: Option<String>,
+    },
 }
 
 impl CaepEvent {
@@ -102,6 +116,7 @@ impl CaepEvent {
             CaepEvent::TokenClaimsChange { .. } => TOKEN_CLAIMS_CHANGE_URI,
             CaepEvent::AssuranceLevelChange { .. } => ASSURANCE_LEVEL_CHANGE_URI,
             CaepEvent::DeviceComplianceChange { .. } => DEVICE_COMPLIANCE_CHANGE_URI,
+            CaepEvent::Verification { .. } => VERIFICATION_URI,
         }
     }
 
@@ -163,6 +178,13 @@ impl CaepEvent {
                 obj.insert("current_status".into(), current_status.clone().into());
                 if let Some(p) = previous_status {
                     obj.insert("previous_status".into(), p.clone().into());
+                }
+                serde_json::Value::Object(obj)
+            }
+            CaepEvent::Verification { state } => {
+                let mut obj = serde_json::Map::new();
+                if let Some(s) = state {
+                    obj.insert("state".into(), s.clone().into());
                 }
                 serde_json::Value::Object(obj)
             }
@@ -251,5 +273,19 @@ mod tests {
             e.payload(),
             json!({"event_timestamp": 9, "current_status": "not-compliant", "previous_status": "compliant"})
         );
+    }
+
+    #[test]
+    fn verification_payload_with_and_without_state() {
+        let with = CaepEvent::Verification {
+            state: Some("abc123".into()),
+        };
+        assert_eq!(with.type_uri(), VERIFICATION_URI);
+        assert_eq!(with.payload(), json!({ "state": "abc123" }));
+
+        let without = CaepEvent::Verification { state: None };
+        assert_eq!(without.type_uri(), VERIFICATION_URI);
+        // No state, no event_timestamp — an empty object.
+        assert_eq!(without.payload(), json!({}));
     }
 }

--- a/crates/xavyo-ssf/src/lib.rs
+++ b/crates/xavyo-ssf/src/lib.rs
@@ -24,7 +24,7 @@ pub mod subject;
 pub use emitter::{CaepEmitter, NoopEmitter};
 pub use events::{
     CaepEvent, CredentialChangeType, ASSURANCE_LEVEL_CHANGE_URI, CREDENTIAL_CHANGE_URI,
-    DEVICE_COMPLIANCE_CHANGE_URI, SESSION_REVOKED_URI, TOKEN_CLAIMS_CHANGE_URI,
+    DEVICE_COMPLIANCE_CHANGE_URI, SESSION_REVOKED_URI, TOKEN_CLAIMS_CHANGE_URI, VERIFICATION_URI,
 };
 pub use set::{SecurityEventToken, SsfError, SET_TYP};
 pub use subject::SubjectId;

--- a/docs/crates/maturity-matrix.md
+++ b/docs/crates/maturity-matrix.md
@@ -62,7 +62,7 @@ Criteria:
 | xavyo-authorization | 🟢 stable | 76 | 16 | Foundation only |
 | xavyo-webhooks | 🟡 beta | 59 | 31 | Needs integration tests |
 | xavyo-siem | 🟡 beta | 115 | 47 | Good coverage, no integration tests |
-| xavyo-ssf | 🔴 alpha | 15 | 23 | CAEP/SSF SET signing + emitter, no integration tests |
+| xavyo-ssf | 🔴 alpha | 16 | 24 | CAEP/SSF SET signing + emitter (incl. SSF verification event), no integration tests |
 | xavyo-secrets | 🟢 stable | 51 | 28 | Multi-provider (Vault, AWS) |
 | xavyo-scim-client | 🟢 stable | 150+ | 24 | Full integration test coverage |
 | xavyo-scim-types | 🟢 stable | 9 | 17 | Pure SCIM 2.0 DTOs (RFC 7643/7644); RFC-pinned shape |


### PR DESCRIPTION
## What

Completes the SSF transmitter surface with the **stream verification event (SSF §7.1.4)**. An admin requests a verification SET for a stream (`POST /ssf/verify`); the receiver echoes the optional `state` back, confirming it can receive and process SETs — the standard SSF stream-health check.

## Changes

- **xavyo-ssf**: `CaepEvent::Verification { state }` + `VERIFICATION_URI`; `type_uri`/`payload` arms. Payload is `{}` or `{"state": ...}` — no `event_timestamp` (it's an SSF management event, not CAEP). A module-doc note acknowledges the enum now carries a non-CAEP event despite its name (rename is a follow-up). +unit test.
- **xavyo-api-ssf**: `POST /ssf/verify` on the **tenant-authed management router** (not the receiver-facing poll router — verification is admin-triggered). Loads the stream, builds a verification SET with subject `iss_sub(issuer, stream_id)`, and sends it via the stream's delivery method (push or enqueue). The push-vs-poll branch is extracted from `emit` into a public `send_one`, used by both the CAEP fan-out and verify. `SsfState` gains the transmitter; config metadata advertises `verification_endpoint`.
- **idp-api**: `SsfState` wired with the shared `ssf_transmitter` (Arc clone).

## Verification

- `cargo +1.95.0 clippy -p xavyo-ssf -p xavyo-api-ssf -p idp-api --all-targets -- -D warnings` clean.
- xavyo-ssf + api-ssf unit tests pass. The HTTP-level verify path needs a test DB (task #54 item 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)