### PR TITLE
feat(auth): carry acr/amr/auth_time across refresh

### DIFF
--- a/crates/xavyo-api-auth/src/services/token_service.rs
+++ b/crates/xavyo-api-auth/src/services/token_service.rs
@@ -200,9 +200,16 @@ impl TokenService {
         let access_token =
             self.create_access_token(user_id, tenant_id, roles, email, auth_context.as_ref())?;
 
-        // Generate refresh token
+        // Generate refresh token, persisting the auth context so it survives
+        // token rotation (carried forward on refresh).
         let refresh_token = self
-            .create_refresh_token(user_id, tenant_id, user_agent, ip_address)
+            .create_refresh_token(
+                user_id,
+                tenant_id,
+                auth_context.as_ref(),
+                user_agent,
+                ip_address,
+            )
             .await?;
 
         let expires_in = self.access_token_validity.num_seconds();
@@ -294,6 +301,7 @@ impl TokenService {
         &self,
         user_id: UserId,
         tenant_id: TenantId,
+        auth_context: Option<&AuthContext>,
         user_agent: Option<String>,
         ip_address: Option<IpAddr>,
     ) -> Result<String, ApiAuthError> {
@@ -303,10 +311,12 @@ impl TokenService {
         let token_hash = hash_token(&opaque_token);
         let expires_at = Utc::now() + self.refresh_token_validity;
 
-        // Store the hash in the database
+        // Store the hash + the authentication context, so a later refresh can
+        // carry the original acr/amr/auth_time forward to the re-issued token.
         let query = r"
-            INSERT INTO refresh_tokens (user_id, tenant_id, token_hash, expires_at, user_agent, ip_address)
-            VALUES ($1, $2, $3, $4, $5, $6)
+            INSERT INTO refresh_tokens
+                (user_id, tenant_id, token_hash, expires_at, user_agent, ip_address, acr, amr, auth_time)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         ";
 
         sqlx::query(query)
@@ -316,6 +326,9 @@ impl TokenService {
             .bind(expires_at)
             .bind(user_agent)
             .bind(ip_address.map(|ip| ip.to_string()))
+            .bind(auth_context.map(|c| c.acr.clone()))
+            .bind(auth_context.map(|c| c.amr.clone()))
+            .bind(auth_context.map(|c| c.auth_time))
             .execute(&self.pool)
             .await?;
 
@@ -349,7 +362,7 @@ impl TokenService {
             // C-3: Filter by tenant_id at DB level when available
             let query = r"
                 SELECT id, user_id, tenant_id, token_hash, expires_at, revoked_at, created_at, user_agent,
-                       COALESCE(ip_address::text, '') as ip_address
+                       COALESCE(ip_address::text, '') as ip_address, acr, amr, auth_time
                 FROM refresh_tokens
                 WHERE token_hash = $1 AND tenant_id = $2
             ";
@@ -361,7 +374,7 @@ impl TokenService {
         } else {
             let query = r"
                 SELECT id, user_id, tenant_id, token_hash, expires_at, revoked_at, created_at, user_agent,
-                       COALESCE(ip_address::text, '') as ip_address
+                       COALESCE(ip_address::text, '') as ip_address, acr, amr, auth_time
                 FROM refresh_tokens
                 WHERE token_hash = $1
             ";
@@ -447,14 +460,25 @@ impl TokenService {
         let user_id = UserId::from_uuid(token.user_id);
         let tenant_id = TenantId::from_uuid(token.tenant_id);
 
-        // FOLLOW-UP (acr/amr/auth_time): the refresh re-issue path cannot yet
-        // carry forward the original authentication context — refresh_tokens does
-        // not store it — so refreshed access tokens currently drop acr/amr/
-        // auth_time. Must be fixed (store at issuance, forward here) before
-        // step-up auth (RFC 9470) ships, or post-refresh tokens would fail
-        // step-up checks.
+        // Carry the ORIGINAL authentication context forward (OIDC: acr/amr/
+        // auth_time describe the login, not this re-issue), so step-up assurance
+        // and max_age survive token rotation. Absent only for tokens issued
+        // before context tracking, or non-interactive issuance.
+        let forwarded_context = match (&token.acr, &token.amr, token.auth_time) {
+            (Some(acr), Some(amr), Some(auth_time)) => {
+                Some(AuthContext::from_parts(acr.clone(), amr.clone(), auth_time))
+            }
+            _ => None,
+        };
+
         self.create_tokens(
-            user_id, tenant_id, roles, email, None, user_agent, ip_address,
+            user_id,
+            tenant_id,
+            roles,
+            email,
+            forwarded_context,
+            user_agent,
+            ip_address,
         )
         .await
     }
@@ -712,5 +736,19 @@ mod tests {
 
         // auth_time is populated for fresh logins.
         assert!(AuthContext::password().auth_time > 0);
+    }
+
+    #[test]
+    fn auth_context_from_parts_round_trip() {
+        // Refresh forwarding reconstructs the context from stored columns; it
+        // must preserve the original values verbatim (not re-stamp auth_time).
+        let ctx = AuthContext::from_parts(
+            "2".to_string(),
+            vec!["pwd".to_string(), "otp".to_string(), "mfa".to_string()],
+            1_700_000_000,
+        );
+        assert_eq!(ctx.acr, "2");
+        assert_eq!(ctx.amr, vec!["pwd", "otp", "mfa"]);
+        assert_eq!(ctx.auth_time, 1_700_000_000);
     }
 }

--- a/crates/xavyo-db/migrations/0216_refresh_tokens_auth_context.sql
+++ b/crates/xavyo-db/migrations/0216_refresh_tokens_auth_context.sql
@@ -1,0 +1,20 @@
+-- Migration: carry the OIDC authentication context across refresh.
+--
+-- A refreshed access token must keep the ORIGINAL acr/amr/auth_time (OIDC: the
+-- time/strength of the end-user authentication, not of token issuance) so that
+-- RFC 9470 step-up checks and `max_age` stay meaningful after token rotation —
+-- otherwise a user who completed MFA (acr "2") would be re-challenged on the
+-- first refresh. Capture them on the refresh-token row at login; the refresh
+-- re-issue path reads them back and stamps the new access token.
+--
+-- All nullable: refresh tokens issued before this change (or non-interactive
+-- issuance) simply carry no context.
+
+ALTER TABLE refresh_tokens
+    ADD COLUMN IF NOT EXISTS acr TEXT,
+    ADD COLUMN IF NOT EXISTS amr TEXT[],
+    ADD COLUMN IF NOT EXISTS auth_time BIGINT;
+
+COMMENT ON COLUMN refresh_tokens.acr IS 'OIDC acr captured at login, carried forward to refreshed access tokens';
+COMMENT ON COLUMN refresh_tokens.amr IS 'OIDC amr (RFC 8176) captured at login, carried forward on refresh';
+COMMENT ON COLUMN refresh_tokens.auth_time IS 'OIDC auth_time (Unix seconds) captured at login, carried forward on refresh';

--- a/crates/xavyo-db/src/models/refresh_token.rs
+++ b/crates/xavyo-db/src/models/refresh_token.rs
@@ -41,6 +41,18 @@ pub struct RefreshToken {
     /// The client's IP address as string (optional, for auditing).
     /// Stored as String because INET type maps to String in sqlx.
     pub ip_address: Option<String>,
+
+    /// OIDC `acr` captured at login, carried forward to refreshed access tokens
+    /// (so step-up assurance survives refresh). `None` for tokens issued before
+    /// authentication-context tracking, or non-interactive issuance.
+    pub acr: Option<String>,
+
+    /// OIDC `amr` (RFC 8176) captured at login, carried forward on refresh.
+    pub amr: Option<Vec<String>>,
+
+    /// OIDC `auth_time` (Unix seconds) captured at login, carried forward on
+    /// refresh so `max_age` checks remain meaningful across token rotation.
+    pub auth_time: Option<i64>,
 }
 
 impl RefreshToken {
@@ -181,6 +193,9 @@ mod tests {
             created_at: Utc::now(),
             user_agent: None,
             ip_address: None,
+            acr: None,
+            amr: None,
+            auth_time: None,
         }
     }
 


### PR DESCRIPTION
## What

Closes the gap noted in #94: refreshed access tokens **dropped** the OIDC authentication context. A user who completed MFA (`acr "2"`) would lose it on the first token rotation and be re-challenged by RFC 9470 step-up ~15 minutes after authenticating. Now the context **survives refresh**.

## Changes

- **Migration 0216**: `refresh_tokens` gains `acr TEXT`, `amr TEXT[]`, `auth_time BIGINT` (all nullable — pre-existing tokens carry no context).
- `RefreshToken` model gains the three fields; both validate SELECTs return them.
- `create_refresh_token` **persists** the `AuthContext` at issuance; `create_tokens` passes it (the same context stamped on the access token).
- The refresh re-issue path **reconstructs** `AuthContext::from_parts` from the stored columns and **forwards** it — so the rotated access token keeps the **original** `acr`/`amr`/`auth_time` (the login's, not the re-issue's).

This makes **step-up auth (RFC 9470, next)** usable: a post-refresh token still satisfies an `acr=2` requirement, and `max_age` stays meaningful across rotation.

## Scope

The api-auth login-session refresh (`refresh_tokens`). The OAuth2 provider refresh (`oauth_refresh_tokens`) is a separate token system whose access tokens don't carry `acr`/`amr` today — out of scope here.

## Verification

- `cargo +1.95.0 clippy -p xavyo-db -p xavyo-api-auth --all-targets -- -D warnings` clean.
- Unit tests pass (incl. `AuthContext::from_parts` round-trip). Live store→refresh→forward needs a test DB (task #54 item 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)