### PR TITLE
feat(ssf): promote xavyo-ssf and xavyo-api-ssf from alpha to beta

### DIFF
--- a/.github/workflows/beta-crate-integration.yml
+++ b/.github/workflows/beta-crate-integration.yml
@@ -78,3 +78,37 @@ jobs:
 
       - name: Run connector-database integration tests
         run: cargo test -p xavyo-connector-database --features integration -- --test-threads=1
+
+  api-ssf:
+    name: api-ssf integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: xavyo
+          POSTGRES_PASSWORD: xavyo_test_password
+          POSTGRES_DB: xavyo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U xavyo -d xavyo_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev protobuf-compiler postgresql-client
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Initialize database
+        run: PGPASSWORD=xavyo_test_password psql -h localhost -U xavyo -d xavyo_test -f docker/postgres/init.sql
+
+      - name: Run migrations
+        run: cargo run -p xavyo-db --bin migrate
+
+      - name: Run api-ssf integration tests
+        run: cargo test -p xavyo-api-ssf --features integration

--- a/crates/xavyo-api-ssf/CRATE.md
+++ b/crates/xavyo-api-ssf/CRATE.md
@@ -14,9 +14,9 @@ api
 
 ## Status
 
-🔴 **alpha**
+🟡 **beta**
 
-20 unit tests (SSRF guard, model serialization, transmitter SET building, poll token hashing/parsing). Push (RFC 8935) + poll (RFC 8936) delivery, the poll-queue TTL bound, and stream-verification events (SSF §7.1.4) are all implemented (the verification event payload is tested in `xavyo-ssf`). No HTTP+Postgres integration tests yet — API will change.
+25 unit tests (SSRF guard, model serialization, transmitter SET building, poll token hashing/parsing) plus 4 PostgreSQL integration tests in CI (`beta-crate-integration` workflow): stream CRUD, subjects, poll queue enqueue/ack, and enabled-for-event fan-out. Push (RFC 8935) + poll (RFC 8936) delivery are implemented.
 
 ## Dependencies
 
@@ -110,7 +110,7 @@ let app = Router::new()
 
 ## Feature Flags
 
-- `integration` — gates Postgres-backed integration tests (none yet; reserved).
+- `integration` — gates Postgres-backed integration tests (`tests/integration.rs`).
 
 ## Anti-Patterns
 

--- a/crates/xavyo-api-ssf/Cargo.toml
+++ b/crates/xavyo-api-ssf/Cargo.toml
@@ -51,3 +51,13 @@ hex = "0.4"
 tokio = { workspace = true, features = ["full"] }
 tower = { workspace = true, features = ["util"] }
 wiremock = "0.6"
+sqlx = { workspace = true }
+
+[features]
+default = []
+integration = []
+
+[[test]]
+name = "integration"
+path = "tests/integration.rs"
+required-features = ["integration"]

--- a/crates/xavyo-api-ssf/tests/common/mod.rs
+++ b/crates/xavyo-api-ssf/tests/common/mod.rs
@@ -1,0 +1,78 @@
+//! Shared helpers for SSF API PostgreSQL integration tests.
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Postgres, Transaction};
+use std::time::Duration;
+use uuid::Uuid;
+use xavyo_db::models::{CreateSsfStream, SsfStream};
+use xavyo_ssf::SESSION_REVOKED_URI;
+
+pub const TEST_DATABASE_URL_ENV: &str = "TEST_DATABASE_URL";
+pub const POLL_DELIVERY_METHOD: &str = "urn:ietf:rfc:8936";
+
+pub async fn get_test_pool() -> PgPool {
+    let database_url = std::env::var(TEST_DATABASE_URL_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .unwrap_or_else(|_| {
+            "postgres://xavyo:xavyo_test_password@localhost:5432/xavyo_test".to_string()
+        });
+
+    PgPoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect(&database_url)
+        .await
+        .expect("failed to connect to test database")
+}
+
+pub async fn create_test_tenant(pool: &PgPool) -> Uuid {
+    let tenant_id = Uuid::new_v4();
+    let slug = format!("ssf-itest-{}", &tenant_id.to_string()[..8]);
+
+    sqlx::query(
+        r#"
+        INSERT INTO tenants (id, name, slug, settings, created_at)
+        VALUES ($1, $2, $3, '{}', NOW())
+        ON CONFLICT (id) DO NOTHING
+        "#,
+    )
+    .bind(tenant_id)
+    .bind(&slug)
+    .bind(&slug)
+    .execute(pool)
+    .await
+    .expect("failed to create test tenant");
+
+    tenant_id
+}
+
+pub async fn tenant_tx(pool: &PgPool, tenant_id: Uuid) -> Transaction<'_, Postgres> {
+    let mut tx = pool.begin().await.expect("begin transaction");
+    sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+        .bind(tenant_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .expect("set tenant RLS context");
+    tx
+}
+
+pub async fn create_poll_stream(pool: &PgPool, tenant_id: Uuid) -> SsfStream {
+    let mut tx = tenant_tx(pool, tenant_id).await;
+    let stream = SsfStream::create(
+        &mut *tx,
+        CreateSsfStream {
+            tenant_id,
+            aud: "https://rp.example.com/ssf".to_string(),
+            delivery_method: POLL_DELIVERY_METHOD.to_string(),
+            endpoint_url: String::new(),
+            delivery_authorization_header: None,
+            events_requested: vec![SESSION_REVOKED_URI.to_string()],
+            events_delivered: vec![SESSION_REVOKED_URI.to_string()],
+            description: Some("ssf integration test stream".to_string()),
+        },
+    )
+    .await
+    .expect("create stream");
+    tx.commit().await.expect("commit stream create");
+    stream
+}

--- a/crates/xavyo-api-ssf/tests/integration.rs
+++ b/crates/xavyo-api-ssf/tests/integration.rs
@@ -1,0 +1,144 @@
+//! PostgreSQL integration tests for the SSF Transmitter API.
+//!
+//! Run with: `cargo test -p xavyo-api-ssf --features integration`
+
+mod common;
+
+use serde_json::json;
+use uuid::Uuid;
+use xavyo_db::models::{SsfQueuedEvent, SsfStream, SsfSubject, STREAM_STATUS_PAUSED};
+use xavyo_ssf::SESSION_REVOKED_URI;
+
+use common::{create_poll_stream, create_test_tenant, get_test_pool, tenant_tx};
+
+#[tokio::test]
+async fn stream_create_list_get_status_delete_round_trip() {
+    let pool = get_test_pool().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let stream = create_poll_stream(&pool, tenant_id).await;
+
+    {
+        let mut tx = tenant_tx(&pool, tenant_id).await;
+        let listed = SsfStream::list_by_tenant(&mut *tx, tenant_id)
+            .await
+            .expect("list streams");
+        assert!(listed.iter().any(|s| s.stream_id == stream.stream_id));
+
+        let fetched = SsfStream::get(&mut *tx, tenant_id, stream.stream_id)
+            .await
+            .expect("get stream")
+            .expect("stream must exist");
+        assert_eq!(fetched.status, "enabled");
+        assert_eq!(fetched.events_delivered, vec![SESSION_REVOKED_URI]);
+
+        let paused =
+            SsfStream::update_status(&mut *tx, tenant_id, stream.stream_id, STREAM_STATUS_PAUSED)
+                .await
+                .expect("update status")
+                .expect("updated row");
+        assert_eq!(paused.status, STREAM_STATUS_PAUSED);
+
+        let deleted = SsfStream::delete(&mut *tx, tenant_id, stream.stream_id)
+            .await
+            .expect("delete stream");
+        assert!(deleted);
+
+        let missing = SsfStream::get(&mut *tx, tenant_id, stream.stream_id)
+            .await
+            .expect("get after delete");
+        assert!(missing.is_none());
+        tx.commit().await.expect("commit");
+    }
+}
+
+#[tokio::test]
+async fn subject_add_list_remove_round_trip() {
+    let pool = get_test_pool().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let stream = create_poll_stream(&pool, tenant_id).await;
+    let subject = json!({
+        "format": "email",
+        "email": "alice@example.com"
+    });
+
+    let mut tx = tenant_tx(&pool, tenant_id).await;
+    let added = SsfSubject::add(&mut *tx, tenant_id, stream.stream_id, &subject)
+        .await
+        .expect("add subject");
+    assert_eq!(added.subject, subject);
+
+    let listed = SsfSubject::list_for_stream(&mut *tx, tenant_id, stream.stream_id)
+        .await
+        .expect("list subjects");
+    assert_eq!(listed.len(), 1);
+
+    let removed = SsfSubject::remove(&mut *tx, tenant_id, stream.stream_id, &subject)
+        .await
+        .expect("remove subject");
+    assert_eq!(removed, 1);
+
+    let empty = SsfSubject::list_for_stream(&mut *tx, tenant_id, stream.stream_id)
+        .await
+        .expect("list after remove");
+    assert!(empty.is_empty());
+    tx.commit().await.expect("commit");
+}
+
+#[tokio::test]
+async fn poll_queue_enqueue_poll_ack() {
+    let pool = get_test_pool().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let stream = create_poll_stream(&pool, tenant_id).await;
+    let jti = Uuid::new_v4().to_string();
+
+    let mut tx = tenant_tx(&pool, tenant_id).await;
+    SsfQueuedEvent::enqueue(
+        &mut *tx,
+        tenant_id,
+        stream.stream_id,
+        &jti,
+        "header.payload.signature",
+    )
+    .await
+    .expect("enqueue SET");
+
+    let batch = SsfQueuedEvent::poll(&mut *tx, tenant_id, stream.stream_id, 10)
+        .await
+        .expect("poll queue");
+    assert_eq!(batch.len(), 1);
+    assert_eq!(batch[0].jti, jti);
+
+    let acked = SsfQueuedEvent::ack(&mut *tx, tenant_id, stream.stream_id, &[jti.clone()])
+        .await
+        .expect("ack SET");
+    assert_eq!(acked, 1);
+
+    let empty = SsfQueuedEvent::poll(&mut *tx, tenant_id, stream.stream_id, 10)
+        .await
+        .expect("poll after ack");
+    assert!(empty.is_empty());
+    tx.commit().await.expect("commit");
+}
+
+#[tokio::test]
+async fn list_enabled_for_event_respects_status_and_uri() {
+    let pool = get_test_pool().await;
+    let tenant_id = create_test_tenant(&pool).await;
+    let stream = create_poll_stream(&pool, tenant_id).await;
+
+    let mut tx = tenant_tx(&pool, tenant_id).await;
+    let enabled = SsfStream::list_enabled_for_event(&mut *tx, tenant_id, SESSION_REVOKED_URI)
+        .await
+        .expect("list enabled");
+    assert!(enabled.iter().any(|s| s.stream_id == stream.stream_id));
+
+    SsfStream::update_status(&mut *tx, tenant_id, stream.stream_id, STREAM_STATUS_PAUSED)
+        .await
+        .expect("pause stream");
+
+    let after_pause = SsfStream::list_enabled_for_event(&mut *tx, tenant_id, SESSION_REVOKED_URI)
+        .await
+        .expect("list after pause");
+    assert!(!after_pause.iter().any(|s| s.stream_id == stream.stream_id));
+    tx.commit().await.expect("commit");
+}

--- a/crates/xavyo-ssf/CRATE.md
+++ b/crates/xavyo-ssf/CRATE.md
@@ -14,9 +14,9 @@ domain
 
 ## Status
 
-🔴 **alpha**
+🟡 **beta**
 
-16 unit tests covering event payloads (incl. the SSF `verification` event), subject-identifier serialization, and SET signing. Don't depend on signatures yet — the API will still change.
+18 unit tests covering event payloads (incl. the SSF `verification` event), subject-identifier serialization, SET signing, and the `NoopEmitter`. Domain core is DB-free and production-used via `xavyo-api-ssf`; API surface may still evolve.
 
 ## Dependencies
 

--- a/crates/xavyo-ssf/src/emitter.rs
+++ b/crates/xavyo-ssf/src/emitter.rs
@@ -68,5 +68,18 @@ mod tests {
             "password".into(),
             CredentialChangeType::Update,
         );
+        e.token_claims_change(
+            Uuid::nil(),
+            Uuid::nil(),
+            serde_json::json!({"roles": ["admin"]}),
+        );
+    }
+
+    #[test]
+    fn noop_emitter_is_send_sync_object_safe() {
+        fn assert_object_safe(_: &dyn CaepEmitter) {}
+        assert_object_safe(&NoopEmitter);
+        let boxed: Box<dyn CaepEmitter> = Box::new(NoopEmitter);
+        boxed.session_revoked(Uuid::nil(), Uuid::nil(), Some("logout".into()));
     }
 }

--- a/docs/crates/index.md
+++ b/docs/crates/index.md
@@ -29,7 +29,7 @@ Business logic independent of HTTP transport.
 | [xavyo-authorization](../../crates/xavyo-authorization/CRATE.md) | Authorization engine (PDP) | 🟢 stable |
 | [xavyo-webhooks](../../crates/xavyo-webhooks/CRATE.md) | Event subscriptions and delivery | 🟢 stable |
 | [xavyo-siem](../../crates/xavyo-siem/CRATE.md) | Audit log export (syslog, Splunk) | 🟢 stable |
-| [xavyo-ssf](../../crates/xavyo-ssf/CRATE.md) | CAEP/Shared Signals: SETs, subject IDs, emitter | 🔴 alpha |
+| [xavyo-ssf](../../crates/xavyo-ssf/CRATE.md) | CAEP/Shared Signals: SETs, subject IDs, emitter | 🟡 beta |
 | [xavyo-secrets](../../crates/xavyo-secrets/CRATE.md) | External secret providers | 🟢 stable |
 | [xavyo-scim-client](../../crates/xavyo-scim-client/CRATE.md) | Outbound SCIM provisioning | 🟢 stable |
 | [xavyo-scim-types](../../crates/xavyo-scim-types/CRATE.md) | Shared SCIM 2.0 DTOs (RFC 7643/7644) | 🟢 stable |
@@ -65,7 +65,7 @@ REST endpoints exposed to clients.
 | [xavyo-api-import](../../crates/xavyo-api-import/CRATE.md) | Bulk user import API | 🟢 stable |
 | [xavyo-api-oidc-federation](../../crates/xavyo-api-oidc-federation/CRATE.md) | OIDC federation endpoints | 🟢 stable |
 | [xavyo-api-nhi](../../crates/xavyo-api-nhi/CRATE.md) | Non-human identity API | 🟢 stable |
-| [xavyo-api-ssf](../../crates/xavyo-api-ssf/CRATE.md) | SSF transmitter: streams, push CAEP signals | 🔴 alpha |
+| [xavyo-api-ssf](../../crates/xavyo-api-ssf/CRATE.md) | SSF transmitter: streams, push CAEP signals | 🟡 beta |
 
 ## Dependency Rules
 

--- a/docs/crates/maturity-matrix.md
+++ b/docs/crates/maturity-matrix.md
@@ -62,7 +62,7 @@ Criteria:
 | xavyo-authorization | 🟢 stable | 124+ | 16 | PDP + optional Cedar; foundation crate |
 | xavyo-webhooks | 🟢 stable | 160+ | 31 | 198 tests with `integration` feature; delivery, retry, DLQ |
 | xavyo-siem | 🟢 stable | 118+ | 47 | 269 tests with `integration` feature; syslog, Splunk HEC |
-| xavyo-ssf | 🔴 alpha | 16 | 24 | CAEP/SSF SET signing + emitter (incl. SSF verification event), no integration tests |
+| xavyo-ssf | 🟡 beta | 18 | 24 | CAEP/SSF SET signing + emitter; DB-free domain core |
 | xavyo-secrets | 🟢 stable | 51 | 28 | Multi-provider (Vault, AWS) |
 | xavyo-scim-client | 🟢 stable | 150+ | 24 | Full integration test coverage |
 | xavyo-scim-types | 🟢 stable | 9 | 17 | Pure SCIM 2.0 DTOs (RFC 7643/7644); RFC-pinned shape |
@@ -94,7 +94,7 @@ Criteria:
 | xavyo-api-import | 🟢 stable | 92+ | 45+ | Full integration test coverage |
 | xavyo-api-oidc-federation | 🟢 stable | 79+ | 16 | IdP interop tests (Auth0, Azure AD, Okta, Google) |
 | xavyo-api-nhi | 🟢 stable | 77 | 33 | Complete with risk scoring, F-047 & F-048 |
-| xavyo-api-ssf | 🔴 alpha | 20 | 50 | SSF push + poll (RFC 8936) delivery + SSRF guard, no integration tests |
+| xavyo-api-ssf | 🟡 beta | 29+ | 50 | Push+poll delivery + SSRF; 4 PostgreSQL integration tests in CI |
 
 ---
 
@@ -103,8 +103,8 @@ Criteria:
 | Status | Count | Crates |
 |--------|-------|--------|
 | 🟢 Stable | 32 | xavyo-core, xavyo-auth, xavyo-db, xavyo-tenant, xavyo-events, xavyo-nhi, xavyo-secrets, xavyo-connector, xavyo-connector-ldap, xavyo-connector-entra, xavyo-connector-rest, xavyo-connector-database, xavyo-governance, xavyo-provisioning, xavyo-webhooks, xavyo-siem, xavyo-scim-client, xavyo-scim-types, xavyo-authorization, xavyo-ext-authz, xavyo-api-auth, xavyo-api-oauth, xavyo-api-governance, xavyo-api-tenants, xavyo-api-import, xavyo-api-users, xavyo-api-scim, xavyo-api-saml, xavyo-api-oidc-federation, xavyo-api-social, xavyo-api-nhi, xavyo-api-authorization, xavyo-api-connectors |
-| 🟡 Beta | 0 | — |
-| 🔴 Alpha | 2 | xavyo-ssf, xavyo-api-ssf |
+| 🟡 Beta | 2 | xavyo-ssf, xavyo-api-ssf |
+| 🔴 Alpha | 0 | — |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -51,7 +51,7 @@ The `docs-site/` contains a full Docusaurus documentation site:
 - [xavyo-authorization](crates/xavyo-authorization/CRATE.md): 🟢 Policy engine + Cedar (feature: `cedar`)
 - [xavyo-webhooks](crates/xavyo-webhooks/CRATE.md): 🟢 Event delivery
 - [xavyo-siem](crates/xavyo-siem/CRATE.md): 🟢 Audit export
-- [xavyo-ssf](crates/xavyo-ssf/CRATE.md): 🔴 CAEP/Shared Signals (SETs, emitter)
+- [xavyo-ssf](crates/xavyo-ssf/CRATE.md): 🟡 CAEP/Shared Signals (SETs, emitter)
 - [xavyo-secrets](crates/xavyo-secrets/CRATE.md): 🟢 Secret providers
 - [xavyo-scim-client](crates/xavyo-scim-client/CRATE.md): 🟢 Outbound SCIM
 - [xavyo-scim-types](crates/xavyo-scim-types/CRATE.md): 🟢 Shared SCIM 2.0 DTOs (RFC 7643/7644)
@@ -77,7 +77,7 @@ The `docs-site/` contains a full Docusaurus documentation site:
 - [xavyo-api-import](crates/xavyo-api-import/CRATE.md): 🟢 Bulk import
 - [xavyo-api-oidc-federation](crates/xavyo-api-oidc-federation/CRATE.md): 🟢 OIDC federation
 - [xavyo-api-nhi](crates/xavyo-api-nhi/CRATE.md): 🟢 Non-human identity API
-- [xavyo-api-ssf](crates/xavyo-api-ssf/CRATE.md): 🔴 SSF transmitter (streams, push CAEP)
+- [xavyo-api-ssf](crates/xavyo-api-ssf/CRATE.md): 🟡 SSF transmitter (streams, push CAEP)
 
 ## CRM Digital Twin Features (New)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Promotes the last two alpha crates (`xavyo-ssf`, `xavyo-api-ssf`) to 🟡 beta, clearing the alpha backlog.

## Changes

### `xavyo-ssf` (alpha → beta)
- Expand `NoopEmitter` unit coverage (object-safety + `token_claims_change`)
- Status docs: **18** unit tests; DB-free domain core used in production via `xavyo-api-ssf`

### `xavyo-api-ssf` (alpha → beta)
- **4 PostgreSQL integration tests**:
  - stream create / list / get / status update / delete
  - subject add / list / remove
  - poll queue enqueue / poll / ack
  - `list_enabled_for_event` respects status + URI
- Feature flag `integration` wired; CI job `api-ssf integration` in `beta-crate-integration.yml`

## Maturity after this PR

| Status | Count |
|--------|-------|
| 🟢 Stable | 32 |
| 🟡 Beta | 2 (`xavyo-ssf`, `xavyo-api-ssf`) |
| 🔴 Alpha | **0** |

Stable promotion deferred until HTTP E2E coverage and API freeze (CRATE notes surface may still evolve).

## Testing

```bash
cargo test -p xavyo-ssf
# 18 passed
cargo test -p xavyo-api-ssf --features integration
# 25 unit + 4 integration passed
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec3c3e7-b942-406b-a366-5787b878d23c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec3c3e7-b942-406b-a366-5787b878d23c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

