### PR TITLE
feat(auth): RFC 9470 step-up authentication challenge

### DIFF
--- a/crates/xavyo-auth/CRATE.md
+++ b/crates/xavyo-auth/CRATE.md
@@ -108,6 +108,19 @@ pub fn verify_dpop_nonce(secret: &[u8], candidate: &str, now: i64, window_secs: 
 pub fn check_or_challenge(secret: &[u8], presented: Option<&str>, now: i64, window_secs: i64, allowed_age_windows: i64) -> NonceCheck;
 ```
 
+Step-up authentication (RFC 9470), in `step_up` — a resource enforces an `acr`
+(assurance) / `auth_time` (freshness) requirement on a sensitive operation, and
+challenges insufficient tokens. `acr`/`auth_time` are stamped on login tokens
+and carried across refresh:
+
+```rust
+/// Check whether the token meets the requirement at `now`; otherwise a Challenge.
+pub fn check_step_up(claims: &JwtClaims, req: &StepUpRequirement, now: i64) -> StepUpOutcome;
+
+/// Build the RFC 9470 §3 `WWW-Authenticate: Bearer error="insufficient_user_authentication" …` value.
+pub fn step_up_challenge_header(acr_values: &str, max_age: Option<i64>) -> String;
+```
+
 ## Usage Example
 
 ```rust

--- a/crates/xavyo-auth/src/lib.rs
+++ b/crates/xavyo-auth/src/lib.rs
@@ -49,6 +49,8 @@ pub mod mtls;
 mod password;
 /// Rich Authorization Requests (RFC 9396) — `authorization_details`.
 pub mod rar;
+/// Step-up authentication challenge (RFC 9470).
+pub mod step_up;
 
 // Re-export public API
 pub use claims::{ActorClaim, JwtClaims, JwtClaimsBuilder};
@@ -71,3 +73,4 @@ pub use jwt::{
 pub use mtls::{cert_binding_satisfied, compute_x5t_s256, x5t_s256_from_pem};
 pub use password::{hash_password, verify_password, PasswordHasher};
 pub use rar::{parse_authorization_details, AuthorizationDetail, RarError};
+pub use step_up::{check_step_up, step_up_challenge_header, StepUpOutcome, StepUpRequirement};

--- a/crates/xavyo-auth/src/step_up.rs
+++ b/crates/xavyo-auth/src/step_up.rs
@@ -1,0 +1,176 @@
+//! Step-up authentication (RFC 9470).
+//!
+//! A resource that needs higher assurance for a sensitive operation calls
+//! [`check_step_up`] with the access token's claims and its requirement. If the
+//! token's `acr` (assurance) or `auth_time` (freshness) is insufficient, the
+//! resource answers `401` with the [`step_up_challenge_header`]
+//! `WWW-Authenticate: Bearer error="insufficient_user_authentication", …`; an
+//! OIDC client re-authenticates at the requested `acr_values` / `max_age` and
+//! retries.
+//!
+//! These are pure primitives — no DB, no HTTP. The acr/amr/auth_time they read
+//! are stamped on login tokens by the auth flow and carried across refresh.
+
+use crate::claims::JwtClaims;
+
+/// What a sensitive operation requires of the caller's authentication (RFC 9470).
+#[derive(Debug, Clone)]
+pub struct StepUpRequirement {
+    /// Minimum acr (xavyo scheme: `"1"` single-factor, `"2"` multi-factor).
+    pub acr: String,
+    /// Maximum age of the authentication in seconds (`auth_time` freshness). A
+    /// `None` means freshness is not required.
+    pub max_age: Option<i64>,
+}
+
+impl StepUpRequirement {
+    /// Require multi-factor authentication (`acr` ≥ `"2"`), no freshness bound.
+    #[must_use]
+    pub fn mfa() -> Self {
+        Self {
+            acr: "2".to_string(),
+            max_age: None,
+        }
+    }
+
+    /// Require multi-factor authentication completed within `max_age` seconds.
+    #[must_use]
+    pub fn mfa_within(max_age_secs: i64) -> Self {
+        Self {
+            acr: "2".to_string(),
+            max_age: Some(max_age_secs),
+        }
+    }
+}
+
+/// The result of a step-up check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StepUpOutcome {
+    /// The token meets the requirement — proceed.
+    Satisfied,
+    /// Insufficient — answer `401` and challenge with these parameters.
+    Challenge {
+        /// The `acr_values` to request (the requirement's acr).
+        acr_values: String,
+        /// The `max_age` to request, if any.
+        max_age: Option<i64>,
+    },
+}
+
+/// Whether `claims` satisfy `req` at time `now` (Unix seconds).
+///
+/// `acr` is compared numerically when both are integer strings (xavyo's `"1"` /
+/// `"2"`), falling back to exact match otherwise. A missing `acr` never
+/// satisfies a requirement. When `max_age` is set, a missing or too-old
+/// `auth_time` fails (freshness cannot be confirmed).
+#[must_use]
+pub fn check_step_up(claims: &JwtClaims, req: &StepUpRequirement, now: i64) -> StepUpOutcome {
+    let acr_ok = match (
+        claims.acr.as_deref().and_then(|a| a.parse::<u32>().ok()),
+        req.acr.parse::<u32>().ok(),
+    ) {
+        (Some(have), Some(need)) => have >= need,
+        // Non-numeric scheme: require an exact match.
+        _ => claims.acr.as_deref() == Some(req.acr.as_str()),
+    };
+
+    let age_ok = match req.max_age {
+        None => true,
+        Some(max) => claims.auth_time.is_some_and(|t| now - t <= max),
+    };
+
+    if acr_ok && age_ok {
+        StepUpOutcome::Satisfied
+    } else {
+        StepUpOutcome::Challenge {
+            acr_values: req.acr.clone(),
+            max_age: req.max_age,
+        }
+    }
+}
+
+/// Build the RFC 9470 §3 `WWW-Authenticate` challenge value for a `401`.
+///
+/// e.g. `Bearer error="insufficient_user_authentication",
+/// error_description="…", acr_values="2", max_age="300"`.
+#[must_use]
+pub fn step_up_challenge_header(acr_values: &str, max_age: Option<i64>) -> String {
+    let mut h = format!(
+        "Bearer error=\"insufficient_user_authentication\", \
+         error_description=\"A higher authentication assurance is required\", \
+         acr_values=\"{acr_values}\""
+    );
+    if let Some(age) = max_age {
+        h.push_str(&format!(", max_age=\"{age}\""));
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn claims_with(acr: Option<&str>, auth_time: Option<i64>) -> JwtClaims {
+        let mut b = JwtClaims::builder().subject("u1");
+        if let Some(a) = acr {
+            b = b.acr(a);
+        }
+        if let Some(t) = auth_time {
+            b = b.auth_time(t);
+        }
+        b.build()
+    }
+
+    #[test]
+    fn mfa_requirement_satisfied_by_acr_2() {
+        let c = claims_with(Some("2"), None);
+        assert_eq!(
+            check_step_up(&c, &StepUpRequirement::mfa(), 1000),
+            StepUpOutcome::Satisfied
+        );
+    }
+
+    #[test]
+    fn mfa_requirement_challenges_acr_1_and_missing() {
+        let req = StepUpRequirement::mfa();
+        assert!(matches!(
+            check_step_up(&claims_with(Some("1"), None), &req, 1000),
+            StepUpOutcome::Challenge { .. }
+        ));
+        assert!(matches!(
+            check_step_up(&claims_with(None, None), &req, 1000),
+            StepUpOutcome::Challenge { .. }
+        ));
+    }
+
+    #[test]
+    fn max_age_freshness_enforced() {
+        let req = StepUpRequirement::mfa_within(300);
+        // Fresh enough.
+        assert_eq!(
+            check_step_up(&claims_with(Some("2"), Some(900)), &req, 1000),
+            StepUpOutcome::Satisfied
+        );
+        // Too old.
+        assert!(matches!(
+            check_step_up(&claims_with(Some("2"), Some(600)), &req, 1000),
+            StepUpOutcome::Challenge { .. }
+        ));
+        // acr ok but no auth_time → cannot confirm freshness → challenge.
+        assert!(matches!(
+            check_step_up(&claims_with(Some("2"), None), &req, 1000),
+            StepUpOutcome::Challenge { .. }
+        ));
+    }
+
+    #[test]
+    fn challenge_header_format() {
+        assert_eq!(
+            step_up_challenge_header("2", Some(300)),
+            "Bearer error=\"insufficient_user_authentication\", \
+             error_description=\"A higher authentication assurance is required\", \
+             acr_values=\"2\", max_age=\"300\""
+        );
+        assert!(!step_up_challenge_header("2", None).contains("max_age"));
+    }
+}

--- a/docs/crates/maturity-matrix.md
+++ b/docs/crates/maturity-matrix.md
@@ -46,7 +46,7 @@ Criteria:
 | Crate | Status | Tests | Public Items | Notes |
 |-------|--------|-------|--------------|-------|
 | xavyo-core | 🟢 stable | 54 | 76 | Foundational types, well-tested |
-| xavyo-auth | 🟢 stable | 44 | 39 | JWT/Argon2id complete |
+| xavyo-auth | 🟢 stable | 51 | 46 | JWT/Argon2id + DPoP, acr/amr/auth_time, RFC 9470 step-up |
 | xavyo-db | 🟢 stable | 958+ | 400+ | 111K LOC, excellent coverage |
 | xavyo-tenant | 🟢 stable | 30 | 13 | Middleware complete |
 | xavyo-events | 🟢 stable | 123+ | 45 | Kafka bus with idempotence |


### PR DESCRIPTION
## What

The **capstone** of the step-up track (foundation #94 → refresh-forwarding #95 → this): a resource that needs higher assurance for a sensitive operation can now require an `acr`/`auth_time` level and **challenge** tokens that fall short.

New `xavyo_auth::step_up` — pure, DB-free primitives (mirrors the DPoP-Nonce challenge shape):

- **`StepUpRequirement`** — `acr` + optional `max_age`; `mfa()` / `mfa_within(secs)` helpers.
- **`check_step_up(claims, req, now) -> StepUpOutcome::{Satisfied, Challenge{acr_values, max_age}}`** — `acr` compared numerically for xavyo's `"1"`/`"2"`; a **missing `acr` never satisfies**; `max_age` requires a fresh-enough `auth_time` (missing `auth_time` **fails closed**).
- **`step_up_challenge_header(acr_values, max_age)`** — builds the RFC 9470 §3 `WWW-Authenticate: Bearer error="insufficient_user_authentication", …` value.

Resources opt in per sensitive operation (like `enforce_dpop`):
```rust
match check_step_up(&claims, &StepUpRequirement::mfa(), now()) {
    StepUpOutcome::Satisfied => { /* proceed */ }
    StepUpOutcome::Challenge { acr_values, max_age } =>
        return (StatusCode::UNAUTHORIZED,
                [(WWW_AUTHENTICATE, step_up_challenge_header(&acr_values, max_age))]).into_response(),
}
```

## Usable end-to-end

Now that login tokens carry `acr`/`amr`/`auth_time` (#94) and refresh preserves them (#95), a post-MFA token satisfies `acr=2` **and survives rotation** — no spurious re-challenge.

## Verification

- `cargo +1.95.0 clippy -p xavyo-auth --all-targets -- -D warnings` clean.
- 4 `step_up` unit tests: satisfied/challenge by `acr`, `max_age` freshness, header format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)