### PR TITLE
fix(api-auth): classify desktop OS user-agents as desktop

### DIFF
--- a/crates/xavyo-api-auth/src/services/user_agent_parser.rs
+++ b/crates/xavyo-api-auth/src/services/user_agent_parser.rs
@@ -61,6 +61,17 @@ fn detect_device_type(ua: &str) -> String {
         return "mobile".to_string();
     }
 
+    // Desktop OS signals — only then classify as desktop.
+    if ua.contains("windows")
+        || ua.contains("macintosh")
+        || ua.contains("mac os x")
+        || ua.contains("linux")
+        || ua.contains("cros")
+        || ua.contains("x11")
+    {
+        return "desktop".to_string();
+    }
+
     // Unrecognized UA is not a desktop — device-type policies must not skip.
     "unknown".to_string()
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes 2 failing unit tests in `xavyo-api-auth` found during a full per-crate functional test campaign.

## Problem

`detect_device_type` returned `"unknown"` for every non-mobile UA, so Chrome on Windows and Firefox on macOS were not classified as `"desktop"`.

## Fix

When no mobile/tablet markers are present, treat Windows / macOS / Linux / X11 / ChromeOS signals as `"desktop"`. Unrecognized UAs remain `"unknown"` (fail-closed for device-type policies).

## Testing

```bash
cargo test -p xavyo-api-auth --lib services::user_agent_parser
# 9 passed
cargo test -p xavyo-api-auth --lib
# 417 passed; 0 failed
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ec3c3e7-b942-406b-a366-5787b878d23c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ec3c3e7-b942-406b-a366-5787b878d23c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

