### PR TITLE
fix(deps): clear cargo-deny advisories blocking CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"
@@ -629,7 +629,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.19",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -1508,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2619,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2902,7 +2902,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.19",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -5298,9 +5298,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -5644,7 +5644,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2 0.4.19",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -7340,7 +7340,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
+ "h2 0.4.19",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio",
 uuid = { version = "1.6", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
-anyhow = "1.0"
+anyhow = "1.0.103"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
 dotenvy = "0.15"

--- a/crates/xavyo-api-governance/tests/self_service_handlers.rs
+++ b/crates/xavyo-api-governance/tests/self_service_handlers.rs
@@ -65,7 +65,7 @@ async fn json_body(response: axum::response::Response) -> Value {
     let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
         .await
         .expect("read body");
-    serde_json::from_slice(&bytes).unwrap_or_else(|_| Value::Null)
+    serde_json::from_slice(&bytes).unwrap_or(Value::Null)
 }
 
 #[tokio::test]

--- a/crates/xavyo-api-saml/Cargo.toml
+++ b/crates/xavyo-api-saml/Cargo.toml
@@ -18,7 +18,7 @@ urlencoding = "2.1"
 url = "2.5"
 
 # XML parsing
-quick-xml = "0.37"
+quick-xml = "0.41"
 
 # Date/time
 chrono.workspace = true

--- a/crates/xavyo-api-saml/src/lib.rs
+++ b/crates/xavyo-api-saml/src/lib.rs
@@ -15,6 +15,7 @@ pub mod router;
 pub mod saml;
 pub mod services;
 pub mod session;
+pub mod xml;
 
 pub use error::{SamlError, SamlResult};
 pub use handlers::metadata::SamlState;

--- a/crates/xavyo-api-saml/src/services/assertion_builder.rs
+++ b/crates/xavyo-api-saml/src/services/assertion_builder.rs
@@ -399,7 +399,7 @@ pub(crate) fn canonicalize_xml(xml: &str) -> SamlResult<String> {
                 output.push('>');
             }
             Ok(Event::Text(ref e)) => {
-                let text = e.unescape().map_err(|err| {
+                let text = e.decode().map_err(|err| {
                     SamlError::AssertionGenerationFailed(format!("XML unescape error: {err}"))
                 })?;
                 c14n_escape_text(&mut output, &text);
@@ -445,8 +445,10 @@ fn write_c14n_start_tag(
         let key = std::str::from_utf8(attr.key.as_ref()).map_err(|err| {
             SamlError::AssertionGenerationFailed(format!("Invalid UTF-8 in attribute name: {err}"))
         })?;
-        let value = attr.unescape_value().map_err(|err| {
-            SamlError::AssertionGenerationFailed(format!("XML attribute unescape error: {err}"))
+        let value = attr
+            .normalized_value(quick_xml::XmlVersion::Implicit1_0)
+            .map_err(|err| {
+            SamlError::AssertionGenerationFailed(format!("XML attribute decode error: {err}"))
         })?;
 
         if key == "xmlns" || key.starts_with("xmlns:") {

--- a/crates/xavyo-api-saml/src/services/assertion_builder.rs
+++ b/crates/xavyo-api-saml/src/services/assertion_builder.rs
@@ -448,8 +448,8 @@ fn write_c14n_start_tag(
         let value = attr
             .normalized_value(quick_xml::XmlVersion::Implicit1_0)
             .map_err(|err| {
-            SamlError::AssertionGenerationFailed(format!("XML attribute decode error: {err}"))
-        })?;
+                SamlError::AssertionGenerationFailed(format!("XML attribute decode error: {err}"))
+            })?;
 
         if key == "xmlns" || key.starts_with("xmlns:") {
             ns_attrs.push((key.to_string(), value.to_string()));

--- a/crates/xavyo-api-saml/src/services/logout_parser.rs
+++ b/crates/xavyo-api-saml/src/services/logout_parser.rs
@@ -71,7 +71,7 @@ pub fn parse_logout_request_xml(xml: &str) -> SamlResult<ParsedLogoutRequest> {
                 }
             }
             Ok(Event::Text(ref e)) => {
-                let text = e.unescape().unwrap_or_default().to_string();
+                let text = e.decode().unwrap_or_default().to_string();
                 match current_element.as_str() {
                     "Issuer" => issuer = Some(text),
                     "NameID" => name_id = Some(text),

--- a/crates/xavyo-api-saml/src/services/request_parser.rs
+++ b/crates/xavyo-api-saml/src/services/request_parser.rs
@@ -98,7 +98,7 @@ impl RequestParser {
                     }
                 }
                 Ok(Event::Text(e)) if in_issuer => {
-                    let issuer = e.unescape().unwrap_or_default().to_string();
+                    let issuer = e.decode().unwrap_or_default().to_string();
                     if issuer.len() > MAX_ISSUER_LENGTH {
                         return Err(SamlError::InvalidAuthnRequest(
                             "Issuer exceeds maximum length".to_string(),
@@ -210,7 +210,7 @@ impl RequestParser {
                         "AuthnRequest" => {
                             for attr in e.attributes().flatten() {
                                 let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
-                                let value = attr.unescape_value().unwrap_or_default();
+                                let value = crate::xml::attribute_value(&attr);
 
                                 match key {
                                     "ID" => id = Some(value.to_string()),
@@ -234,7 +234,7 @@ impl RequestParser {
                                 let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
                                 if key == "Format" {
                                     name_id_format =
-                                        Some(attr.unescape_value().unwrap_or_default().to_string());
+                                        Some(crate::xml::attribute_value(&attr).to_string());
                                 }
                             }
                         }
@@ -242,7 +242,7 @@ impl RequestParser {
                     }
                 }
                 Ok(Event::Text(e)) if in_issuer => {
-                    issuer = Some(e.unescape().unwrap_or_default().to_string());
+                    issuer = Some(e.decode().unwrap_or_default().to_string());
                 }
                 Ok(Event::End(e)) => {
                     let local_name = e.local_name();

--- a/crates/xavyo-api-saml/src/services/signature_validator.rs
+++ b/crates/xavyo-api-saml/src/services/signature_validator.rs
@@ -324,7 +324,7 @@ fn extract_signature_info(xml: &str) -> SamlResult<SignatureInfo> {
                     for attr in e.attributes().flatten() {
                         let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
                         if let Some(prefix) = key.strip_prefix("xmlns:") {
-                            let value = attr.unescape_value().unwrap_or_default().to_string();
+                            let value = crate::xml::attribute_value(&attr).to_string();
                             // Keep only the latest declaration per prefix
                             ancestor_namespaces.retain(|(p, _)| p != prefix);
                             ancestor_namespaces.push((prefix.to_string(), value));
@@ -340,7 +340,7 @@ fn extract_signature_info(xml: &str) -> SamlResult<SignatureInfo> {
                     for attr in e.attributes().flatten() {
                         let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
                         if key == "URI" {
-                            reference_uri = attr.unescape_value().unwrap_or_default().to_string();
+                            reference_uri = crate::xml::attribute_value(&attr).to_string();
                         }
                     }
                 }
@@ -359,7 +359,7 @@ fn extract_signature_info(xml: &str) -> SamlResult<SignatureInfo> {
                         let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
                         if key == "Algorithm" {
                             signature_algorithm =
-                                Some(attr.unescape_value().unwrap_or_default().to_string());
+                                Some(crate::xml::attribute_value(&attr).to_string());
                         }
                     }
                 } else if local == "DigestMethod" {
@@ -367,7 +367,7 @@ fn extract_signature_info(xml: &str) -> SamlResult<SignatureInfo> {
                         let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
                         if key == "Algorithm" {
                             digest_algorithm =
-                                Some(attr.unescape_value().unwrap_or_default().to_string());
+                                Some(crate::xml::attribute_value(&attr).to_string());
                         }
                     }
                 }
@@ -395,7 +395,7 @@ fn extract_signature_info(xml: &str) -> SamlResult<SignatureInfo> {
                 }
             }
             Ok(Event::Text(e)) => {
-                let text = e.unescape().unwrap_or_default();
+                let text = e.decode().unwrap_or_default();
                 if in_signed_info {
                     signed_info_content.push_str(&text);
                 } else if in_signature_value {
@@ -524,7 +524,7 @@ fn extract_element_by_id(xml: &str, element_id: &str) -> SamlResult<String> {
                         // Case-insensitive matching would find non-SAML elements with lowercase
                         // "id" attributes, enabling an XSW variant attack.
                         if key == "ID" {
-                            let val = attr.unescape_value().unwrap_or_default();
+                            let val = crate::xml::attribute_value(&attr);
                             if val.as_ref() == element_id {
                                 capturing = true;
                                 depth = 1;
@@ -560,7 +560,7 @@ fn extract_element_by_id(xml: &str, element_id: &str) -> SamlResult<String> {
                 for attr in e.attributes().flatten() {
                     let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
                     if key == "ID" {
-                        let val = attr.unescape_value().unwrap_or_default();
+                        let val = crate::xml::attribute_value(&attr);
                         if val.as_ref() == element_id {
                             let end_offset = reader.buffer_position() as usize;
                             return Ok(xml

--- a/crates/xavyo-api-saml/src/services/signature_validator.rs
+++ b/crates/xavyo-api-saml/src/services/signature_validator.rs
@@ -366,8 +366,7 @@ fn extract_signature_info(xml: &str) -> SamlResult<SignatureInfo> {
                     for attr in e.attributes().flatten() {
                         let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
                         if key == "Algorithm" {
-                            digest_algorithm =
-                                Some(crate::xml::attribute_value(&attr).to_string());
+                            digest_algorithm = Some(crate::xml::attribute_value(&attr).to_string());
                         }
                     }
                 }

--- a/crates/xavyo-api-saml/src/xml.rs
+++ b/crates/xavyo-api-saml/src/xml.rs
@@ -1,0 +1,12 @@
+//! quick-xml 0.41+ helpers shared across SAML parsers.
+
+use std::borrow::Cow;
+
+use quick_xml::events::attributes::Attribute;
+use quick_xml::XmlVersion;
+
+/// Decode a normalized attribute value for SAML 1.0-compatible documents.
+pub fn attribute_value<'a>(attr: &'a Attribute<'_>) -> Cow<'a, str> {
+    attr.normalized_value(XmlVersion::Implicit1_0)
+        .unwrap_or_default()
+}

--- a/crates/xavyo-api-saml/tests/interop/common.rs
+++ b/crates/xavyo-api-saml/tests/interop/common.rs
@@ -425,7 +425,7 @@ pub fn parse_saml_xml(xml: &str) -> Result<ParsedAssertion, String> {
                 }
             }
             Ok(Event::Text(e)) => {
-                let text = e.unescape().unwrap_or_default().to_string();
+                let text = e.decode().unwrap_or_default().to_string();
                 match current_element.as_str() {
                     "Issuer" if parsed.issuer.is_none() => {
                         parsed.issuer = Some(text);

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,17 @@ ignore = [
 
     # (RUSTSEC-2024-0363 sqlx removed 2026-05-25: resolved by the sqlx 0.8.6 upgrade.)
 
+    # rustls-webpki 0.101.7 / h2 0.3.27 — advisories in the legacy AWS SDK
+    # rustls-0.21 / hyper-0.14 connector stack (optional `aws-provider` on
+    # xavyo-secrets and transitive aws-config users). cargo-deny scans with
+    # `--all-features`, so these appear even though no default xavyo binary
+    # links the legacy connector; compiled TLS uses rustls 0.23 / h2 0.4.
+    # Deadline: 2026-09-01 — drop once AWS SDK drops the rustls-0.21 connector.
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 only via optional aws-provider/aws-config; absent from default build graph" },
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 only via optional aws-provider/aws-config; absent from default build graph" },
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 only via optional aws-provider/aws-config; absent from default build graph" },
+    { id = "RUSTSEC-2026-0258", reason = "h2 0.3.27 only via optional aws-config connector; default build uses h2 0.4.19; no 0.3.x patch upstream" },
+
     # RUSTSEC-2026-0097: rand — unsound when a custom `log::Log` implementation calls
     # `rand::rng()` reentrantly from within its own logging path.
     # Affected crate: rand (transitive). xavyo logs via `tracing`; it installs no custom

--- a/deny.toml
+++ b/deny.toml
@@ -35,25 +35,6 @@ ignore = [
 
     # (RUSTSEC-2024-0363 sqlx removed 2026-05-25: resolved by the sqlx 0.8.6 upgrade.)
 
-    # rustls-webpki 0.101.7 — three advisories in the legacy webpki used by the
-    # AWS SDK's rustls-0.21 connector:
-    #   RUSTSEC-2026-0104  reachable panic in CRL parsing
-    #   RUSTSEC-2026-0098  name constraints accepted for URI names
-    #   RUSTSEC-2026-0099  name constraints accepted for wildcard-name certs
-    # Affected crate: rustls-webpki 0.101.7 (transitive via xavyo-secrets' OPTIONAL
-    #   `aws-provider` feature). `cargo tree` confirms it is ABSENT from the default
-    #   build graph — no compiled xavyo binary links it; all compiled TLS uses
-    #   rustls 0.23 / rustls-webpki 0.103.13. cargo-deny still flags it because it
-    #   scans the full `cargo metadata` graph (optional deps included), so these
-    #   need explicit exemptions even though the code path is never built.
-    # Reachability: all three require actually validating a server certificate with
-    #   the 0.21 connector, which xavyo never does (aws-provider is off by default).
-    # Deadline: 2026-09-01 — drop once the AWS SDK moves off its rustls-0.21 connector
-    #   (tracked: bumping aws-smithy-http-client past the legacy connector).
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 only via optional aws-provider feature; absent from default build graph, not compiled into any xavyo binary" },
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 only via optional aws-provider feature; absent from default build graph, not compiled into any xavyo binary" },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 only via optional aws-provider feature; absent from default build graph, not compiled into any xavyo binary" },
-
     # RUSTSEC-2026-0097: rand — unsound when a custom `log::Log` implementation calls
     # `rand::rng()` reentrantly from within its own logging path.
     # Affected crate: rand (transitive). xavyo logs via `tracing`; it installs no custom


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `cargo-deny` Dependency audit job that has been failing on master since new RUSTSEC advisories landed in 2026.

## Changes

- Bump `anyhow` workspace dep to `>=1.0.103` (RUSTSEC-2026-0190)
- Update lockfile: `crossbeam-epoch` 0.9.20, `h2` 0.4.19, `quick-xml` 0.41.0
- Upgrade `xavyo-api-saml` to quick-xml 0.41 and migrate parsers (`decode`, `normalized_value`)
- Add `xml::attribute_value` helper for SAML attribute decoding
- Document optional AWS connector advisories for `cargo-deny --all-features` (h2 0.3, rustls-webpki 0.101)
- Fix clippy in governance self-service test

## Testing

- `cargo deny --all-features check` — PASS
- `RUSTFLAGS=-Dwarnings cargo build -p idp-api` — PASS
- `cargo test -p xavyo-api-saml` — 28/28 PASS
- CI: Dependency audit, Build, Clippy, Golden path smoke, Formatting — PASS
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec3c3e7-b942-406b-a366-5787b878d23c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec3c3e7-b942-406b-a366-5787b878d23c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

