### PR TITLE
chore: pin the Rust toolchain (rust-toolchain.toml) for CI/local parity

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,16 @@
+# Pin the Rust toolchain so local builds match CI.
+#
+# Why: CI installs the toolchain via `dtolnay/rust-toolchain@stable` (a floating
+# channel). On 2026-05-25 stable advanced to clippy 1.95.0, which flagged lints
+# that a local 1.92.0 toolchain did not — master went red and the divergence
+# could not be reproduced locally until the exact CI version was installed by
+# hand. Pinning here makes `cargo` use the same toolchain everywhere
+# (rust-toolchain.toml takes precedence over rustup's default and directory
+# overrides), so CI lints are reproducible locally before pushing.
+#
+# Bumping: change `channel` deliberately, after confirming
+# `cargo clippy --workspace --all-targets -- -D warnings` is clean on the new
+# version (and update CI's dtolnay pin if/when it is also pinned).
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## What

Adds a `rust-toolchain.toml` pinning the toolchain to **1.95.0** (with `clippy` + `rustfmt`).

## Why

CI installs the toolchain via `dtolnay/rust-toolchain@stable` — a **floating** channel. On 2026-05-25 stable advanced to **clippy 1.95.0**, which flagged lints a local **1.92.0** toolchain did not. Master went red, and the failure couldn't be reproduced locally until 1.95.0 was installed by hand (a full clippy-cleanup detour this session). Pinning makes `cargo` use the same toolchain everywhere — `rust-toolchain.toml` takes precedence over rustup's default and directory overrides — so **CI lints are reproducible locally before pushing**.

## Risk: none (zero-regression)

Even if a CI runner's action setup ignored the file, CI would keep floating exactly as it does today — no change. Meanwhile local dev becomes pinned, which is the gap that cost the time. This PR's own CI run exercises the pinned setup.

Verified locally: plain `cargo --version` now resolves to **1.95.0** via the file (was 1.92.0). The workspace is already clippy-clean on 1.95.0 (every PR this session was verified against it).

## Maintenance

Bump `channel` deliberately, after confirming `cargo clippy --workspace --all-targets -- -D warnings` is clean on the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)