### PR TITLE
feat(auth): OIDC authentication-context claims (acr/amr/auth_time)

### DIFF
--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -1993,7 +1993,17 @@ impl xavyo_api_social::AuthService for SocialAuthAdapter {
 
         // Issue tokens with 15 minute access token, 7 day refresh token
         match token_service
-            .create_tokens(typed_user_id, typed_tenant_id, roles, email, None, None)
+            // Social/federated login — assurance was established by the external
+            // IdP, not by xavyo, so no acr/amr/auth_time is asserted here.
+            .create_tokens(
+                typed_user_id,
+                typed_tenant_id,
+                roles,
+                email,
+                None,
+                None,
+                None,
+            )
             .await
         {
             Ok((access_token, refresh_token, expires_in)) => {

--- a/crates/xavyo-api-auth/src/handlers/login.rs
+++ b/crates/xavyo-api-auth/src/handlers/login.rs
@@ -6,9 +6,9 @@ use crate::error::ApiAuthError;
 use crate::models::{LoginRequest, MfaMethod, MfaRequiredResponse, TokenResponse};
 use crate::services::security_audit::{SecurityAudit, SecurityEventType};
 use crate::services::{
-    AlertService, AuditService, AuthService, DevicePolicyService, DeviceService, LockoutService,
-    LoginRiskContext, MfaService, RecordLoginAttemptInput, RiskEnforcementService, SessionService,
-    TokenService, WebAuthnService,
+    AlertService, AuditService, AuthContext, AuthService, DevicePolicyService, DeviceService,
+    LockoutService, LoginRiskContext, MfaService, RecordLoginAttemptInput, RiskEnforcementService,
+    SessionService, TokenService, WebAuthnService,
 };
 use axum::extract::FromRequest;
 use axum::http::StatusCode;
@@ -543,6 +543,9 @@ pub async fn login_handler(
             tenant_id_val,
             roles,
             Some(request.email.clone()),
+            // This path issues a full token only when MFA is not required, i.e.
+            // single-factor password authentication (acr "1").
+            Some(AuthContext::password()),
             user_agent.clone(),
             ip_address,
         )

--- a/crates/xavyo-api-auth/src/handlers/mfa/recovery.rs
+++ b/crates/xavyo-api-auth/src/handlers/mfa/recovery.rs
@@ -1,5 +1,6 @@
 //! Recovery code handlers.
 
+use crate::services::AuthContext;
 use axum::{extract::State, http::StatusCode, Extension, Json};
 use std::net::IpAddr;
 use tracing::info;
@@ -86,6 +87,8 @@ pub async fn verify_recovery_code(
             user.tenant_id(),
             roles,
             Some(user.email.clone()),
+            // Completed via an MFA recovery code — multi-factor (acr "2").
+            Some(AuthContext::mfa_recovery_code()),
             user_agent,
             ip_address,
         )

--- a/crates/xavyo-api-auth/src/handlers/mfa/verify.rs
+++ b/crates/xavyo-api-auth/src/handlers/mfa/verify.rs
@@ -1,5 +1,6 @@
 //! TOTP verification handler for login flow.
 
+use crate::services::AuthContext;
 use axum::{extract::State, http::StatusCode, Extension, Json};
 use std::net::IpAddr;
 use tracing::info;
@@ -86,6 +87,8 @@ pub async fn verify_totp(
             user.tenant_id(),
             roles,
             Some(user.email.clone()),
+            // Password + TOTP verified — multi-factor (acr "2").
+            Some(AuthContext::mfa_totp()),
             user_agent,
             ip_address,
         )

--- a/crates/xavyo-api-auth/src/handlers/signup.rs
+++ b/crates/xavyo-api-auth/src/handlers/signup.rs
@@ -9,8 +9,8 @@
 use crate::error::ApiAuthError;
 use crate::models::{SignupRequest, SignupResponse};
 use crate::services::{
-    generate_email_verification_token, AuthService, EmailSender, PasswordPolicyService,
-    TokenService, EMAIL_VERIFICATION_TOKEN_VALIDITY_HOURS,
+    generate_email_verification_token, AuthContext, AuthService, EmailSender,
+    PasswordPolicyService, TokenService, EMAIL_VERIFICATION_TOKEN_VALIDITY_HOURS,
 };
 use axum::{extract::ConnectInfo, http::StatusCode, Extension, Json};
 use chrono::{Duration, Utc};
@@ -129,6 +129,8 @@ pub async fn signup_handler(
             tenant_id,
             vec![], // No roles for new user
             Some(email.clone()),
+            // Signup auto-login is password-based — single factor (acr "1").
+            Some(AuthContext::password()),
             None, // No user agent
             Some(addr.ip()),
         )

--- a/crates/xavyo-api-auth/src/middleware/api_key.rs
+++ b/crates/xavyo-api-auth/src/middleware/api_key.rs
@@ -525,6 +525,10 @@ pub async fn api_key_auth_middleware(
         cnf: None,
         // RFC 9396: API keys carry coarse scopes, not authorization_details
         authorization_details: None,
+        // API keys are not interactive user authentication — no acr/amr/auth_time.
+        acr: None,
+        amr: None,
+        auth_time: None,
     };
 
     request.extensions_mut().insert(synthetic_claims);

--- a/crates/xavyo-api-auth/src/services/mod.rs
+++ b/crates/xavyo-api-auth/src/services/mod.rs
@@ -79,7 +79,7 @@ pub use ses_email_service::{SesEmailConfig, SesEmailSender};
 pub use session_service::SessionService;
 pub use token_service::{
     generate_email_verification_token, generate_password_reset_token, generate_secure_token,
-    hash_token, verify_token_hash_constant_time, TokenConfig, TokenService,
+    hash_token, verify_token_hash_constant_time, AuthContext, TokenConfig, TokenService,
     ACCESS_TOKEN_VALIDITY_MINUTES, EMAIL_VERIFICATION_TOKEN_VALIDITY_HOURS,
     PASSWORD_RESET_TOKEN_VALIDITY_HOURS, REFRESH_TOKEN_VALIDITY_DAYS, SECURE_TOKEN_BYTES,
 };

--- a/crates/xavyo-api-auth/src/services/passwordless_service.rs
+++ b/crates/xavyo-api-auth/src/services/passwordless_service.rs
@@ -6,7 +6,7 @@
 use crate::error::ApiAuthError;
 use crate::services::email_service::EmailSender;
 use crate::services::token_service::{
-    generate_secure_token, hash_token, verify_token_hash_constant_time, TokenService,
+    generate_secure_token, hash_token, verify_token_hash_constant_time, AuthContext, TokenService,
 };
 use chrono::{Duration, Utc};
 use parking_lot::Mutex;
@@ -553,7 +553,16 @@ impl PasswordlessService {
 
         let (access_token, refresh_token, expires_in) = self
             .token_service
-            .create_tokens(uid, tid, roles, email, user_agent.map(String::from), ip)
+            .create_tokens(
+                uid,
+                tid,
+                roles,
+                email,
+                // Passwordless email link/OTP — single factor (acr "1").
+                Some(AuthContext::passwordless()),
+                user_agent.map(String::from),
+                ip,
+            )
             .await?;
 
         Ok(PasswordlessVerifyResult::Success {

--- a/crates/xavyo-api-auth/src/services/token_service.rs
+++ b/crates/xavyo-api-auth/src/services/token_service.rs
@@ -33,6 +33,73 @@ pub const EMAIL_VERIFICATION_TOKEN_VALIDITY_HOURS: i64 = 24;
 /// Size of secure tokens in bytes (256 bits of entropy).
 pub const SECURE_TOKEN_BYTES: usize = 32;
 
+/// Authentication context captured when a user completes login, surfaced as the
+/// OIDC `acr` / `amr` / `auth_time` claims on the issued access token.
+///
+/// ACR is xavyo's scheme: `"1"` = single-factor, `"2"` = multi-factor satisfied
+/// (consumed by RFC 9470 step-up). `amr` values follow RFC 8176. The
+/// constructors are the single source of truth for the method→acr/amr mapping,
+/// so call sites just name the method they completed.
+#[derive(Debug, Clone)]
+pub struct AuthContext {
+    /// Authentication context class reference (`"1"` or `"2"`).
+    pub acr: String,
+    /// Authentication methods references (RFC 8176).
+    pub amr: Vec<String>,
+    /// When the end-user authentication occurred (Unix seconds).
+    pub auth_time: i64,
+}
+
+impl AuthContext {
+    fn now(acr: &str, amr: &[&str]) -> Self {
+        Self {
+            acr: acr.to_string(),
+            amr: amr.iter().map(|s| (*s).to_string()).collect(),
+            auth_time: Utc::now().timestamp(),
+        }
+    }
+
+    /// Password only — single factor.
+    #[must_use]
+    pub fn password() -> Self {
+        Self::now("1", &["pwd"])
+    }
+
+    /// Password + TOTP — multi-factor.
+    #[must_use]
+    pub fn mfa_totp() -> Self {
+        Self::now("2", &["pwd", "otp", "mfa"])
+    }
+
+    /// Password + MFA recovery code — multi-factor (proves prior MFA enrollment).
+    #[must_use]
+    pub fn mfa_recovery_code() -> Self {
+        Self::now("2", &["pwd", "mfa"])
+    }
+
+    /// WebAuthn / passkey — multi-factor, hardware-backed.
+    #[must_use]
+    pub fn webauthn() -> Self {
+        Self::now("2", &["mfa", "hwk"])
+    }
+
+    /// Passwordless email link / OTP — single factor (a one-time credential).
+    #[must_use]
+    pub fn passwordless() -> Self {
+        Self::now("1", &["otp"])
+    }
+
+    /// Reconstruct from stored values (e.g. carried forward across refresh).
+    #[must_use]
+    pub fn from_parts(acr: String, amr: Vec<String>, auth_time: i64) -> Self {
+        Self {
+            acr,
+            amr,
+            auth_time,
+        }
+    }
+}
+
 /// Configuration for JWT token generation.
 ///
 /// `private_key` is held inside `Arc<Zeroizing<Vec<u8>>>` so:
@@ -111,6 +178,8 @@ impl TokenService {
     /// * `tenant_id` - The user's tenant ID
     /// * `roles` - User's roles for the JWT claims
     /// * `email` - User's email address for the JWT claims
+    /// * `auth_context` - OIDC `acr`/`amr`/`auth_time` for interactive logins;
+    ///   `None` for non-interactive issuance (refresh re-issue, federated, etc.)
     /// * `user_agent` - Optional client user agent
     /// * `ip_address` - Optional client IP address
     ///
@@ -123,11 +192,13 @@ impl TokenService {
         tenant_id: TenantId,
         roles: Vec<String>,
         email: Option<String>,
+        auth_context: Option<AuthContext>,
         user_agent: Option<String>,
         ip_address: Option<IpAddr>,
     ) -> Result<(String, String, i64), ApiAuthError> {
         // Generate access token
-        let access_token = self.create_access_token(user_id, tenant_id, roles, email)?;
+        let access_token =
+            self.create_access_token(user_id, tenant_id, roles, email, auth_context.as_ref())?;
 
         // Generate refresh token
         let refresh_token = self
@@ -146,6 +217,7 @@ impl TokenService {
         tenant_id: TenantId,
         roles: Vec<String>,
         email: Option<String>,
+        auth_context: Option<&AuthContext>,
     ) -> Result<String, ApiAuthError> {
         let mut builder = JwtClaims::builder()
             .subject(user_id.to_string())
@@ -157,6 +229,18 @@ impl TokenService {
 
         if let Some(email) = email {
             builder = builder.email(email);
+        }
+
+        // OIDC authentication context (acr/amr/auth_time). Emitted on
+        // interactive-login tokens (always present there, so resource-side
+        // step-up logic is uniform); absent when None — e.g. the refresh
+        // re-issue path, which cannot yet carry forward the original context
+        // (a follow-up will store + forward it).
+        if let Some(ctx) = auth_context {
+            builder = builder
+                .acr(&ctx.acr)
+                .amr(ctx.amr.clone())
+                .auth_time(ctx.auth_time);
         }
 
         let claims = builder.build();
@@ -363,8 +447,16 @@ impl TokenService {
         let user_id = UserId::from_uuid(token.user_id);
         let tenant_id = TenantId::from_uuid(token.tenant_id);
 
-        self.create_tokens(user_id, tenant_id, roles, email, user_agent, ip_address)
-            .await
+        // FOLLOW-UP (acr/amr/auth_time): the refresh re-issue path cannot yet
+        // carry forward the original authentication context — refresh_tokens does
+        // not store it — so refreshed access tokens currently drop acr/amr/
+        // auth_time. Must be fixed (store at issuance, forward here) before
+        // step-up auth (RFC 9470) ships, or post-refresh tokens would fail
+        // step-up checks.
+        self.create_tokens(
+            user_id, tenant_id, roles, email, None, user_agent, ip_address,
+        )
+        .await
     }
 
     /// Revoke a refresh token by its opaque value.
@@ -593,5 +685,32 @@ mod tests {
         assert_eq!(hash.len(), 64);
         // Token should verify against its hash
         assert!(verify_token_hash_constant_time(&token, &hash));
+    }
+
+    #[test]
+    fn auth_context_constructors_map_method_to_acr_amr() {
+        // Single-factor methods → acr "1".
+        assert_eq!(AuthContext::password().acr, "1");
+        assert_eq!(AuthContext::password().amr, vec!["pwd".to_string()]);
+        assert_eq!(AuthContext::passwordless().acr, "1");
+        assert_eq!(AuthContext::passwordless().amr, vec!["otp".to_string()]);
+
+        // Multi-factor methods → acr "2", with an "mfa" amr value so resource
+        // step-up checks can be `amr.contains("mfa")`.
+        for ctx in [
+            AuthContext::mfa_totp(),
+            AuthContext::mfa_recovery_code(),
+            AuthContext::webauthn(),
+        ] {
+            assert_eq!(ctx.acr, "2", "MFA methods must be acr 2");
+            assert!(
+                ctx.amr.iter().any(|m| m == "mfa"),
+                "MFA methods must include the 'mfa' amr value, got {:?}",
+                ctx.amr
+            );
+        }
+
+        // auth_time is populated for fresh logins.
+        assert!(AuthContext::password().auth_time > 0);
     }
 }

--- a/crates/xavyo-api-auth/tests/integration_test.rs
+++ b/crates/xavyo-api-auth/tests/integration_test.rs
@@ -318,6 +318,7 @@ RSiBP/6TepaXLEdSsrN4dARjpDeuV87IokbrVay54JWW0yTStzAzbLFcodp3sBNn
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await
                 .expect("Token creation should succeed");
@@ -373,6 +374,7 @@ RSiBP/6TepaXLEdSsrN4dARjpDeuV87IokbrVay54JWW0yTStzAzbLFcodp3sBNn
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await
                 .expect("Token creation should succeed");
@@ -425,6 +427,7 @@ RSiBP/6TepaXLEdSsrN4dARjpDeuV87IokbrVay54JWW0yTStzAzbLFcodp3sBNn
                     user.user_id(),
                     user.tenant_id(),
                     vec!["user".to_string()],
+                    None,
                     None,
                     None,
                     None,
@@ -500,6 +503,7 @@ RSiBP/6TepaXLEdSsrN4dARjpDeuV87IokbrVay54JWW0yTStzAzbLFcodp3sBNn
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await
                 .expect("Token creation should succeed");
@@ -539,6 +543,7 @@ RSiBP/6TepaXLEdSsrN4dARjpDeuV87IokbrVay54JWW0yTStzAzbLFcodp3sBNn
                     user.user_id(),
                     user.tenant_id(),
                     vec!["user".to_string()],
+                    None,
                     None,
                     None,
                     None,

--- a/crates/xavyo-api-tenants/src/handlers/provision.rs
+++ b/crates/xavyo-api-tenants/src/handlers/provision.rs
@@ -123,6 +123,9 @@ pub async fn provision_handler(
             new_tenant_id,
             vec!["super_admin".to_string()],
             Some(email.clone()),
+            // No interactive authentication occurred — the admin was provisioned,
+            // not logged in — so no acr/amr/auth_time is asserted.
+            None,
             user_agent.clone(),
             ip_address.as_deref().and_then(|ip| ip.parse().ok()),
         )

--- a/crates/xavyo-auth/src/claims.rs
+++ b/crates/xavyo-auth/src/claims.rs
@@ -194,6 +194,23 @@ pub struct JwtClaims {
     /// token carries only coarse `scope`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization_details: Option<Vec<AuthorizationDetail>>,
+
+    /// OIDC Authentication Context Class Reference. xavyo uses `"1"`
+    /// (single-factor) and `"2"` (multi-factor satisfied). Consumed by step-up
+    /// authentication (RFC 9470). Absent on machine/partial tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acr: Option<String>,
+
+    /// OIDC Authentication Methods References (RFC 8176): the methods used to
+    /// authenticate, e.g. `["pwd"]`, `["pwd","otp","mfa"]`, `["mfa","hwk"]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amr: Option<Vec<String>>,
+
+    /// OIDC `auth_time` — when the end-user authentication occurred (Unix
+    /// seconds). NOT the token-issuance time; carried forward across refresh so
+    /// `max_age` checks remain meaningful. Absent on machine/partial tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_time: Option<i64>,
 }
 
 /// RFC 7800 confirmation claim. Carries the proof-of-possession binding for a
@@ -351,6 +368,9 @@ pub struct JwtClaimsBuilder {
     may_act: Option<MayActClaim>,
     cnf: Option<CnfClaim>,
     authorization_details: Option<Vec<AuthorizationDetail>>,
+    acr: Option<String>,
+    amr: Option<Vec<String>>,
+    auth_time: Option<i64>,
 }
 
 impl JwtClaimsBuilder {
@@ -549,6 +569,27 @@ impl JwtClaimsBuilder {
         self
     }
 
+    /// Set the OIDC `acr` (authentication context class reference).
+    #[must_use]
+    pub fn acr(mut self, acr: impl Into<String>) -> Self {
+        self.acr = Some(acr.into());
+        self
+    }
+
+    /// Set the OIDC `amr` (authentication methods references, RFC 8176).
+    #[must_use]
+    pub fn amr(mut self, amr: Vec<String>) -> Self {
+        self.amr = Some(amr);
+        self
+    }
+
+    /// Set the OIDC `auth_time` (when end-user authentication occurred, seconds).
+    #[must_use]
+    pub fn auth_time(mut self, auth_time: i64) -> Self {
+        self.auth_time = Some(auth_time);
+        self
+    }
+
     /// Build the JWT claims.
     ///
     /// # Defaults
@@ -596,6 +637,9 @@ impl JwtClaimsBuilder {
             may_act: self.may_act,
             cnf: self.cnf,
             authorization_details: self.authorization_details,
+            acr: self.acr,
+            amr: self.amr,
+            auth_time: self.auth_time,
         }
     }
 }
@@ -976,5 +1020,59 @@ mod tests {
         assert_eq!(chain[0], "agent-top");
         assert_eq!(chain[1], "agent-mid");
         assert_eq!(chain[2], "agent-leaf");
+    }
+
+    #[test]
+    fn builder_sets_authentication_context() {
+        let claims = JwtClaims::builder()
+            .subject("u1")
+            .acr("2")
+            .amr(vec![
+                "pwd".to_string(),
+                "otp".to_string(),
+                "mfa".to_string(),
+            ])
+            .auth_time(1_700_000_000)
+            .build();
+        assert_eq!(claims.acr.as_deref(), Some("2"));
+        assert_eq!(
+            claims.amr,
+            Some(vec!["pwd".into(), "otp".into(), "mfa".into()])
+        );
+        assert_eq!(claims.auth_time, Some(1_700_000_000));
+    }
+
+    #[test]
+    fn auth_context_claims_absent_by_default() {
+        let claims = JwtClaims::builder().subject("u1").build();
+        assert!(claims.acr.is_none());
+        assert!(claims.amr.is_none());
+        assert!(claims.auth_time.is_none());
+    }
+
+    #[test]
+    fn auth_context_serde_round_trip_and_legacy_compat() {
+        // Round-trip with the claims present.
+        let claims = JwtClaims::builder()
+            .subject("u1")
+            .acr("1")
+            .amr(vec!["pwd".to_string()])
+            .auth_time(42)
+            .build();
+        let json = serde_json::to_string(&claims).unwrap();
+        assert!(json.contains("\"acr\":\"1\""));
+        assert!(json.contains("\"auth_time\":42"));
+        let back: JwtClaims = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.acr.as_deref(), Some("1"));
+        assert_eq!(back.amr, Some(vec!["pwd".into()]));
+        assert_eq!(back.auth_time, Some(42));
+
+        // Legacy token (no acr/amr/auth_time) deserializes with the fields None —
+        // so tokens issued before this change keep working.
+        let legacy = r#"{"sub":"u1","iss":"xavyo","aud":[],"exp":9999999999,"iat":1,"jti":"j"}"#;
+        let parsed: JwtClaims = serde_json::from_str(legacy).unwrap();
+        assert!(parsed.acr.is_none());
+        assert!(parsed.amr.is_none());
+        assert!(parsed.auth_time.is_none());
     }
 }


### PR DESCRIPTION
## What

Threads the OIDC **authentication context** — `acr` (assurance level), `amr` (methods, RFC 8176), `auth_time` — into interactive-login access tokens. This is the **foundation for RFC 9470 step-up authentication** (the next item): a resource can require `acr_values=2` for sensitive operations and challenge weaker sessions.

## Design (advisor-reviewed)

- **ACR scheme**: plain strings `"1"` (single-factor) / `"2"` (multi-factor satisfied) — what Auth0/Okta/Keycloak use; RFC 9470 just string-compares.
- **`amr`** per RFC 8176: `pwd`, `otp`, `mfa`, `hwk`.
- **`AuthContext`** constructors are the single source of truth for the method→acr/amr mapping, so call sites just name the method they completed.
- **Always emit** on interactive-login tokens (uniform resource-side checks); **omit** on partial (MFA-pending) and client-credentials tokens. serde defaults so **pre-existing tokens still deserialize**.

## Call sites

| Flow | Context |
|------|---------|
| password login, signup auto-login | `password()` — acr `"1"` |
| MFA TOTP | `mfa_totp()` — acr `"2"`, amr `[pwd,otp,mfa]` |
| MFA recovery code | `mfa_recovery_code()` — acr `"2"` |
| passwordless | `passwordless()` — acr `"1"` |
| social/federated, admin provisioning, refresh re-issue | `None` (assurance not established by xavyo) |

## ⚠️ Known gap (loudly noted — fix before step-up ships)

The **refresh re-issue path** does not yet carry forward the original `acr`/`amr`/`auth_time` (`refresh_tokens` doesn't store them), so refreshed access tokens drop these claims. **Next PR**: add storage + forward on refresh. Until then a post-refresh token would fail an `acr` step-up check. The issuance foundation here is independently correct and useful, and step-up (#2) isn't shipping in this PR.

## Verification

- `cargo +1.95.0 clippy -p xavyo-auth -p xavyo-api-auth -p xavyo-api-tenants -p idp-api --all-targets -- -D warnings` clean.
- Unit tests: builder setters, `AuthContext` method→acr/amr mapping, serde round-trip + **legacy-token (no acr/amr) compatibility**.
- Per-flow behavioral tests need a DB (task #54 item 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)