### PR TITLE
fix(connector-ldap): add DN to AD mapping test fixtures

### DIFF
--- a/crates/xavyo-connector-ldap/CRATE.md
+++ b/crates/xavyo-connector-ldap/CRATE.md
@@ -14,7 +14,7 @@ connector
 
 🟢 **stable**
 
-Production-ready with extensive test coverage (239 tests). Most mature connector implementation with full LDAP v3 support.
+Production-ready with extensive test coverage (253+ unit tests). Most mature connector implementation with full LDAP v3 support. AD mapping requires `distinguishedName`/`dn` on every entry (fail-closed).
 
 ## Dependencies
 

--- a/crates/xavyo-connector-ldap/src/ad/groups.rs
+++ b/crates/xavyo-connector-ldap/src/ad/groups.rs
@@ -859,6 +859,7 @@ mod tests {
     fn test_map_ad_group_single_member() {
         let mut entry = AttributeSet::new();
         entry.set("objectGUID", AttributeValue::Binary(vec![0x02; 16]));
+        entry.set("distinguishedName", "CN=SoloGroup,OU=Groups,DC=ex,DC=com");
         entry.set("groupType", AttributeValue::Integer(-2147483646));
         // Single member as string (not array)
         entry.set("member", "CN=Solo,OU=Users,DC=ex,DC=com");

--- a/crates/xavyo-connector-ldap/src/ad/sync.rs
+++ b/crates/xavyo-connector-ldap/src/ad/sync.rs
@@ -916,7 +916,10 @@ mod tests {
     fn test_map_ad_user_cn_fallback_display_name() {
         let mut entry = AttributeSet::new();
         entry.set("objectGUID", AttributeValue::Binary(vec![0x01; 16]));
-        entry.set("distinguishedName", "CN=John Doe,OU=Users,DC=example,DC=com");
+        entry.set(
+            "distinguishedName",
+            "CN=John Doe,OU=Users,DC=example,DC=com",
+        );
         entry.set("cn", "John Doe");
         // No displayName set
 
@@ -1445,7 +1448,10 @@ mod tests {
             {
                 let mut e = AttributeSet::new();
                 e.set("objectGUID", AttributeValue::Binary(vec![0xAA; 16]));
-                e.set("distinguishedName", "CN=GoodUser,OU=Users,DC=example,DC=com");
+                e.set(
+                    "distinguishedName",
+                    "CN=GoodUser,OU=Users,DC=example,DC=com",
+                );
                 e.set("sAMAccountName", "good_user");
                 e
             },

--- a/crates/xavyo-connector-ldap/src/ad/sync.rs
+++ b/crates/xavyo-connector-ldap/src/ad/sync.rs
@@ -788,6 +788,7 @@ mod tests {
     fn test_map_ad_user_no_uac_is_inactive() {
         let mut entry = AttributeSet::new();
         entry.set("objectGUID", AttributeValue::Binary(vec![0x01; 16]));
+        entry.set("distinguishedName", "CN=Test,OU=Users,DC=example,DC=com");
         entry.set("sAMAccountName", "test");
 
         let mapped = map_ad_user(&entry).unwrap();
@@ -904,6 +905,7 @@ mod tests {
     fn test_map_ad_user_objectguid_as_string() {
         let mut entry = AttributeSet::new();
         entry.set("objectGUID", "some-guid-string");
+        entry.set("distinguishedName", "CN=Test,OU=Users,DC=example,DC=com");
         entry.set("sAMAccountName", "test");
 
         let mapped = map_ad_user(&entry).unwrap();
@@ -914,6 +916,7 @@ mod tests {
     fn test_map_ad_user_cn_fallback_display_name() {
         let mut entry = AttributeSet::new();
         entry.set("objectGUID", AttributeValue::Binary(vec![0x01; 16]));
+        entry.set("distinguishedName", "CN=John Doe,OU=Users,DC=example,DC=com");
         entry.set("cn", "John Doe");
         // No displayName set
 
@@ -925,6 +928,7 @@ mod tests {
     fn test_map_ad_user_minimal_entry() {
         let mut entry = AttributeSet::new();
         entry.set("objectGUID", AttributeValue::Binary(vec![0xFF; 16]));
+        entry.set("distinguishedName", "CN=Minimal,OU=Users,DC=example,DC=com");
 
         let mapped = map_ad_user(&entry).unwrap();
         assert!(!mapped.external_id.is_empty());
@@ -1399,6 +1403,7 @@ mod tests {
             {
                 let mut e = AttributeSet::new();
                 e.set("objectGUID", AttributeValue::Binary(vec![0x01; 16]));
+                e.set("distinguishedName", "CN=User1,OU=Users,DC=example,DC=com");
                 e.set("sAMAccountName", "user1");
                 e
             },
@@ -1412,6 +1417,7 @@ mod tests {
             {
                 let mut e = AttributeSet::new();
                 e.set("objectGUID", AttributeValue::Binary(vec![0x03; 16]));
+                e.set("distinguishedName", "CN=User3,OU=Users,DC=example,DC=com");
                 e.set("sAMAccountName", "user3");
                 e
             },
@@ -1439,6 +1445,7 @@ mod tests {
             {
                 let mut e = AttributeSet::new();
                 e.set("objectGUID", AttributeValue::Binary(vec![0xAA; 16]));
+                e.set("distinguishedName", "CN=GoodUser,OU=Users,DC=example,DC=com");
                 e.set("sAMAccountName", "good_user");
                 e
             },

--- a/docs/crates/maturity-matrix.md
+++ b/docs/crates/maturity-matrix.md
@@ -72,7 +72,7 @@ Criteria:
 
 | Crate | Status | Tests | Public Items | Notes |
 |-------|--------|-------|--------------|-------|
-| xavyo-connector-ldap | 🟢 stable | 239 | 31 | Most mature connector |
+| xavyo-connector-ldap | 🟢 stable | 253+ | 31 | Most mature connector; DN-required AD mapping + 253 unit tests in CI |
 | xavyo-connector-entra | 🟢 stable | 64 | 42 | Crate/API with rate limiting; no UI form |
 | xavyo-connector-rest | 🟢 stable | 114 | 7 | Matches CRATE.md: CRUD, rate limit, retry, SSRF. Crate/API; not a production UI path |
 | xavyo-connector-database | 🟡 beta | 51 | 4 | PostgreSQL CRUD + transactions; needs DB integration tests |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes 7 failing unit tests in `xavyo-connector-ldap` that blocked the main CI `Tests` job on master. Refreshes stable-crate documentation with current test counts.

## Changes

- Add `distinguishedName` to minimal AD user/group test fixtures in `sync.rs` and `groups.rs`
- Update batch sync tests so entries with `objectGUID` also include DN
- `cargo fmt` on long DN lines
- Update `CRATE.md` and `maturity-matrix.md` (253+ unit tests, DN fail-closed note)

## Related Issues

Unblocks master CI after DN requirement was added to `map_ad_user()` and `map_ad_group()`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Testing

```bash
cargo fmt --all --check
cargo test -p xavyo-connector-ldap
# 253 passed; 0 failed
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec3c3e7-b942-406b-a366-5787b878d23c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec3c3e7-b942-406b-a366-5787b878d23c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

