### PR TITLE
fix(idp-api): align admin bootstrap with case-insensitive email index

### DIFF
--- a/apps/idp-api/src/bootstrap.rs
+++ b/apps/idp-api/src/bootstrap.rs
@@ -105,7 +105,7 @@ async fn bootstrap_admin_user(pool: &PgPool) {
         }
     };
 
-    // Insert user (idempotent via ON CONFLICT)
+    // Insert user (idempotent via case-insensitive unique index users_tenant_email_ci_unique)
     let result = sqlx::query(
         r"
         INSERT INTO users (
@@ -116,7 +116,7 @@ async fn bootstrap_admin_user(pool: &PgPool) {
             gen_random_uuid(), $1, $2, $3, 'Admin',
             true, true, NOW(), NOW(), NOW()
         )
-        ON CONFLICT (tenant_id, email) DO NOTHING
+        ON CONFLICT (tenant_id, (lower(email))) DO NOTHING
         ",
     )
     .bind(SYSTEM_TENANT_ID)
@@ -128,38 +128,52 @@ async fn bootstrap_admin_user(pool: &PgPool) {
     match result {
         Ok(r) if r.rows_affected() > 0 => {
             info!(email = %admin_email, "bootstrap.admin.created: Admin user created");
-
-            // Fetch the user ID for role assignment
-            let user_id: Result<(uuid::Uuid,), _> =
-                sqlx::query_as("SELECT id FROM users WHERE tenant_id = $1 AND email = $2")
-                    .bind(SYSTEM_TENANT_ID)
-                    .bind(&admin_email)
-                    .fetch_one(pool)
-                    .await;
-
-            if let Ok((uid,)) = user_id {
-                // Assign super_admin role
-                let _ = sqlx::query(
-                    r"
-                    INSERT INTO user_roles (user_id, role_name, created_at)
-                    VALUES ($1, 'super_admin', NOW())
-                    ON CONFLICT (user_id, role_name) DO NOTHING
-                    ",
-                )
-                .bind(uid)
-                .execute(pool)
-                .await;
-
-                info!(email = %admin_email, role = "super_admin", "bootstrap.admin.role: Admin role assigned");
-            }
         }
         Ok(_) => {
             info!(email = %admin_email, "bootstrap.admin.exists: Admin user already exists");
         }
         Err(e) => {
             error!(error = %e, email = %admin_email, "Failed to create admin user");
+            return;
         }
     }
+
+    // Ensure super_admin role even when the user already existed (idempotent restarts)
+    let uid = match sqlx::query_as::<_, (uuid::Uuid,)>(
+        "SELECT id FROM users WHERE tenant_id = $1 AND lower(email) = lower($2)",
+    )
+    .bind(SYSTEM_TENANT_ID)
+    .bind(&admin_email)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(Some((uid,))) => uid,
+        Ok(None) => {
+            error!(email = %admin_email, "Admin user missing after bootstrap insert");
+            return;
+        }
+        Err(e) => {
+            error!(error = %e, email = %admin_email, "Failed to look up bootstrap admin user");
+            return;
+        }
+    };
+
+    if let Err(e) = sqlx::query(
+        r"
+        INSERT INTO user_roles (user_id, role_name, created_at)
+        VALUES ($1, 'super_admin', NOW())
+        ON CONFLICT (user_id, role_name) DO NOTHING
+        ",
+    )
+    .bind(uid)
+    .execute(pool)
+    .await
+    {
+        error!(error = %e, email = %admin_email, "Failed to assign super_admin role");
+        return;
+    }
+
+    info!(email = %admin_email, role = "super_admin", "bootstrap.admin.role: Admin role assigned");
 }
 
 /// Runs bootstrap and returns a boolean indicating success.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes admin user bootstrap on fresh installs. The `ON CONFLICT` clause did not match the case-insensitive unique index on `(tenant_id, lower(email))`, so `ADMIN_EMAIL` / `ADMIN_PASSWORD` never created the bootstrap admin.

## Changes

- Use `ON CONFLICT (tenant_id, (lower(email))) DO NOTHING` to match migration `0196_users_email_ci_unique.sql`
- Look up the bootstrap admin with `lower(email) = lower($2)` for case-insensitive matching
- Assign `super_admin` role on every bootstrap run (idempotent via `ON CONFLICT DO NOTHING`), including when the user already exists

## Related Issues

Fixes #110

## Type of Change

- [x] Bug fix

## Checklist

- [x] Code compiles (`cargo check --workspace`)
- [ ] Tests pass (`cargo test --workspace`)
- [ ] No clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [ ] Code formatted (`cargo fmt --all --check`)
- [x] Conventional commit messages used
- [ ] Documentation updated (if applicable)
- [x] Multi-tenancy: all queries include `tenant_id` filter

## Testing

1. Deleted existing `admin@xavyo.local` user from DB
2. Restarted `idp-api` with `ADMIN_EMAIL` / `ADMIN_PASSWORD` set
3. Verified logs: `bootstrap.admin.created` and `bootstrap.admin.role`
4. Verified DB: user exists with `email_verified=true`, `role_name=super_admin`
5. Verified login: `POST /auth/login` with `X-Tenant-ID` header → HTTP 200

## Notes

No schema changes required — this aligns application code with the existing unique index.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec3c3e7-b942-406b-a366-5787b878d23c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec3c3e7-b942-406b-a366-5787b878d23c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

