### PR TITLE
fix(iam): harden auth — funnel, WebAuthn, invites, social, login 500, OIDC federation (real-provider + refreshable + SPA session)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8825,6 +8825,7 @@ name = "xavyo-api-oidc-federation"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
+ "async-trait",
  "axum",
  "base64 0.22.1",
  "chrono",

--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -1003,7 +1003,14 @@ async fn main() {
         frontend_url: config.frontend_url.clone(),
         jwt_private_key_pem: config.jwt_private_key.expose_secret().as_bytes().to_vec(),
     };
-    let federation_state = FederationState::new(&federation_config);
+    let mut federation_state = FederationState::new(&federation_config);
+    // Issue federation session tokens through the shared TokenService so the
+    // refresh token is persisted (refreshable + revocable), matching password
+    // and social login. The default standalone JWT issuer is not refreshable.
+    federation_state.token_issuer = std::sync::Arc::new(FederationTokenAdapter {
+        pool: pool.clone(),
+        jwt_private_key: SecretString::from(config.jwt_private_key.expose_secret().to_string()),
+    });
 
     // F-1: CRITICAL - Split federation routes based on tenant requirements
     // Routes that need tenant context (discover, authorize, logout) - require X-Tenant-ID
@@ -2019,6 +2026,58 @@ fn build_cors_layer(origins: &[String]) -> CorsLayer {
     }
 
     layer
+}
+
+/// Adapter so OIDC federation issues session tokens via the shared `TokenService`
+/// (persisted, refreshable, revocable refresh tokens) instead of the standalone
+/// non-persisted JWT issuer.
+struct FederationTokenAdapter {
+    pool: sqlx::PgPool,
+    jwt_private_key: SecretString,
+}
+
+#[async_trait::async_trait]
+impl xavyo_api_oidc_federation::FederationTokenIssuer for FederationTokenAdapter {
+    async fn issue_tokens(
+        &self,
+        user_id: uuid::Uuid,
+        tenant_id: uuid::Uuid,
+        roles: Vec<String>,
+        email: Option<String>,
+        _name: Option<String>,
+        _federation_claims: Option<xavyo_api_oidc_federation::models::FederationClaims>,
+    ) -> Result<xavyo_api_oidc_federation::IssuedTokens, xavyo_api_oidc_federation::FederationError>
+    {
+        let token_config = TokenConfig::new(
+            self.jwt_private_key.expose_secret().as_bytes().to_vec(),
+            "xavyo".to_string(),
+            "xavyo".to_string(),
+        );
+        let token_service = TokenService::new(token_config, self.pool.clone());
+
+        // External IdP established the assurance, so no acr/amr/auth_time is asserted.
+        let (access_token, refresh_token, expires_in) = token_service
+            .create_tokens(
+                xavyo_core::UserId::from_uuid(user_id),
+                xavyo_core::TenantId::from_uuid(tenant_id),
+                roles,
+                email,
+                None,
+                None,
+                None,
+            )
+            .await
+            .map_err(|e| {
+                xavyo_api_oidc_federation::FederationError::TokenIssueFailed(e.to_string())
+            })?;
+
+        Ok(xavyo_api_oidc_federation::IssuedTokens {
+            access_token,
+            expires_in,
+            refresh_token: Some(refresh_token),
+            token_type: "Bearer".to_string(),
+        })
+    }
 }
 
 /// Adapter to connect xavyo-api-social to xavyo-auth.

--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -1000,6 +1000,7 @@ async fn main() {
         pool: pool.clone(),
         master_key: config.federation_encryption_key,
         callback_base_url: config.issuer_url.clone(),
+        frontend_url: config.frontend_url.clone(),
         jwt_private_key_pem: config.jwt_private_key.expose_secret().as_bytes().to_vec(),
     };
     let federation_state = FederationState::new(&federation_config);

--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -1608,6 +1608,13 @@ async fn main() {
         .layer(axum::Extension(api_key_rate_limiter.clone()))
         // F082-US4: Revocation cache for fast JTI lookups
         .layer(axum::Extension(revocation_cache))
+        // The JWT auth middleware's revoke-all *sentinel* check (cascade
+        // revocation from logout / admin revoke / auth-code reuse / password
+        // change) requires a PgPool in the request extensions. Most authenticated
+        // route groups did not layer one, so the sentinel check silently
+        // fail-opened there and revoked access tokens kept working until TTL.
+        // Provide the pool globally so cascade revocation is enforced everywhere.
+        .layer(axum::Extension(pool.clone()))
         // F085: Webhook event publisher for identity lifecycle events
         .layer(axum::Extension(event_publisher))
         // Trusted proxy config for X-Forwarded-For validation

--- a/apps/idp-api/src/main.rs
+++ b/apps/idp-api/src/main.rs
@@ -851,9 +851,14 @@ async fn main() {
         .layer(axum::Extension(lockout_service_for_device.clone()))
         .layer(axum::Extension(mfa_service_for_device.clone()))
         .layer(axum::Extension(audit_service_for_device.clone()))
+        // RFC 8628: the browser-facing device pages must load without an
+        // X-Tenant-ID header — the tenant is resolved from the globally-unique
+        // user_code by the `resolve_device_tenant` middleware inside
+        // `device_router` (which injects the header the handlers read). So this
+        // layer must NOT hard-require the header, or the entry page 401s.
         .layer(TenantLayer::with_config(
             xavyo_tenant::TenantConfig::builder()
-                .require_tenant(true)
+                .require_tenant(false)
                 .build(),
         ));
 

--- a/apps/idp-api/src/openapi.rs
+++ b/apps/idp-api/src/openapi.rs
@@ -1439,7 +1439,6 @@ impl Modify for SecurityAddon {
         xavyo_api_auth::handlers::mfa::webauthn::register::RegistrationResponse,
         xavyo_api_auth::handlers::mfa::webauthn::authenticate::AuthenticationOptionsResponse,
         xavyo_api_auth::handlers::mfa::webauthn::authenticate::FinishAuthenticationRequest,
-        xavyo_api_auth::handlers::mfa::webauthn::authenticate::AuthenticationSuccessResponse,
         xavyo_api_auth::handlers::mfa::webauthn::credentials::CredentialListResponse,
         xavyo_api_auth::handlers::mfa::webauthn::credentials::UpdateCredentialRequest,
         xavyo_api_auth::handlers::mfa::webauthn::credentials::UpdateCredentialResponse,

--- a/crates/xavyo-api-auth/src/handlers/forgot_password.rs
+++ b/crates/xavyo-api-auth/src/handlers/forgot_password.rs
@@ -69,26 +69,37 @@ pub async fn forgot_password_handler(
         return Err(ApiAuthError::RateLimitExceeded);
     }
 
-    // Process the reset request
-    // Always return success to prevent email enumeration
-    if let Err(e) = process_forgot_password(
-        &pool,
-        email_sender.as_ref(),
-        tenant_id,
-        &email,
-        ip,
-        &headers,
-    )
-    .await
-    {
-        // Log the error but don't return it to prevent enumeration
-        tracing::warn!(
-            email = %email,
-            tenant_id = %tenant_id,
-            error = %e,
-            "Failed to process password reset (not returned to user)"
-        );
-    }
+    // Extract user agent for audit before moving into the background task.
+    let user_agent = headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+
+    // Process the reset in the background and return immediately. All the
+    // per-account work (user lookup, token creation, and — most importantly —
+    // the SMTP send) is done off the request path so the response time does not
+    // depend on whether the account exists. Otherwise the ~45ms email-send cost
+    // for existing accounts is a timing side-channel that enumerates valid emails
+    // despite the identical response body. Always returns the generic message.
+    let bg_email_sender = email_sender.clone();
+    tokio::spawn(async move {
+        if let Err(e) = process_forgot_password(
+            &pool,
+            bg_email_sender.as_ref(),
+            tenant_id,
+            &email,
+            ip,
+            user_agent,
+        )
+        .await
+        {
+            tracing::warn!(
+                tenant_id = %tenant_id,
+                error = %e,
+                "Failed to process password reset (not returned to user)"
+            );
+        }
+    });
 
     Ok(Json(ForgotPasswordResponse::default()))
 }
@@ -100,7 +111,7 @@ async fn process_forgot_password(
     tenant_id: TenantId,
     email: &str,
     ip: IpAddr,
-    headers: &HeaderMap,
+    user_agent: Option<String>,
 ) -> Result<(), ApiAuthError> {
     // Look up user by email and tenant
     let user_row: Option<(uuid::Uuid, bool)> = sqlx::query_as(
@@ -135,12 +146,6 @@ async fn process_forgot_password(
     // Generate new token
     let (token, token_hash) = generate_password_reset_token();
     let expires_at = Utc::now() + Duration::hours(PASSWORD_RESET_TOKEN_VALIDITY_HOURS);
-
-    // Extract user agent for audit
-    let user_agent = headers
-        .get(axum::http::header::USER_AGENT)
-        .and_then(|v| v.to_str().ok())
-        .map(String::from);
 
     // Use a transaction with tenant context for RLS compliance
     let mut tx = pool.begin().await?;
@@ -226,6 +231,24 @@ mod tests {
         assert!(
             !production.contains("WHERE user_id = $1 AND used_at IS NULL"),
             "must not invalidate reset tokens by user_id alone"
+        );
+    }
+
+    #[test]
+    fn forgot_password_processes_reset_off_the_request_path() {
+        // The per-account work (user lookup, token creation, and the SMTP send)
+        // must run in a background task so response time does not depend on whether
+        // the account exists — otherwise the email-send latency is a timing oracle
+        // that enumerates valid emails despite the identical response body.
+        let src = include_str!("forgot_password.rs");
+        let handler = src
+            .split("pub async fn forgot_password_handler")
+            .nth(1)
+            .and_then(|s| s.split("async fn process_forgot_password").next())
+            .expect("forgot_password_handler");
+        assert!(
+            handler.contains("tokio::spawn") && handler.contains("process_forgot_password("),
+            "forgot-password must process the reset in a spawned task (constant-time response)"
         );
     }
 }

--- a/crates/xavyo-api-auth/src/handlers/login.rs
+++ b/crates/xavyo-api-auth/src/handlers/login.rs
@@ -21,7 +21,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use validator::Validate;
 use xavyo_core::TenantId;
-use xavyo_db::{AuthMethod, FailureReason, UserRole};
+use xavyo_db::{AuthMethod, FailureReason, Tenant, UserRole};
 use xavyo_webhooks::{EventPublisher, WebhookEvent};
 
 /// Login response that can be either full tokens or MFA required.
@@ -95,6 +95,19 @@ pub async fn login_handler(
             .collect();
         ApiAuthError::Validation(errors.join(", "))
     })?;
+
+    // Fail closed on an unknown tenant. The client-supplied X-Tenant-ID is only
+    // format-validated by the tenant layer, never checked against the DB. Without
+    // this guard, a login for a non-existent tenant reaches the failed-attempt /
+    // audit writes, whose tenant_id foreign keys reject the row and surface a 500.
+    // Return the same generic error as bad credentials so an unknown tenant and an
+    // unknown user are indistinguishable (no tenant-enumeration oracle).
+    if Tenant::find_by_id(&pool, *tenant_id.as_uuid())
+        .await?
+        .is_none()
+    {
+        return Err(ApiAuthError::InvalidCredentials);
+    }
 
     // Extract client info early for audit logging and IP restriction.
     // Forwarded headers are used only when TrustXff is present.
@@ -740,6 +753,26 @@ mod tests {
         assert!(
             !production.contains("EnforcementDecision::skip()"),
             "must not treat risk-eval errors as a skipped decision"
+        );
+    }
+
+    #[test]
+    fn login_handler_rejects_unknown_tenant_before_recording_attempts() {
+        // A login for a non-existent tenant must fail closed as InvalidCredentials
+        // *before* any tenant-scoped write, otherwise the failed-attempt/audit
+        // foreign keys reject the row and the handler 500s (and leaks tenant
+        // existence). Guard both the check and its ordering.
+        let src = include_str!("login.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        let guard = production
+            .find("Tenant::find_by_id(&pool")
+            .expect("login must verify the tenant exists");
+        let authenticate = production
+            .find(".login(tenant_id")
+            .expect("login must call auth_service.login");
+        assert!(
+            guard < authenticate,
+            "tenant existence must be checked before authentication/attempt recording"
         );
     }
 

--- a/crates/xavyo-api-auth/src/handlers/login.rs
+++ b/crates/xavyo-api-auth/src/handlers/login.rs
@@ -532,29 +532,18 @@ pub async fn login_handler(
         }
     }
 
-    // MFA not enabled - issue full tokens
-    let (access_token, refresh_token, expires_in) = token_service
-        .create_tokens(
-            user_id,
-            tenant_id_val,
-            roles,
-            Some(request.email.clone()),
-            // This path issues a full token only when MFA is not required, i.e.
-            // single-factor password authentication (acr "1").
-            Some(AuthContext::password()),
-            user_agent.clone(),
-            ip_address,
-        )
-        .await?;
-
-    // Create session entry for tracking. Errors must refuse login so the
-    // issued tokens are not advertised without a tracked session.
-    login_session_recorded(
+    // MFA not enabled - issue full tokens.
+    //
+    // Create the session FIRST so the access token's `jti` can be pinned to the
+    // session id. This links the session <-> access token (so `is_current` works)
+    // and lets session revocation invalidate the associated tokens. Errors must
+    // refuse login so tokens are not advertised without a tracked session.
+    let session = login_session_recorded(
         session_service
             .create_session(
                 *user_id.as_uuid(),
                 *tenant_id_val.as_uuid(),
-                None, // No refresh_token_id linking for now
+                None,
                 user_agent.as_deref(),
                 ip_address.map(|ip| ip.to_string()).as_deref(),
             )
@@ -572,6 +561,33 @@ pub async fn login_handler(
         );
         e
     })?;
+
+    let (access_token, refresh_token, expires_in) = token_service
+        .create_session_tokens(
+            session.id,
+            user_id,
+            tenant_id_val,
+            roles,
+            Some(request.email.clone()),
+            // This path issues a full token only when MFA is not required, i.e.
+            // single-factor password authentication (acr "1").
+            Some(AuthContext::password()),
+            user_agent.clone(),
+            ip_address,
+        )
+        .await?;
+
+    // Link the refresh token to the session so revoking the session revokes it.
+    // Best-effort: a link failure must not fail the login (the session and tokens
+    // are already valid), but it is logged for observability.
+    if let Ok(rt) = token_service.validate_refresh_token(&refresh_token).await {
+        let link_result = session_service
+            .link_refresh_token(session.id, *tenant_id_val.as_uuid(), rt.id)
+            .await;
+        if let Err(e) = link_result {
+            tracing::warn!(error = %e, "Failed to link session to refresh token");
+        }
+    }
 
     let response = TokenResponse::new(access_token, refresh_token, expires_in);
 

--- a/crates/xavyo-api-auth/src/handlers/me/password.rs
+++ b/crates/xavyo-api-auth/src/handlers/me/password.rs
@@ -4,12 +4,13 @@
 //! Delegates to the shared `do_password_change` logic.
 
 use crate::error::ApiAuthError;
-use crate::handlers::password_change::do_password_change;
+use crate::handlers::password_change::{current_session_id, do_password_change};
 use crate::models::{PasswordChangeRequest, PasswordChangeResponse};
 use crate::services::{AlertService, PasswordPolicyService, SessionService};
 use axum::{extract::ConnectInfo, Extension, Json};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use xavyo_auth::JwtClaims;
 use xavyo_core::{TenantId, UserId};
 
 /// Handle PUT /me/password request.
@@ -30,6 +31,7 @@ use xavyo_core::{TenantId, UserId};
 pub async fn me_password_change(
     Extension(tenant_id): Extension<TenantId>,
     Extension(user_id): Extension<UserId>,
+    Extension(claims): Extension<JwtClaims>,
     Extension(password_policy_service): Extension<Arc<PasswordPolicyService>>,
     Extension(alert_service): Extension<Arc<AlertService>>,
     Extension(session_service): Extension<Arc<SessionService>>,
@@ -37,6 +39,7 @@ pub async fn me_password_change(
     Json(request): Json<PasswordChangeRequest>,
 ) -> Result<Json<PasswordChangeResponse>, ApiAuthError> {
     let revoke = request.revoke_other_sessions;
+    let current = current_session_id(&claims);
     do_password_change(
         &tenant_id,
         &user_id,
@@ -46,6 +49,7 @@ pub async fn me_password_change(
         addr,
         request,
         revoke,
+        current,
     )
     .await
 }

--- a/crates/xavyo-api-auth/src/handlers/mfa/webauthn/authenticate.rs
+++ b/crates/xavyo-api-auth/src/handlers/mfa/webauthn/authenticate.rs
@@ -9,10 +9,10 @@ use tracing::info;
 use utoipa::ToSchema;
 use uuid::Uuid;
 use webauthn_rs::prelude::{PublicKeyCredential, RequestChallengeResponse};
-use xavyo_core::UserId;
+use xavyo_auth::JwtClaims;
 use xavyo_webhooks::{EventPublisher, WebhookEvent};
 
-use crate::{error::ApiAuthError, router::AuthState};
+use crate::{error::ApiAuthError, models::TokenResponse, router::AuthState, services::AuthContext};
 
 /// Response containing `WebAuthn` authentication options.
 #[derive(Debug, Serialize, ToSchema)]
@@ -35,15 +35,6 @@ pub struct FinishAuthenticationRequest {
     pub credential: PublicKeyCredential,
 }
 
-/// Response after successful `WebAuthn` authentication.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct AuthenticationSuccessResponse {
-    /// Success message.
-    pub message: String,
-    /// The credential ID that was used.
-    pub credential_id: String,
-}
-
 /// POST /auth/mfa/webauthn/authenticate/start
 ///
 /// Start `WebAuthn` authentication for MFA.
@@ -62,26 +53,26 @@ pub struct AuthenticationSuccessResponse {
 )]
 pub async fn start_webauthn_authentication(
     State(state): State<AuthState>,
-    Extension(user_id): Extension<UserId>,
-    Extension(tenant_id): Extension<xavyo_core::TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Extension(ip_address): Extension<Option<IpAddr>>,
     Extension(user_agent): Extension<Option<String>>,
 ) -> Result<(StatusCode, Json<AuthenticationOptionsResponse>), ApiAuthError> {
+    // Identity comes from the partial (mfa_verification) token. The UserId/TenantId
+    // request extensions are not populated for partial tokens, so read the claims
+    // directly — mirroring verify_totp.
+    if claims.purpose.as_deref() != Some("mfa_verification") {
+        return Err(ApiAuthError::PartialTokenInvalid);
+    }
+    let user_id = Uuid::parse_str(&claims.sub).map_err(|_| ApiAuthError::PartialTokenInvalid)?;
+    let tenant_id = claims.tid.ok_or(ApiAuthError::PartialTokenInvalid)?;
+
     // Start authentication ceremony
     let options = state
         .webauthn_service
-        .start_authentication(
-            *user_id.as_uuid(),
-            *tenant_id.as_uuid(),
-            ip_address,
-            user_agent,
-        )
+        .start_authentication(user_id, tenant_id, ip_address, user_agent)
         .await?;
 
-    info!(
-        user_id = %user_id.as_uuid(),
-        "WebAuthn authentication started"
-    );
+    info!(user_id = %user_id, "WebAuthn authentication started");
 
     Ok((
         StatusCode::OK,
@@ -98,7 +89,7 @@ pub async fn start_webauthn_authentication(
     path = "/auth/mfa/webauthn/authenticate/finish",
     request_body = FinishAuthenticationRequest,
     responses(
-        (status = 200, description = "Authentication successful", body = AuthenticationSuccessResponse),
+        (status = 200, description = "Authentication successful, tokens issued", body = TokenResponse),
         (status = 400, description = "Invalid authenticator response or verification failed"),
         (status = 401, description = "Invalid or expired partial token"),
         (status = 404, description = "Credential not found or challenge expired"),
@@ -108,29 +99,65 @@ pub async fn start_webauthn_authentication(
 )]
 pub async fn finish_webauthn_authentication(
     State(state): State<AuthState>,
-    Extension(user_id): Extension<UserId>,
-    Extension(tenant_id): Extension<xavyo_core::TenantId>,
+    Extension(claims): Extension<JwtClaims>,
     Extension(ip_address): Extension<Option<IpAddr>>,
     Extension(user_agent): Extension<Option<String>>,
     publisher: Option<Extension<EventPublisher>>,
     Json(request): Json<FinishAuthenticationRequest>,
-) -> Result<(StatusCode, Json<AuthenticationSuccessResponse>), ApiAuthError> {
-    // Finish authentication ceremony
+) -> Result<(StatusCode, Json<TokenResponse>), ApiAuthError> {
+    // This endpoint completes the login MFA challenge, so it must run against a
+    // partial (mfa_verification) token — mirroring the TOTP/recovery verify paths.
+    // Identity comes from the token claims (UserId/TenantId extensions are not
+    // populated for partial tokens).
+    if claims.purpose.as_deref() != Some("mfa_verification") {
+        return Err(ApiAuthError::PartialTokenInvalid);
+    }
+
+    let uid = Uuid::parse_str(&claims.sub).map_err(|_| ApiAuthError::PartialTokenInvalid)?;
+    let tid = claims.tid.ok_or(ApiAuthError::PartialTokenInvalid)?;
+
+    // Finish the authenticator assertion ceremony.
     let credential_id = state
         .webauthn_service
         .finish_authentication(
-            *user_id.as_uuid(),
-            *tenant_id.as_uuid(),
+            uid,
+            tid,
             &request.credential,
             ip_address,
+            user_agent.clone(),
+        )
+        .await?;
+
+    // Issue a full session (mirrors verify_totp): password + WebAuthn = MFA.
+    // SECURITY: fail closed if the role fetch fails rather than issuing a
+    // downgraded token.
+    let user = xavyo_db::User::find_by_id_in_tenant(&state.pool, tid, uid)
+        .await
+        .map_err(ApiAuthError::Database)?
+        .ok_or(ApiAuthError::InvalidCredentials)?;
+    let roles = xavyo_db::UserRole::get_user_roles(&state.pool, uid, tid)
+        .await
+        .map_err(|e| {
+            tracing::error!(user_id = %uid, error = %e, "Failed to fetch user roles during WebAuthn MFA verification");
+            ApiAuthError::Internal("Failed to fetch user roles".to_string())
+        })?;
+    let tokens = state
+        .token_service
+        .create_tokens(
+            user.user_id(),
+            user.tenant_id(),
+            roles,
+            Some(user.email.clone()),
+            Some(AuthContext::webauthn()),
             user_agent,
+            ip_address,
         )
         .await?;
 
     info!(
-        user_id = %user_id.as_uuid(),
+        user_id = %uid,
         credential_id = %credential_id,
-        "WebAuthn authentication successful"
+        "WebAuthn MFA verification successful, tokens issued"
     );
 
     // F085: Publish auth.mfa.verified webhook event
@@ -138,11 +165,11 @@ pub async fn finish_webauthn_authentication(
         publisher.publish(WebhookEvent {
             event_id: Uuid::new_v4(),
             event_type: "auth.mfa.verified".to_string(),
-            tenant_id: *tenant_id.as_uuid(),
-            actor_id: Some(*user_id.as_uuid()),
+            tenant_id: tid,
+            actor_id: Some(uid),
             timestamp: chrono::Utc::now(),
             data: serde_json::json!({
-                "user_id": user_id.as_uuid(),
+                "user_id": uid,
                 "factor_type": "webauthn",
             }),
         });
@@ -150,9 +177,6 @@ pub async fn finish_webauthn_authentication(
 
     Ok((
         StatusCode::OK,
-        Json(AuthenticationSuccessResponse {
-            message: "Authentication successful".to_string(),
-            credential_id: credential_id.to_string(),
-        }),
+        Json(TokenResponse::new(tokens.0, tokens.1, tokens.2)),
     ))
 }

--- a/crates/xavyo-api-auth/src/handlers/password_change.rs
+++ b/crates/xavyo-api-auth/src/handlers/password_change.rs
@@ -11,8 +11,16 @@ use crate::services::{
 use axum::{extract::ConnectInfo, Extension, Json};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use uuid::Uuid;
 use validator::Validate;
+use xavyo_auth::JwtClaims;
 use xavyo_core::{TenantId, UserId};
+
+/// The current session id is the access token's `jti` (login pins jti == session id).
+/// Used to preserve the caller's own session when revoking on password change.
+pub(crate) fn current_session_id(claims: &JwtClaims) -> Option<Uuid> {
+    Uuid::parse_str(&claims.jti).ok()
+}
 
 /// Shared password change logic for both `/auth/password` and `/me/password`.
 pub(crate) async fn do_password_change(
@@ -24,6 +32,7 @@ pub(crate) async fn do_password_change(
     addr: SocketAddr,
     request: PasswordChangeRequest,
     revoke_sessions: bool,
+    current_session_id: Option<Uuid>,
 ) -> Result<Json<PasswordChangeResponse>, ApiAuthError> {
     request.validate().map_err(extract_validation_errors)?;
 
@@ -34,6 +43,7 @@ pub(crate) async fn do_password_change(
             &request.current_password,
             &request.new_password,
             revoke_sessions,
+            current_session_id,
             session_service,
         )
         .await?;
@@ -87,12 +97,17 @@ pub(crate) fn password_change_alert_recorded<T, E>(result: Result<T, E>) -> Resu
 pub async fn password_change_handler(
     Extension(tenant_id): Extension<TenantId>,
     Extension(user_id): Extension<UserId>,
+    Extension(claims): Extension<JwtClaims>,
     Extension(password_policy_service): Extension<Arc<PasswordPolicyService>>,
     Extension(alert_service): Extension<Arc<AlertService>>,
     Extension(session_service): Extension<Arc<SessionService>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Json(request): Json<PasswordChangeRequest>,
 ) -> Result<Json<PasswordChangeResponse>, ApiAuthError> {
+    // Honor the caller's revoke_other_sessions preference; preserve the current
+    // session so the user is not signed out by their own password change.
+    let revoke = request.revoke_other_sessions;
+    let current = current_session_id(&claims);
     do_password_change(
         &tenant_id,
         &user_id,
@@ -101,7 +116,8 @@ pub async fn password_change_handler(
         &session_service,
         addr,
         request,
-        true, // always revoke
+        revoke,
+        current,
     )
     .await
 }
@@ -134,6 +150,27 @@ mod tests {
         assert!(
             !production.contains("let _ = alert_service"),
             "must not report password change success when the alert was not recorded"
+        );
+    }
+
+    #[test]
+    fn password_change_honors_flag_and_preserves_current_session() {
+        let src = include_str!("password_change.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        // /auth/password must honor the caller's revoke_other_sessions preference
+        // rather than hardcoding a full revoke...
+        assert!(
+            !production.contains("true, // always revoke"),
+            "/auth/password must not hardcode revoke=true (ignores the checkbox)"
+        );
+        assert!(
+            production.contains("let revoke = request.revoke_other_sessions;"),
+            "/auth/password must use the request's revoke_other_sessions flag"
+        );
+        // ...and pass the current session id so the caller's own session survives.
+        assert!(
+            production.contains("current_session_id(&claims)"),
+            "password change must derive the current session id to preserve it"
         );
     }
 }

--- a/crates/xavyo-api-auth/src/handlers/verify_email.rs
+++ b/crates/xavyo-api-auth/src/handlers/verify_email.rs
@@ -4,13 +4,14 @@
 
 use crate::error::ApiAuthError;
 use crate::models::{VerifyEmailRequest, VerifyEmailResponse};
-use crate::services::{hash_token, verify_token_hash_constant_time};
+use crate::services::{hash_token, verify_token_hash_constant_time, TokenService};
 use axum::{Extension, Json};
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
+use std::sync::Arc;
 use validator::Validate;
-use xavyo_core::TenantId;
-use xavyo_db::set_tenant_context;
+use xavyo_core::{TenantId, UserId};
+use xavyo_db::{set_tenant_context, UserRole};
 
 /// Email verification token row from database query.
 type EmailVerificationTokenRow = (
@@ -39,6 +40,7 @@ type EmailVerificationTokenRow = (
 )]
 pub async fn verify_email_handler(
     Extension(pool): Extension<PgPool>,
+    Extension(token_service): Extension<Arc<TokenService>>,
     Json(request): Json<VerifyEmailRequest>,
 ) -> Result<Json<VerifyEmailResponse>, ApiAuthError> {
     // Validate request format
@@ -84,8 +86,8 @@ pub async fn verify_email_handler(
     let tenant_id = TenantId::from_uuid(token_tenant_id);
 
     // Check if user is already verified (include tenant_id for defense-in-depth)
-    let (is_active, email_verified): (bool, bool) = sqlx::query_as(
-        "SELECT is_active, email_verified FROM users WHERE id = $1 AND tenant_id = $2",
+    let (is_active, email_verified, email): (bool, bool, String) = sqlx::query_as(
+        "SELECT is_active, email_verified, email FROM users WHERE id = $1 AND tenant_id = $2",
     )
     .bind(user_id)
     .bind(*tenant_id.as_uuid())
@@ -160,7 +162,40 @@ pub async fn verify_email_handler(
         "Email verification completed successfully"
     );
 
-    Ok(Json(VerifyEmailResponse::verified()))
+    // Issue a session so the just-verified user is signed in automatically,
+    // instead of being bounced back to the login screen. This mirrors the
+    // passwordless email-OTP verify flow, which also proves control of the
+    // mailbox and returns tokens. Role/token issuance failures fall back to a
+    // successful (but session-less) verification so the account is still usable.
+    let roles = UserRole::get_user_roles(&pool, user_id, *tenant_id.as_uuid())
+        .await
+        .unwrap_or_default();
+
+    match token_service
+        .create_tokens(
+            UserId::from_uuid(user_id),
+            tenant_id,
+            roles,
+            Some(email),
+            None,
+            None,
+            None,
+        )
+        .await
+    {
+        Ok((access_token, refresh_token, expires_in)) => Ok(Json(
+            VerifyEmailResponse::verified_with_session(access_token, refresh_token, expires_in),
+        )),
+        Err(e) => {
+            tracing::warn!(
+                user_id = %user_id,
+                tenant_id = %tenant_id,
+                error = %e,
+                "Email verified but auto-login session issuance failed; user can still log in"
+            );
+            Ok(Json(VerifyEmailResponse::verified()))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/xavyo-api-auth/src/models/admin_invite.rs
+++ b/crates/xavyo-api-auth/src/models/admin_invite.rs
@@ -14,7 +14,8 @@ pub struct CreateInvitationRequest {
     /// Optional role template to assign on acceptance.
     pub role_template_id: Option<Uuid>,
 
-    /// Role to assign: "member" or "admin". Defaults to "admin" if omitted.
+    /// Role to assign: "member" or "admin". Defaults to "member" (least
+    /// privilege) if omitted.
     pub role: Option<String>,
 }
 
@@ -32,9 +33,11 @@ impl CreateInvitationRequest {
         Ok(())
     }
 
-    /// Get the resolved role, defaulting to "admin" if not specified.
+    /// Get the resolved role, defaulting to "member" (least privilege) when a
+    /// role is not specified. Defaulting to "admin" would silently grant
+    /// administrator access to every invitee created without an explicit role.
     pub fn resolved_role(&self) -> &str {
-        self.role.as_deref().unwrap_or("admin")
+        self.role.as_deref().unwrap_or("member")
     }
 }
 
@@ -248,20 +251,22 @@ mod tests {
     }
 
     #[test]
-    fn test_resolved_role_defaults_to_admin() {
+    fn test_resolved_role_defaults_to_member() {
+        // Least privilege: an invite created without an explicit role must NOT
+        // grant administrator access.
         let req = CreateInvitationRequest {
             email: "test@example.com".to_string(),
             role_template_id: None,
             role: None,
         };
-        assert_eq!(req.resolved_role(), "admin");
+        assert_eq!(req.resolved_role(), "member");
 
         let req = CreateInvitationRequest {
             email: "test@example.com".to_string(),
             role_template_id: None,
-            role: Some("member".to_string()),
+            role: Some("admin".to_string()),
         };
-        assert_eq!(req.resolved_role(), "member");
+        assert_eq!(req.resolved_role(), "admin");
     }
 
     #[test]

--- a/crates/xavyo-api-auth/src/models/responses.rs
+++ b/crates/xavyo-api-auth/src/models/responses.rs
@@ -90,15 +90,55 @@ pub struct VerifyEmailResponse {
 
     /// True if email was already verified (idempotent).
     pub already_verified: bool,
+
+    /// Access token issued for automatic sign-in immediately after a fresh
+    /// verification, so the user is not forced to log in again. Absent on the
+    /// idempotent already-verified path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_token: Option<String>,
+
+    /// Refresh token paired with `access_token` (see above).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+
+    /// Token type for the issued session (always `Bearer` when present).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_type: Option<String>,
+
+    /// Access-token lifetime in seconds (present with `access_token`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_in: Option<i64>,
 }
 
 impl VerifyEmailResponse {
-    /// Create a new response for a newly verified email.
+    /// Create a new response for a newly verified email (no auto-login session).
     #[must_use]
     pub fn verified() -> Self {
         Self {
             message: "Email verified successfully.".to_string(),
             already_verified: false,
+            access_token: None,
+            refresh_token: None,
+            token_type: None,
+            expires_in: None,
+        }
+    }
+
+    /// Create a response for a freshly verified email that also carries a session
+    /// so the frontend can sign the user in automatically.
+    #[must_use]
+    pub fn verified_with_session(
+        access_token: String,
+        refresh_token: String,
+        expires_in: i64,
+    ) -> Self {
+        Self {
+            message: "Email verified successfully.".to_string(),
+            already_verified: false,
+            access_token: Some(access_token),
+            refresh_token: Some(refresh_token),
+            token_type: Some("Bearer".to_string()),
+            expires_in: Some(expires_in),
         }
     }
 
@@ -108,6 +148,10 @@ impl VerifyEmailResponse {
         Self {
             message: "Email verified successfully.".to_string(),
             already_verified: true,
+            access_token: None,
+            refresh_token: None,
+            token_type: None,
+            expires_in: None,
         }
     }
 }

--- a/crates/xavyo-api-auth/src/services/admin_invite_service.rs
+++ b/crates/xavyo-api-auth/src/services/admin_invite_service.rs
@@ -174,7 +174,13 @@ impl AdminInviteService {
         .map_err(|e| ApiAuthError::Internal(e.to_string()))?;
 
         // Send invitation email
-        let invitation_url = format!("{}/invite/{}", self.frontend_base_url, raw_token);
+        // Include the tenant so the post-accept login preserves tenant context
+        // (a user accepting from a new device has no tenant cookie; without this
+        // they would land on the system-tenant login and fail to authenticate).
+        let invitation_url = format!(
+            "{}/invite/{}?tenant={}",
+            self.frontend_base_url, raw_token, tenant_id
+        );
         let role_label = if role == "admin" {
             "an administrator"
         } else {
@@ -510,7 +516,13 @@ If you didn't expect this invitation, you can safely ignore this email.
         .ok_or_else(|| ApiAuthError::Internal("Failed to refresh invitation".to_string()))?;
 
         // Send new email
-        let invitation_url = format!("{}/invite/{}", self.frontend_base_url, raw_token);
+        // Include the tenant so the post-accept login preserves tenant context
+        // (a user accepting from a new device has no tenant cookie; without this
+        // they would land on the system-tenant login and fail to authenticate).
+        let invitation_url = format!(
+            "{}/invite/{}?tenant={}",
+            self.frontend_base_url, raw_token, tenant_id
+        );
         let role_label = if invitation.role == "admin" {
             "an administrator"
         } else {

--- a/crates/xavyo-api-auth/src/services/email_service.rs
+++ b/crates/xavyo-api-auth/src/services/email_service.rs
@@ -173,7 +173,11 @@ If you didn't request this, you can safely ignore this email.
     /// magic link would fail with a 401 off the original device.
     #[must_use]
     pub fn magic_link_body(&self, token: &str, tenant_id: TenantId) -> String {
-        let url = format!("{}&tenant={}", self.magic_link_url(token), tenant_id.as_uuid());
+        let url = format!(
+            "{}&tenant={}",
+            self.magic_link_url(token),
+            tenant_id.as_uuid()
+        );
         format!(
             r"Hi,
 

--- a/crates/xavyo-api-auth/src/services/email_service.rs
+++ b/crates/xavyo-api-auth/src/services/email_service.rs
@@ -166,9 +166,14 @@ If you didn't request this, you can safely ignore this email.
     }
 
     /// Build the magic link email body.
+    ///
+    /// The tenant is included in the link so that clicking it on a device without
+    /// the tenant cookie (e.g. a phone or a fresh browser) still resolves the tenant
+    /// — the passwordless verify endpoint requires tenant context, so without this the
+    /// magic link would fail with a 401 off the original device.
     #[must_use]
-    pub fn magic_link_body(&self, token: &str) -> String {
-        let url = self.magic_link_url(token);
+    pub fn magic_link_body(&self, token: &str, tenant_id: TenantId) -> String {
+        let url = format!("{}&tenant={}", self.magic_link_url(token), tenant_id.as_uuid());
         format!(
             r"Hi,
 
@@ -437,7 +442,7 @@ impl EmailSender for SmtpEmailSender {
             .parse()
             .map_err(|e| EmailError::InvalidAddress(format!("Invalid recipient: {e}")))?;
 
-        let body = self.config.magic_link_body(token);
+        let body = self.config.magic_link_body(token, tenant_id);
 
         let email = Message::builder()
             .from(from)
@@ -829,6 +834,34 @@ mod tests {
                 tenant_id.as_uuid()
             )),
             "reset email link must include the tenant; body was:\n{body}"
+        );
+    }
+
+    #[test]
+    fn magic_link_body_includes_tenant_for_cross_device_signin() {
+        let config = EmailConfig {
+            smtp_host: "smtp.example.com".to_string(),
+            smtp_port: 587,
+            smtp_username: "u".to_string(),
+            smtp_password: "p".to_string(),
+            smtp_tls: true,
+            from_address: "noreply@example.com".to_string(),
+            from_name: "Test".to_string(),
+            frontend_base_url: "https://app.xavyo.com".to_string(),
+            password_reset_path: "/reset-password".to_string(),
+            email_verify_path: "/verify-email".to_string(),
+            magic_link_path: "/passwordless/magic-link/verify".to_string(),
+        };
+        let tenant_id = TenantId::new();
+        let body = config.magic_link_body("mltoken", tenant_id);
+        // The magic link must carry the tenant so it works when opened on a device
+        // without the tenant cookie (the verify endpoint requires tenant context).
+        assert!(
+            body.contains(&format!(
+                "https://app.xavyo.com/passwordless/magic-link/verify?token=mltoken&tenant={}",
+                tenant_id.as_uuid()
+            )),
+            "magic link email must include the tenant; body was:\n{body}"
         );
     }
 

--- a/crates/xavyo-api-auth/src/services/email_service.rs
+++ b/crates/xavyo-api-auth/src/services/email_service.rs
@@ -137,9 +137,18 @@ impl EmailConfig {
     }
 
     /// Build the password reset email body.
+    ///
+    /// The tenant is included in the link so that, after resetting, the "log in"
+    /// handoff preserves tenant context — otherwise a user resetting from a device
+    /// without the tenant cookie (e.g. a new device) would land on the system-tenant
+    /// login and fail to authenticate.
     #[must_use]
-    pub fn password_reset_body(&self, token: &str) -> String {
-        let url = self.password_reset_url(token);
+    pub fn password_reset_body(&self, token: &str, tenant_id: TenantId) -> String {
+        let url = format!(
+            "{}&tenant={}",
+            self.password_reset_url(token),
+            tenant_id.as_uuid()
+        );
         format!(
             r"Hi,
 
@@ -354,7 +363,7 @@ impl EmailSender for SmtpEmailSender {
             .parse()
             .map_err(|e| EmailError::InvalidAddress(format!("Invalid recipient: {e}")))?;
 
-        let body = self.config.password_reset_body(token);
+        let body = self.config.password_reset_body(token, tenant_id);
 
         let email = Message::builder()
             .from(from)
@@ -792,6 +801,34 @@ mod tests {
         assert_eq!(
             magic_url,
             "https://app.xavyo.com/passwordless/magic-link/verify?token=ml_token"
+        );
+    }
+
+    #[test]
+    fn password_reset_body_includes_tenant_for_login_handoff() {
+        let config = EmailConfig {
+            smtp_host: "smtp.example.com".to_string(),
+            smtp_port: 587,
+            smtp_username: "u".to_string(),
+            smtp_password: "p".to_string(),
+            smtp_tls: true,
+            from_address: "noreply@example.com".to_string(),
+            from_name: "Test".to_string(),
+            frontend_base_url: "https://app.xavyo.com".to_string(),
+            password_reset_path: "/reset-password".to_string(),
+            email_verify_path: "/verify-email".to_string(),
+            magic_link_path: "/passwordless/magic-link/verify".to_string(),
+        };
+        let tenant_id = TenantId::new();
+        let body = config.password_reset_body("abc123", tenant_id);
+        // The reset link must carry the tenant so the post-reset login preserves
+        // tenant context (otherwise a new-device reset lands on the system tenant).
+        assert!(
+            body.contains(&format!(
+                "https://app.xavyo.com/reset-password?token=abc123&tenant={}",
+                tenant_id.as_uuid()
+            )),
+            "reset email link must include the tenant; body was:\n{body}"
         );
     }
 

--- a/crates/xavyo-api-auth/src/services/email_service.rs
+++ b/crates/xavyo-api-auth/src/services/email_service.rs
@@ -55,9 +55,9 @@ pub struct EmailConfig {
     pub smtp_tls: bool,
     /// Base URL for frontend links (e.g., `https://app.xavyo.com`).
     pub frontend_base_url: String,
-    /// Path for password reset page (e.g., "/auth/reset-password").
+    /// Path for password reset page (e.g., "/reset-password").
     pub password_reset_path: String,
-    /// Path for email verification page (e.g., "/auth/verify-email").
+    /// Path for email verification page (e.g., "/verify-email").
     pub email_verify_path: String,
     /// Path for magic link verification page (e.g., "/passwordless/magic-link/verify").
     pub magic_link_path: String,
@@ -77,8 +77,8 @@ impl EmailConfig {
     ///
     /// Optional environment variables (with defaults):
     /// - `EMAIL_SMTP_TLS` (default: "true") — set to "false" for local dev (e.g., Mailpit)
-    /// - `PASSWORD_RESET_PATH` (default: "/auth/reset-password")
-    /// - `EMAIL_VERIFY_PATH` (default: "/auth/verify-email")
+    /// - `PASSWORD_RESET_PATH` (default: "/reset-password")
+    /// - `EMAIL_VERIFY_PATH` (default: "/verify-email")
     pub fn from_env() -> Result<Self, EmailError> {
         Ok(Self {
             smtp_host: std::env::var("EMAIL_SMTP_HOST")
@@ -101,9 +101,9 @@ impl EmailConfig {
             frontend_base_url: std::env::var("FRONTEND_BASE_URL")
                 .map_err(|_| EmailError::ConfigError("FRONTEND_BASE_URL not set".to_string()))?,
             password_reset_path: std::env::var("PASSWORD_RESET_PATH")
-                .unwrap_or_else(|_| "/auth/reset-password".to_string()),
+                .unwrap_or_else(|_| "/reset-password".to_string()),
             email_verify_path: std::env::var("EMAIL_VERIFY_PATH")
-                .unwrap_or_else(|_| "/auth/verify-email".to_string()),
+                .unwrap_or_else(|_| "/verify-email".to_string()),
             magic_link_path: std::env::var("MAGIC_LINK_PATH")
                 .unwrap_or_else(|_| "/passwordless/magic-link/verify".to_string()),
         })

--- a/crates/xavyo-api-auth/src/services/email_service.rs
+++ b/crates/xavyo-api-auth/src/services/email_service.rs
@@ -832,12 +832,15 @@ mod tests {
         let body = config.password_reset_body("abc123", tenant_id);
         // The reset link must carry the tenant so the post-reset login preserves
         // tenant context (otherwise a new-device reset lands on the system tenant).
+        // NB: do not interpolate `body` into the assert message — it contains the
+        // reset link/token and CodeQL flags that as clear-text logging of secrets.
+        let expected = format!(
+            "https://app.xavyo.com/reset-password?token=abc123&tenant={}",
+            tenant_id.as_uuid()
+        );
         assert!(
-            body.contains(&format!(
-                "https://app.xavyo.com/reset-password?token=abc123&tenant={}",
-                tenant_id.as_uuid()
-            )),
-            "reset email link must include the tenant; body was:\n{body}"
+            body.contains(&expected),
+            "reset email link must include the tenant"
         );
     }
 
@@ -860,12 +863,15 @@ mod tests {
         let body = config.magic_link_body("mltoken", tenant_id);
         // The magic link must carry the tenant so it works when opened on a device
         // without the tenant cookie (the verify endpoint requires tenant context).
+        // NB: do not interpolate `body` into the assert message — it contains the
+        // magic-link token and CodeQL flags that as clear-text logging of secrets.
+        let expected = format!(
+            "https://app.xavyo.com/passwordless/magic-link/verify?token=mltoken&tenant={}",
+            tenant_id.as_uuid()
+        );
         assert!(
-            body.contains(&format!(
-                "https://app.xavyo.com/passwordless/magic-link/verify?token=mltoken&tenant={}",
-                tenant_id.as_uuid()
-            )),
-            "magic link email must include the tenant; body was:\n{body}"
+            body.contains(&expected),
+            "magic link email must include the tenant"
         );
     }
 

--- a/crates/xavyo-api-auth/src/services/password_policy_service.rs
+++ b/crates/xavyo-api-auth/src/services/password_policy_service.rs
@@ -477,6 +477,7 @@ impl PasswordPolicyService {
         current_password: &str,
         new_password: &str,
         revoke_sessions: bool,
+        current_session_id: Option<Uuid>,
         session_service: &SessionService,
     ) -> Result<PasswordChangeResult, ApiAuthError> {
         // Acquire a connection with tenant context for RLS on the users table
@@ -571,17 +572,31 @@ impl PasswordPolicyService {
         self.update_password_timestamps(user_id, tenant_id, policy.expiration_days)
             .await?;
 
-        // 12. Revoke sessions and refresh tokens concurrently if requested
+        // 12. Revoke OTHER sessions + refresh tokens if requested. The current
+        // session (identified by the access token jti == session id) is preserved
+        // so a self-service password change does not log the user out — matching
+        // Auth0/Okta. When the caller has no identifiable session (e.g. an API-key
+        // token), fall back to revoking everything.
         let (sessions_revoked, refresh_tokens_revoked) = if revoke_sessions {
-            let (s, r) = tokio::try_join!(
-                session_service.revoke_all_user_sessions(
-                    user_id,
-                    tenant_id,
-                    RevokeReason::PasswordChange
-                ),
-                session_service.revoke_all_user_refresh_tokens(user_id, tenant_id),
-            )?;
-            (s as i64, r as i64)
+            match current_session_id {
+                Some(current) => {
+                    let s = session_service
+                        .revoke_all_except_current(user_id, tenant_id, current)
+                        .await?;
+                    (s as i64, s as i64)
+                }
+                None => {
+                    let (s, r) = tokio::try_join!(
+                        session_service.revoke_all_user_sessions(
+                            user_id,
+                            tenant_id,
+                            RevokeReason::PasswordChange
+                        ),
+                        session_service.revoke_all_user_refresh_tokens(user_id, tenant_id),
+                    )?;
+                    (s as i64, r as i64)
+                }
+            }
         } else {
             (0, 0)
         };

--- a/crates/xavyo-api-auth/src/services/profile_service.rs
+++ b/crates/xavyo-api-auth/src/services/profile_service.rs
@@ -11,7 +11,7 @@ use crate::services::{AlertService, DeviceService, MfaService, SessionService, W
 use sqlx::PgPool;
 use tracing::info;
 use uuid::Uuid;
-use xavyo_db::{set_tenant_context, User};
+use xavyo_db::{set_tenant_context, User, UserWebAuthnCredential};
 
 /// Profile management service.
 #[derive(Clone)]
@@ -133,8 +133,14 @@ impl ProfileService {
             .map_err(ApiAuthError::Database)?
             .ok_or(ApiAuthError::UserNotFound)?;
 
-        // Get MFA status
+        // Get MFA status (TOTP) and WebAuthn passkey count. The overview must
+        // reflect passkeys too — a passkey-only user still has MFA enabled.
         let mfa_status = mfa_service.get_status(user_id, tenant_id).await?;
+        let webauthn_enabled =
+            UserWebAuthnCredential::count_by_user_id_and_tenant(&self.pool, tenant_id, user_id)
+                .await
+                .map_err(ApiAuthError::Database)?
+                > 0;
 
         // Get active sessions count
         let sessions = session_service
@@ -154,14 +160,16 @@ impl ProfileService {
             .await?;
 
         // Build MFA methods list
-        let mfa_methods = if mfa_status.totp_enabled {
-            vec!["totp".to_string()]
-        } else {
-            vec![]
-        };
+        let mut mfa_methods = Vec::new();
+        if mfa_status.totp_enabled {
+            mfa_methods.push("totp".to_string());
+        }
+        if webauthn_enabled {
+            mfa_methods.push("webauthn".to_string());
+        }
 
         Ok(SecurityOverviewResponse {
-            mfa_enabled: mfa_status.totp_enabled,
+            mfa_enabled: mfa_status.totp_enabled || webauthn_enabled,
             mfa_methods,
             trusted_devices_count,
             active_sessions_count,

--- a/crates/xavyo-api-auth/src/services/ses_email_service.rs
+++ b/crates/xavyo-api-auth/src/services/ses_email_service.rs
@@ -179,7 +179,7 @@ impl EmailSender for SesEmailSender {
         token: &str,
         tenant_id: TenantId,
     ) -> Result<(), EmailError> {
-        let body = self.config.base.magic_link_body(token);
+        let body = self.config.base.magic_link_body(token, tenant_id);
         self.send_ses_email(to, "Sign in to Xavyo", &body).await?;
 
         tracing::info!(

--- a/crates/xavyo-api-auth/src/services/ses_email_service.rs
+++ b/crates/xavyo-api-auth/src/services/ses_email_service.rs
@@ -141,7 +141,7 @@ impl EmailSender for SesEmailSender {
         token: &str,
         tenant_id: TenantId,
     ) -> Result<(), EmailError> {
-        let body = self.config.base.password_reset_body(token);
+        let body = self.config.base.password_reset_body(token, tenant_id);
         self.send_ses_email(to, "Reset your Xavyo password", &body)
             .await?;
 

--- a/crates/xavyo-api-auth/src/services/session_service.rs
+++ b/crates/xavyo-api-auth/src/services/session_service.rs
@@ -199,7 +199,34 @@ impl SessionService {
             .map_err(ApiAuthError::Database)
     }
 
+    /// Link a session to the refresh token issued alongside it, so revoking the
+    /// session can invalidate that refresh token.
+    pub async fn link_refresh_token(
+        &self,
+        session_id: Uuid,
+        tenant_id: Uuid,
+        refresh_token_id: Uuid,
+    ) -> Result<(), ApiAuthError> {
+        let mut conn = self.pool.acquire().await.map_err(ApiAuthError::Database)?;
+        set_tenant_context(&mut *conn, xavyo_core::TenantId::from_uuid(tenant_id))
+            .await
+            .map_err(ApiAuthError::DatabaseInternal)?;
+        sqlx::query("UPDATE sessions SET refresh_token_id = $1 WHERE id = $2 AND tenant_id = $3")
+            .bind(refresh_token_id)
+            .bind(session_id)
+            .bind(tenant_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(ApiAuthError::Database)?;
+        Ok(())
+    }
+
     /// Revoke a specific session.
+    ///
+    /// Also revokes the refresh token linked to the session so the device cannot
+    /// mint new access tokens after being signed out (the security control that
+    /// "revoke this device" implies). The short-lived access token expires on its
+    /// own TTL.
     pub async fn revoke_session(
         &self,
         session_id: Uuid,
@@ -211,11 +238,31 @@ impl SessionService {
             .await
             .map_err(ApiAuthError::DatabaseInternal)?;
 
+        // Capture the linked refresh token before revoking the session.
+        let refresh_token_id: Option<Uuid> = sqlx::query_scalar::<_, Option<Uuid>>(
+            "SELECT refresh_token_id FROM sessions WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(session_id)
+        .bind(tenant_id)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(ApiAuthError::Database)?
+        .flatten();
+
         let result = Session::revoke(&mut *conn, tenant_id, session_id, reason)
             .await
             .map_err(ApiAuthError::Database)?;
 
         if result {
+            if let Some(rt_id) = refresh_token_id {
+                let _ = sqlx::query(
+                    "UPDATE refresh_tokens SET revoked_at = NOW() WHERE id = $1 AND tenant_id = $2 AND revoked_at IS NULL",
+                )
+                .bind(rt_id)
+                .bind(tenant_id)
+                .execute(&mut *conn)
+                .await;
+            }
             info!(session_id = %session_id, reason = %reason, "Session revoked");
         }
 
@@ -234,6 +281,20 @@ impl SessionService {
             .await
             .map_err(ApiAuthError::DatabaseInternal)?;
 
+        // Capture the refresh tokens of the sessions about to be revoked so they
+        // can be invalidated too (otherwise those devices could keep refreshing).
+        let refresh_token_ids: Vec<Uuid> = sqlx::query_scalar::<_, Uuid>(
+            "SELECT refresh_token_id FROM sessions \
+             WHERE user_id = $1 AND tenant_id = $2 AND id <> $3 \
+               AND revoked_at IS NULL AND refresh_token_id IS NOT NULL",
+        )
+        .bind(user_id)
+        .bind(tenant_id)
+        .bind(current_session_id)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(ApiAuthError::Database)?;
+
         let count = Session::revoke_all_except(
             &mut *conn,
             tenant_id,
@@ -243,6 +304,17 @@ impl SessionService {
         )
         .await
         .map_err(ApiAuthError::Database)?;
+
+        if !refresh_token_ids.is_empty() {
+            let _ = sqlx::query(
+                "UPDATE refresh_tokens SET revoked_at = NOW() \
+                 WHERE id = ANY($1) AND tenant_id = $2 AND revoked_at IS NULL",
+            )
+            .bind(&refresh_token_ids)
+            .bind(tenant_id)
+            .execute(&mut *conn)
+            .await;
+        }
 
         info!(
             user_id = %user_id,
@@ -547,6 +619,32 @@ mod tests {
         assert!(
             production.contains("UPDATE oauth_refresh_tokens"),
             "refresh-token revoke must also revoke OAuth refresh tokens"
+        );
+    }
+
+    #[test]
+    fn revoking_a_session_revokes_its_refresh_token() {
+        let src = include_str!("session_service.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        // Single revoke must invalidate the linked refresh token so the device
+        // cannot mint new access tokens ("sign out this device" must actually work).
+        assert!(
+            production.contains("pub async fn link_refresh_token"),
+            "login must be able to link a session to its refresh token"
+        );
+        assert!(
+            production.contains("SELECT refresh_token_id FROM sessions WHERE id = $1"),
+            "revoke_session must resolve the linked refresh token"
+        );
+        assert!(
+            production.contains("UPDATE refresh_tokens SET revoked_at = NOW() WHERE id = $1"),
+            "revoke_session must revoke the linked refresh token"
+        );
+        // Revoke-all-others must invalidate the other sessions' refresh tokens too.
+        assert!(
+            production.contains("UPDATE refresh_tokens SET revoked_at = NOW() \n                 WHERE id = ANY($1)")
+                || production.contains("WHERE id = ANY($1) AND tenant_id = $2 AND revoked_at IS NULL"),
+            "revoke_all_except_current must revoke the other sessions' refresh tokens"
         );
     }
 

--- a/crates/xavyo-api-auth/src/services/token_service.rs
+++ b/crates/xavyo-api-auth/src/services/token_service.rs
@@ -196,6 +196,58 @@ impl TokenService {
         user_agent: Option<String>,
         ip_address: Option<IpAddr>,
     ) -> Result<(String, String, i64), ApiAuthError> {
+        self.create_tokens_inner(
+            None,
+            user_id,
+            tenant_id,
+            roles,
+            email,
+            auth_context,
+            user_agent,
+            ip_address,
+        )
+        .await
+    }
+
+    /// Like [`create_tokens`], but pins the access token's `jti` to `session_id`
+    /// so the session row and the access token are linked (`is_current` detection
+    /// and session-scoped revocation depend on this). Used by the login path.
+    pub async fn create_session_tokens(
+        &self,
+        session_id: uuid::Uuid,
+        user_id: UserId,
+        tenant_id: TenantId,
+        roles: Vec<String>,
+        email: Option<String>,
+        auth_context: Option<AuthContext>,
+        user_agent: Option<String>,
+        ip_address: Option<IpAddr>,
+    ) -> Result<(String, String, i64), ApiAuthError> {
+        self.create_tokens_inner(
+            Some(session_id),
+            user_id,
+            tenant_id,
+            roles,
+            email,
+            auth_context,
+            user_agent,
+            ip_address,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn create_tokens_inner(
+        &self,
+        jti: Option<uuid::Uuid>,
+        user_id: UserId,
+        tenant_id: TenantId,
+        roles: Vec<String>,
+        email: Option<String>,
+        auth_context: Option<AuthContext>,
+        user_agent: Option<String>,
+        ip_address: Option<IpAddr>,
+    ) -> Result<(String, String, i64), ApiAuthError> {
         // Advertised tenant IP restrictions must apply at token issue.
         let ip_str = ip_address.map(|ip| ip.to_string());
         super::IpRestrictionService::new(self.pool.clone())
@@ -220,6 +272,7 @@ impl TokenService {
 
         // Generate access token
         let access_token = self.create_access_token(
+            jti,
             user_id,
             tenant_id,
             roles,
@@ -246,8 +299,12 @@ impl TokenService {
     }
 
     /// Create a JWT access token.
+    ///
+    /// When `jti` is `Some`, the token's `jti` is pinned to that value (the owning
+    /// session id) instead of a random one, linking the access token to its session.
     fn create_access_token(
         &self,
+        jti: Option<uuid::Uuid>,
         user_id: UserId,
         tenant_id: TenantId,
         roles: Vec<String>,
@@ -262,6 +319,10 @@ impl TokenService {
             .audience(vec![&self.config.audience])
             .roles(roles)
             .expires_in_secs(self.access_token_validity.num_seconds());
+
+        if let Some(jti) = jti {
+            builder = builder.jwt_id(jti.to_string());
+        }
 
         if let Some(email) = email {
             builder = builder.email(email);
@@ -504,16 +565,47 @@ impl TokenService {
             _ => None,
         };
 
-        self.create_tokens(
-            user_id,
-            tenant_id,
-            roles,
-            Some(email),
-            forwarded_context,
-            user_agent,
-            ip_address,
+        // Preserve the session linkage across rotation: if this refresh token
+        // belongs to a tracked session, keep the new access token's jti pinned to
+        // that session id and re-point the session at the new refresh token. This
+        // keeps `is_current` stable and keeps session revocation able to kill the
+        // (rotated) refresh token.
+        let session_id: Option<uuid::Uuid> = sqlx::query_scalar(
+            "SELECT id FROM sessions WHERE refresh_token_id = $1 AND tenant_id = $2 AND revoked_at IS NULL",
         )
+        .bind(token.id)
+        .bind(token.tenant_id)
+        .fetch_optional(&self.pool)
         .await
+        .unwrap_or(None);
+
+        let issued = self
+            .create_tokens_inner(
+                session_id,
+                user_id,
+                tenant_id,
+                roles,
+                Some(email),
+                forwarded_context,
+                user_agent,
+                ip_address,
+            )
+            .await?;
+
+        if let Some(sid) = session_id {
+            if let Ok(new_rt) = self.validate_refresh_token(&issued.1).await {
+                let _ = sqlx::query(
+                    "UPDATE sessions SET refresh_token_id = $1 WHERE id = $2 AND tenant_id = $3",
+                )
+                .bind(new_rt.id)
+                .bind(sid)
+                .bind(token.tenant_id)
+                .execute(&self.pool)
+                .await;
+            }
+        }
+
+        Ok(issued)
     }
 
     /// Revoke a refresh token by its opaque value.
@@ -917,6 +1009,30 @@ mod tests {
         assert!(
             production.contains("builder = builder.name(name)"),
             "create_access_token must set JwtClaims.name"
+        );
+    }
+
+    #[test]
+    fn session_tokens_pin_jti_and_refresh_preserves_linkage() {
+        let src = include_str!("token_service.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        // Login issues session-pinned tokens so session.id == access token jti.
+        assert!(
+            production.contains("pub async fn create_session_tokens"),
+            "must expose create_session_tokens for the login path"
+        );
+        assert!(
+            production.contains("builder = builder.jwt_id(jti.to_string())"),
+            "create_access_token must pin jti when provided"
+        );
+        // Refresh rotation must keep the session pinned + re-point it to the new token.
+        assert!(
+            production.contains("SELECT id FROM sessions WHERE refresh_token_id = $1"),
+            "refresh must resolve the owning session for jti continuity"
+        );
+        assert!(
+            production.contains("UPDATE sessions SET refresh_token_id = $1"),
+            "refresh must re-point the session at the rotated refresh token"
         );
     }
 

--- a/crates/xavyo-api-auth/src/services/user_agent_parser.rs
+++ b/crates/xavyo-api-auth/src/services/user_agent_parser.rs
@@ -61,6 +61,20 @@ fn detect_device_type(ua: &str) -> String {
         return "mobile".to_string();
     }
 
+    // Recognized desktop platforms (after mobile/tablet so e.g. Android's
+    // "Linux" token doesn't win). Without this, ordinary desktop logins (Chrome
+    // on Windows, Firefox on macOS) were classified "unknown" in the sessions/
+    // devices UI instead of "desktop".
+    if ua.contains("windows")
+        || ua.contains("macintosh")
+        || ua.contains("mac os x")
+        || ua.contains("cros")
+        || ua.contains("x11")
+        || (ua.contains("linux") && !ua.contains("android"))
+    {
+        return "desktop".to_string();
+    }
+
     // Unrecognized UA is not a desktop — device-type policies must not skip.
     "unknown".to_string()
 }

--- a/crates/xavyo-api-auth/src/services/webauthn_service.rs
+++ b/crates/xavyo-api-auth/src/services/webauthn_service.rs
@@ -402,14 +402,13 @@ impl WebAuthnService {
             return Err(ApiAuthError::WebAuthnNoCredentials);
         }
 
-        // Convert to passkeys for webauthn-rs
+        // Convert to passkeys for webauthn-rs. Registration stores the full
+        // `Passkey` (serde_json::to_vec(&passkey)), so it must be deserialized
+        // back as a `Passkey` — deserializing as a bare `Credential` fails for
+        // every row and makes the user look like they have no credentials.
         let passkeys: Vec<Passkey> = credentials
             .iter()
-            .filter_map(|c| {
-                let cred: webauthn_rs::prelude::Credential =
-                    serde_json::from_slice(&c.public_key).ok()?;
-                Some(Passkey::from(cred))
-            })
+            .filter_map(|c| serde_json::from_slice::<Passkey>(&c.public_key).ok())
             .collect();
 
         if passkeys.is_empty() {

--- a/crates/xavyo-api-governance/src/handlers/lifecycle_config.rs
+++ b/crates/xavyo-api-governance/src/handlers/lifecycle_config.rs
@@ -787,10 +787,17 @@ pub async fn get_user_lifecycle_status(
         .ok_or_else(|| crate::error::ApiGovernanceError::Unauthorized)?;
 
     // Get user information
+    // The user's lifecycle is tracked via `users.lifecycle_state_id` (FK to
+    // gov_lifecycle_states). Derive the owning config id and the state name from
+    // that state row; `users` has no `lifecycle_config_id`/`lifecycle_state`
+    // columns (querying them 500s the whole user detail page).
     let user: Option<(Option<Uuid>, Option<Uuid>, Option<String>)> = sqlx::query_as(
         r"
-        SELECT lifecycle_config_id, archetype_id, lifecycle_state FROM users
-        WHERE id = $1 AND tenant_id = $2
+        SELECT ls.config_id, u.archetype_id, ls.name
+        FROM users u
+        LEFT JOIN gov_lifecycle_states ls
+          ON ls.id = u.lifecycle_state_id AND ls.tenant_id = u.tenant_id
+        WHERE u.id = $1 AND u.tenant_id = $2
         ",
     )
     .bind(user_id)

--- a/crates/xavyo-api-governance/src/services/archetype_lifecycle_service.rs
+++ b/crates/xavyo-api-governance/src/services/archetype_lifecycle_service.rs
@@ -111,11 +111,16 @@ impl ArchetypeLifecycleService {
         tenant_id: Uuid,
         user_id: Uuid,
     ) -> Result<Option<EffectiveLifecycleModel>, GovernanceError> {
-        // Get the user to find their archetype
+        // Get the user's archetype and their effective lifecycle config. The
+        // config is derived from `users.lifecycle_state_id` (FK to
+        // gov_lifecycle_states); there is no `lifecycle_config_id` column.
         let user: Option<(Option<Uuid>, Option<Uuid>)> = sqlx::query_as(
             r"
-            SELECT archetype_id, lifecycle_config_id FROM users
-            WHERE id = $1 AND tenant_id = $2
+            SELECT u.archetype_id, ls.config_id
+            FROM users u
+            LEFT JOIN gov_lifecycle_states ls
+              ON ls.id = u.lifecycle_state_id AND ls.tenant_id = u.tenant_id
+            WHERE u.id = $1 AND u.tenant_id = $2
             ",
         )
         .bind(user_id)

--- a/crates/xavyo-api-import/src/handlers/invitations.rs
+++ b/crates/xavyo-api-import/src/handlers/invitations.rs
@@ -260,41 +260,117 @@ pub async fn accept_invitation(
     let password_hash = xavyo_auth::hash_password(&body.password)
         .map_err(|e| ImportError::Internal(format!("Failed to hash password: {e}")))?;
 
-    // Atomically mark invitation as accepted (prevents concurrent double-acceptance)
-    let accepted = UserInvitation::mark_accepted(
-        &pool,
-        invitation.tenant_id,
-        invitation.id,
-        None, // IP address — can be extracted from ConnectInfo if needed
-        None, // User-Agent — can be extracted from headers if needed
-    )
-    .await?;
+    // Two invitation shapes share this endpoint:
+    //  - Bulk-import invitations pre-create the user (user_id set): activate + set password.
+    //  - Admin invitations have no user yet (user_id NULL): create the account and
+    //    assign the invited role. Previously the UPDATE below matched zero rows for
+    //    admin invitations, so acceptance reported success but never created the
+    //    account — the invited user could never log in.
+    if let Some(existing_user_id) = invitation.user_id {
+        // Atomically mark invitation as accepted (prevents concurrent double-acceptance)
+        let accepted =
+            UserInvitation::mark_accepted(&pool, invitation.tenant_id, invitation.id, None, None)
+                .await?;
+        if accepted.is_none() {
+            return Err(ImportError::TokenAlreadyUsed);
+        }
 
-    // If mark_accepted returned None, the invitation was already accepted concurrently
-    if accepted.is_none() {
-        return Err(ImportError::TokenAlreadyUsed);
+        sqlx::query(
+            r"
+            UPDATE users
+            SET password_hash = $3, is_active = true, email_verified = true,
+                email_verified_at = NOW(), updated_at = NOW()
+            WHERE id = $1 AND tenant_id = $2
+            ",
+        )
+        .bind(existing_user_id)
+        .bind(invitation.tenant_id)
+        .bind(&password_hash)
+        .execute(&pool)
+        .await?;
+
+        tracing::info!(
+            user_id = %existing_user_id,
+            invitation_id = %invitation.id,
+            "Invitation accepted, existing account activated"
+        );
+    } else {
+        // Admin invitation: create the user and assign the invited role atomically.
+        let email = invitation
+            .email
+            .as_ref()
+            .ok_or_else(|| ImportError::Internal("Invitation missing email".to_string()))?;
+
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|e| ImportError::Internal(format!("Failed to begin transaction: {e}")))?;
+
+        // RLS tenant context for the transaction.
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(invitation.tenant_id.to_string())
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ImportError::Internal(format!("Failed to set tenant context: {e}")))?;
+
+        // Atomic single-use guard.
+        let status: Option<(String,)> = sqlx::query_as(
+            "SELECT status FROM user_invitations WHERE id = $1 AND tenant_id = $2 FOR UPDATE",
+        )
+        .bind(invitation.id)
+        .bind(invitation.tenant_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        match status {
+            Some((s,)) if s == "pending" || s == "sent" => {}
+            Some(_) => return Err(ImportError::TokenAlreadyUsed),
+            None => return Err(ImportError::InvalidToken),
+        }
+
+        let new_user_id = uuid::Uuid::new_v4();
+        sqlx::query(
+            r"
+            INSERT INTO users (id, tenant_id, email, password_hash, is_active, email_verified, email_verified_at, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, true, true, NOW(), NOW(), NOW())
+            ",
+        )
+        .bind(new_user_id)
+        .bind(invitation.tenant_id)
+        .bind(email)
+        .bind(&password_hash)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query("INSERT INTO user_roles (user_id, role_name) VALUES ($1, $2)")
+            .bind(new_user_id)
+            .bind(&invitation.role)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query(
+            r"
+            UPDATE user_invitations
+            SET status = 'accepted', accepted_at = NOW(), user_id = $3, updated_at = NOW()
+            WHERE id = $1 AND tenant_id = $2
+            ",
+        )
+        .bind(invitation.id)
+        .bind(invitation.tenant_id)
+        .bind(new_user_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit()
+            .await
+            .map_err(|e| ImportError::Internal(format!("Failed to commit: {e}")))?;
+
+        tracing::info!(
+            user_id = %new_user_id,
+            invitation_id = %invitation.id,
+            role = %invitation.role,
+            "Admin invitation accepted, account created and role assigned"
+        );
     }
-
-    // Update user: set password and activate
-    sqlx::query(
-        r"
-        UPDATE users
-        SET password_hash = $3, is_active = true, email_verified = true,
-            email_verified_at = NOW(), updated_at = NOW()
-        WHERE id = $1 AND tenant_id = $2
-        ",
-    )
-    .bind(invitation.user_id)
-    .bind(invitation.tenant_id)
-    .bind(&password_hash)
-    .execute(&pool)
-    .await?;
-
-    tracing::info!(
-        user_id = ?invitation.user_id,
-        invitation_id = %invitation.id,
-        "Invitation accepted, account activated"
-    );
 
     Ok(Json(AcceptInvitationResponse {
         success: true,
@@ -321,4 +397,34 @@ fn hash_token(token: &str) -> String {
 /// Get frontend base URL from environment.
 fn get_frontend_base_url() -> String {
     std::env::var("FRONTEND_BASE_URL").unwrap_or_else(|_| "https://app.xavyo.com".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn accept_creates_user_and_role_for_admin_invitation() {
+        // Admin invitations have user_id = NULL (no pre-created user). The accept
+        // handler must CREATE the user and assign the invited role for that case —
+        // otherwise acceptance silently no-ops (the old UPDATE ... WHERE id = NULL
+        // matched zero rows) and the invited user can never log in.
+        let src = include_str!("invitations.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        let accept = production
+            .split("pub async fn accept_invitation")
+            .nth(1)
+            .expect("accept_invitation handler");
+        assert!(
+            accept.contains("if let Some(existing_user_id) = invitation.user_id"),
+            "accept must branch on whether the invitation has a pre-created user"
+        );
+        assert!(
+            accept.contains("INSERT INTO users"),
+            "accept must create the user for admin invitations (user_id NULL)"
+        );
+        assert!(
+            accept.contains("INSERT INTO user_roles (user_id, role_name)")
+                && accept.contains("&invitation.role"),
+            "accept must assign the invited role for admin invitations"
+        );
+    }
 }

--- a/crates/xavyo-api-oauth/src/handlers/device.rs
+++ b/crates/xavyo-api-oauth/src/handlers/device.rs
@@ -479,10 +479,14 @@ pub async fn device_verify_code_handler(
     // Determine secure flag based on environment
     let is_secure = state.is_production();
 
-    // Helper to build response with new CSRF token
-    let with_csrf_cookie = |html: String| -> Response {
-        let csrf_token = generate_csrf_token();
-        let csrf_cookie = create_csrf_cookie(&csrf_token, is_secure);
+    // Helper to attach the CSRF cookie. The cookie MUST carry the *same* token
+    // that was embedded in the page's hidden form field, otherwise the next POST
+    // fails CSRF validation ("Session expired"). Previously this closure minted a
+    // fresh token for the cookie while the HTML kept a different one, so the
+    // approval page always mismatched and device authorization could never be
+    // completed in a browser.
+    let with_csrf_cookie = |html: String, csrf_token: &str| -> Response {
+        let csrf_cookie = create_csrf_cookie(csrf_token, is_secure);
         let mut response = Html(html).into_response();
         if let Ok(cookie_value) = HeaderValue::from_str(&csrf_cookie) {
             response.headers_mut().insert(SET_COOKIE, cookie_value);
@@ -511,11 +515,14 @@ pub async fn device_verify_code_handler(
                 "Device verify: CSRF validation failed"
             );
             let csrf_token = generate_csrf_token();
-            return with_csrf_cookie(render_verification_page(
-                &request.user_code,
-                "Session expired. Please try again.",
+            return with_csrf_cookie(
+                render_verification_page(
+                    &request.user_code,
+                    "Session expired. Please try again.",
+                    &csrf_token,
+                ),
                 &csrf_token,
-            ));
+            );
         }
     }
 
@@ -529,11 +536,14 @@ pub async fn device_verify_code_handler(
                 "Device verify: missing or invalid tenant ID"
             );
             let csrf_token = generate_csrf_token();
-            return with_csrf_cookie(render_verification_page(
-                &request.user_code,
-                "Invalid request. Please try again.",
+            return with_csrf_cookie(
+                render_verification_page(
+                    &request.user_code,
+                    "Invalid request. Please try again.",
+                    &csrf_token,
+                ),
                 &csrf_token,
-            ));
+            );
         }
     };
 
@@ -578,33 +588,43 @@ pub async fn device_verify_code_handler(
                 };
 
                 // User is logged in - show enhanced approval page with context
-                with_csrf_cookie(render_approval_page_with_context(&context))
+                let approval_csrf = context.csrf_token.clone();
+                with_csrf_cookie(render_approval_page_with_context(&context), &approval_csrf)
             } else {
                 // User not logged in - show login form with device code context
-                with_csrf_cookie(render_login_page(
-                    &request.user_code,
-                    &device_code.client_id,
-                    &device_code.scopes,
-                    None, // No error initially
+                with_csrf_cookie(
+                    render_login_page(
+                        &request.user_code,
+                        &device_code.client_id,
+                        &device_code.scopes,
+                        None, // No error initially
+                        &csrf_token,
+                    ),
                     &csrf_token,
-                ))
+                )
             }
         }
         Ok(None) => {
             let csrf_token = generate_csrf_token();
-            with_csrf_cookie(render_verification_page(
-                &request.user_code,
-                "Invalid or expired code. Please check the code and try again.",
+            with_csrf_cookie(
+                render_verification_page(
+                    &request.user_code,
+                    "Invalid or expired code. Please check the code and try again.",
+                    &csrf_token,
+                ),
                 &csrf_token,
-            ))
+            )
         }
         Err(_) => {
             let csrf_token = generate_csrf_token();
-            with_csrf_cookie(render_verification_page(
-                &request.user_code,
-                "An error occurred. Please try again.",
+            with_csrf_cookie(
+                render_verification_page(
+                    &request.user_code,
+                    "An error occurred. Please try again.",
+                    &csrf_token,
+                ),
                 &csrf_token,
-            ))
+            )
         }
     }
 }
@@ -1923,6 +1943,32 @@ fn render_confirmation_result_page(success: bool, message: &str) -> String {
 mod tests {
     use super::*;
     use chrono::{Duration, Utc};
+
+    #[test]
+    fn device_csrf_cookie_matches_embedded_form_token() {
+        // Regression: with_csrf_cookie used to mint a NEW token for the cookie
+        // while the rendered HTML embedded a different one, so every device POST
+        // page shipped a form token that never matched its cookie — the approval
+        // step always failed CSRF ("Session expired") and device authorization
+        // could not be completed in a browser. The cookie must use the same token
+        // that was embedded in the page.
+        let src = include_str!("device.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        let closure = production
+            .split("let with_csrf_cookie =")
+            .nth(1)
+            .and_then(|s| s.split("};").next())
+            .expect("with_csrf_cookie closure");
+        assert!(
+            closure.contains("csrf_token: &str")
+                && closure.contains("create_csrf_cookie(csrf_token"),
+            "with_csrf_cookie must set the cookie to the embedded form token, not a fresh one"
+        );
+        assert!(
+            !closure.contains("generate_csrf_token()"),
+            "with_csrf_cookie must NOT mint its own token (would mismatch the form)"
+        );
+    }
 
     #[test]
     fn device_flow_resolves_tenant_from_user_code_without_header() {

--- a/crates/xavyo-api-oauth/src/handlers/device.rs
+++ b/crates/xavyo-api-oauth/src/handlers/device.rs
@@ -15,8 +15,10 @@ use crate::router::OAuthState;
 use crate::services::{DeviceAuthorizationStatus, DeviceCodeService, RiskAction, RiskContext};
 use crate::utils::{extract_country_code, extract_origin_ip};
 use axum::{
-    extract::{ConnectInfo, Query, State},
+    body::{to_bytes, Body},
+    extract::{ConnectInfo, Query, Request, State},
     http::{header::SET_COOKIE, HeaderMap, HeaderValue},
+    middleware::Next,
     response::{Html, IntoResponse, Response},
     Extension, Form,
 };
@@ -321,6 +323,93 @@ pub async fn device_authorization_handler(
         expires_in: response.expires_in,
         interval: response.interval,
     }))
+}
+
+/// Max device-flow form body we will buffer to resolve the tenant (device forms
+/// are tiny: a user_code plus a CSRF token).
+const DEVICE_FORM_BUFFER_LIMIT: usize = 16 * 1024;
+
+/// Resolve the tenant for browser-facing device-verification requests.
+///
+/// RFC 8628 has the user open `verification_uri` in a plain browser, which cannot
+/// send the `X-Tenant-ID` header this app uses for tenant resolution — so without
+/// this the entire `/device` flow returned 401. `user_code` is globally unique, so
+/// we derive the tenant from it (query `code`/`user_code`, or the form body) and
+/// inject the header before the tenant middleware/handlers run. Requests that
+/// already carry the header (or carry no resolvable code, e.g. the bare entry
+/// page) pass through unchanged.
+pub async fn resolve_device_tenant(
+    State(state): State<OAuthState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    if req.headers().contains_key("x-tenant-id") {
+        return next.run(req).await;
+    }
+
+    // 1. Try query params (GET /device?code=..., and GET login/mfa pages).
+    let user_code = req.uri().query().and_then(|q| {
+        url::form_urlencoded::parse(q.as_bytes())
+            .find(|(k, _)| k == "code" || k == "user_code")
+            .map(|(_, v)| v.into_owned())
+    });
+
+    if let Some(code) = user_code {
+        return inject_tenant_and_run(state, req, next, &code).await;
+    }
+
+    // 2. For POSTs with a form body, buffer it, read user_code, then rebuild.
+    let is_form = req
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.starts_with("application/x-www-form-urlencoded"));
+
+    if req.method() == axum::http::Method::POST && is_form {
+        let (parts, body) = req.into_parts();
+        let bytes = match to_bytes(body, DEVICE_FORM_BUFFER_LIMIT).await {
+            Ok(b) => b,
+            Err(_) => {
+                // Body too large / unreadable: rebuild empty and let the handler 400.
+                let req = Request::from_parts(parts, Body::empty());
+                return next.run(req).await;
+            }
+        };
+        let code = url::form_urlencoded::parse(&bytes)
+            .find(|(k, _)| k == "user_code" || k == "code")
+            .map(|(_, v)| v.into_owned());
+        let mut req = Request::from_parts(parts, Body::from(bytes));
+        if let Some(code) = code {
+            if let Ok(Some(tenant_id)) = DeviceCodeService::new(state.pool.clone())
+                .resolve_tenant_by_user_code(&code)
+                .await
+            {
+                if let Ok(hv) = HeaderValue::from_str(&tenant_id.to_string()) {
+                    req.headers_mut().insert("x-tenant-id", hv);
+                }
+            }
+        }
+        return next.run(req).await;
+    }
+
+    next.run(req).await
+}
+
+async fn inject_tenant_and_run(
+    state: OAuthState,
+    mut req: Request,
+    next: Next,
+    user_code: &str,
+) -> Response {
+    if let Ok(Some(tenant_id)) = DeviceCodeService::new(state.pool.clone())
+        .resolve_tenant_by_user_code(user_code)
+        .await
+    {
+        if let Ok(hv) = HeaderValue::from_str(&tenant_id.to_string()) {
+            req.headers_mut().insert("x-tenant-id", hv);
+        }
+    }
+    next.run(req).await
 }
 
 /// Device verification page (HTML).
@@ -1834,6 +1923,36 @@ fn render_confirmation_result_page(success: bool, message: &str) -> String {
 mod tests {
     use super::*;
     use chrono::{Duration, Utc};
+
+    #[test]
+    fn device_flow_resolves_tenant_from_user_code_without_header() {
+        // Regression (RFC 8628): the browser-facing /device pages must work
+        // without an X-Tenant-ID header (a user opens verification_uri in a plain
+        // browser). The middleware derives the tenant from the globally-unique
+        // user_code (query or form) and injects the header; it must NOT hard-fail
+        // when the header is absent.
+        let src = include_str!("device.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        assert!(
+            production.contains("pub async fn resolve_device_tenant"),
+            "device routes must have a tenant-from-user_code resolver middleware"
+        );
+        assert!(
+            production.contains("resolve_tenant_by_user_code"),
+            "middleware must resolve the tenant from the user_code"
+        );
+        // It resolves from both the query string and the buffered form body.
+        assert!(
+            production.contains("req.uri().query()") && production.contains("to_bytes(body"),
+            "middleware must read user_code from query and form body"
+        );
+        // And it injects the header the handlers read, only when absent.
+        assert!(
+            production.contains("req.headers().contains_key(\"x-tenant-id\")")
+                && production.contains("insert(\"x-tenant-id\""),
+            "middleware must inject X-Tenant-ID (and skip when already present)"
+        );
+    }
 
     #[test]
     fn test_html_escape() {

--- a/crates/xavyo-api-oauth/src/handlers/logout.rs
+++ b/crates/xavyo-api-oauth/src/handlers/logout.rs
@@ -18,9 +18,11 @@ use axum::{
     response::{IntoResponse, Redirect, Response},
     Form, Json,
 };
+use chrono::Utc;
 use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use xavyo_db::models::{CreateRevokedToken, RevokedToken};
 
 /// Parameters for the OIDC RP-Initiated Logout endpoint.
 ///
@@ -399,22 +401,68 @@ async fn revoke_user_sessions(
             OAuthError::Internal("Failed to set tenant context".to_string())
         })?;
 
-    let result = sqlx::query("DELETE FROM user_sessions WHERE tenant_id = $1 AND user_id = $2")
-        .bind(tenant_id)
-        .bind(user_id)
-        .execute(&mut *conn)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                user_id = %user_id,
-                tenant_id = %tenant_id,
-                error = %e,
-                "Failed to delete user sessions"
-            );
-            OAuthError::Internal("Failed to revoke user sessions".to_string())
-        })?;
+    // Soft-revoke every active session for the user in the `sessions` table
+    // (the app's session store — there is no `user_sessions` table; querying it
+    // 500'd the entire logout). Sessions are revoked via `revoked_at`, matching
+    // SessionService and the JWT/session checks that key off it.
+    let result = sqlx::query(
+        "UPDATE sessions SET revoked_at = NOW(), revoked_reason = 'oidc_logout' \
+         WHERE tenant_id = $1 AND user_id = $2 AND revoked_at IS NULL",
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .execute(&mut *conn)
+    .await
+    .map_err(|e| {
+        tracing::error!(
+            user_id = %user_id,
+            tenant_id = %tenant_id,
+            error = %e,
+            "Failed to revoke user sessions"
+        );
+        OAuthError::Internal("Failed to revoke user sessions".to_string())
+    })?;
 
     let rows_deleted = result.rows_affected();
+
+    // Also revoke the session-issued refresh tokens so the device cannot mint new
+    // access tokens after logout (the OAuth client refresh tokens are revoked
+    // separately by TokenService::revoke_user_tokens).
+    let _ = sqlx::query(
+        "UPDATE refresh_tokens SET revoked_at = NOW() \
+         WHERE user_id = $1 AND tenant_id = $2 AND revoked_at IS NULL",
+    )
+    .bind(user_id)
+    .bind(tenant_id)
+    .execute(&mut *conn)
+    .await;
+
+    // Blacklist all currently-valid access tokens via a revoke-all sentinel so
+    // logout takes effect immediately rather than after the (short) access-token
+    // TTL — matching Auth0/Okta, where RP-initiated logout ends the session now.
+    // The JWT auth middleware rejects any of the user's tokens issued before this.
+    let sentinel = CreateRevokedToken {
+        jti: format!("revoke-all:{user_id}:{}", Utc::now().timestamp()),
+        user_id,
+        tenant_id,
+        reason: Some("oidc_logout".to_string()),
+        // Cover the access-token max lifetime with a comfortable buffer.
+        expires_at: Utc::now() + chrono::Duration::hours(1),
+        revoked_by: None,
+    };
+    if let Err(e) = RevokedToken::insert(&mut *conn, sentinel).await {
+        // A failed sentinel would let access tokens live out their TTL — surface it.
+        tracing::error!(
+            user_id = %user_id,
+            tenant_id = %tenant_id,
+            error = %e,
+            "Failed to write revoke-all sentinel during OIDC logout"
+        );
+        return Err(OAuthError::Internal(
+            "Failed to fully revoke user tokens".to_string(),
+        ));
+    }
+
     tracing::info!(
         user_id = %user_id,
         tenant_id = %tenant_id,
@@ -428,6 +476,35 @@ async fn revoke_user_sessions(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn logout_revokes_sessions_in_the_real_sessions_table() {
+        // Regression: RP-initiated logout deleted from a non-existent
+        // `user_sessions` table, so any logout with an id_token_hint that
+        // identified a user returned 500 (session revocation crashed the whole
+        // request). Must target the real `sessions` table and soft-revoke via
+        // revoked_at, consistent with SessionService.
+        let src = include_str!("logout.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        assert!(
+            !production.contains("FROM user_sessions"),
+            "logout must not reference the non-existent user_sessions table"
+        );
+        assert!(
+            production.contains("UPDATE sessions SET revoked_at = NOW()"),
+            "logout must soft-revoke sessions in the real sessions table"
+        );
+        // It must also revoke the session refresh tokens so the device cannot
+        // continue the session, and write a revoke-all sentinel.
+        assert!(
+            production.contains("UPDATE refresh_tokens SET revoked_at = NOW()"),
+            "logout must revoke the session refresh tokens"
+        );
+        assert!(
+            production.contains("revoke-all:{user_id}") && production.contains("\"oidc_logout\""),
+            "logout must write a revoke-all sentinel to end the session immediately"
+        );
+    }
 
     #[test]
     fn test_end_session_params_deserialize_empty() {

--- a/crates/xavyo-api-oauth/src/handlers/token.rs
+++ b/crates/xavyo-api-oauth/src/handlers/token.rs
@@ -357,14 +357,21 @@ async fn lookup_authorization_code(
     hasher.update(code.as_bytes());
     let code_hash = hex::encode(hasher.finalize());
 
-    // Query WITHOUT setting RLS context - we need to find the tenant_id
+    // Query WITHOUT setting RLS context - we need to find the tenant_id.
+    //
+    // Intentionally resolve on `code_hash` alone: do NOT filter on `used` or
+    // `expires_at` here. All of those checks — and, critically, the RFC 6749
+    // §10.5 reuse detection that revokes the previously-issued token family —
+    // live in `validate_and_consume_code`. Filtering `used = FALSE` here would
+    // short-circuit a replayed code with a plain "not found" before reuse
+    // detection could fire, leaving any tokens minted from the intercepted code
+    // valid. This lookup only resolves the tenant/client context; the atomic
+    // transaction downstream enforces expiry, single-use, and reuse revocation.
     let result: Option<(Uuid, Uuid)> = sqlx::query_as(
         r"
         SELECT client_id, tenant_id
         FROM authorization_codes
         WHERE code_hash = $1
-          AND used = FALSE
-          AND expires_at > NOW()
         ",
     )
     .bind(&code_hash)
@@ -1085,6 +1092,39 @@ async fn handle_token_exchange_grant(
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
+
+    #[test]
+    fn lookup_does_not_filter_used_so_reuse_detection_can_fire() {
+        // Regression: lookup_authorization_code filtered `used = FALSE`, so a
+        // replayed authorization code was rejected here with a plain "not found"
+        // BEFORE reaching validate_and_consume_code — making the RFC 6749 §10.5
+        // reuse-detection branch (which writes the revoke-all token-family
+        // sentinel) dead code. The lookup must resolve on code_hash alone and let
+        // the downstream atomic transaction enforce expiry / single-use / reuse.
+        let src = include_str!("token.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        let lookup = production
+            .split("async fn lookup_authorization_code")
+            .nth(1)
+            .expect("lookup_authorization_code");
+        // Inspect only the SQL string of the lookup (between the raw-string
+        // delimiters), so explanatory comments mentioning these clauses don't
+        // trip the assertions.
+        let sql = lookup
+            .split("r\"")
+            .nth(1)
+            .and_then(|s| s.split("\"")
+                .next())
+            .expect("lookup SQL literal");
+        assert!(
+            !sql.contains("AND used = FALSE"),
+            "lookup SQL must not filter used=FALSE (short-circuits reuse detection)"
+        );
+        assert!(
+            !sql.contains("AND expires_at > NOW()"),
+            "lookup SQL must not filter expiry (validate_and_consume_code is authoritative)"
+        );
+    }
 
     #[test]
     fn test_extract_client_credentials_from_basic_auth() {

--- a/crates/xavyo-api-oauth/src/handlers/token.rs
+++ b/crates/xavyo-api-oauth/src/handlers/token.rs
@@ -1113,8 +1113,7 @@ mod tests {
         let sql = lookup
             .split("r\"")
             .nth(1)
-            .and_then(|s| s.split("\"")
-                .next())
+            .and_then(|s| s.split("\"").next())
             .expect("lookup SQL literal");
         assert!(
             !sql.contains("AND used = FALSE"),

--- a/crates/xavyo-api-oauth/src/models/discovery.rs
+++ b/crates/xavyo-api-oauth/src/models/discovery.rs
@@ -100,6 +100,7 @@ impl OpenIdConfiguration {
                 "iat".to_string(),
                 "auth_time".to_string(),
                 "nonce".to_string(),
+                "at_hash".to_string(),
                 "email".to_string(),
                 "email_verified".to_string(),
                 "name".to_string(),

--- a/crates/xavyo-api-oauth/src/router.rs
+++ b/crates/xavyo-api-oauth/src/router.rs
@@ -461,6 +461,12 @@ pub fn device_router(state: OAuthState) -> Router {
             "/resend-confirmation",
             post(device_resend_confirmation_handler),
         )
+        // RFC 8628: resolve the tenant from the globally-unique user_code so the
+        // browser-facing device pages work without an X-Tenant-ID header.
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            crate::handlers::device::resolve_device_tenant,
+        ))
         .with_state(state)
 }
 

--- a/crates/xavyo-api-oauth/src/services/device_code.rs
+++ b/crates/xavyo-api-oauth/src/services/device_code.rs
@@ -178,6 +178,24 @@ impl DeviceCodeService {
         })
     }
 
+    /// Resolve the owning tenant of a pending device code from its `user_code`.
+    ///
+    /// Used by the browser-facing device verification routes to derive tenant
+    /// context without an `X-Tenant-ID` header (RFC 8628 has the user open the
+    /// verification URL in a plain browser). `user_code` is globally unique.
+    pub async fn resolve_tenant_by_user_code(
+        &self,
+        user_code: &str,
+    ) -> Result<Option<Uuid>, OAuthError> {
+        let normalized = Self::normalize_user_code(user_code);
+        DeviceCode::resolve_tenant_by_user_code(&self.pool, &normalized)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to resolve tenant from user_code: {}", e);
+                OAuthError::Internal("Database error".to_string())
+            })
+    }
+
     /// Find a pending device code by user code (for verification page).
     pub async fn find_pending_by_user_code(
         &self,

--- a/crates/xavyo-api-oauth/src/services/token.rs
+++ b/crates/xavyo-api-oauth/src/services/token.rs
@@ -314,6 +314,15 @@ impl TokenService {
         hex::encode(hash)
     }
 
+    /// Compute the OIDC `at_hash` for an access token: base64url (no padding) of
+    /// the left-most 128 bits of its SHA-256 digest (RS256 ⇒ SHA-256).
+    fn access_token_hash(access_token: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(access_token.as_bytes());
+        let digest = hasher.finalize();
+        URL_SAFE_NO_PAD.encode(&digest[..16])
+    }
+
     /// Look up user email and name fields from the database.
     /// Failures are logged and ignored so token issuance is never blocked by a
     /// profile lookup failure.
@@ -536,6 +545,7 @@ impl TokenService {
         auth_time: i64,
         scope: &str,
         profile: Option<&TokenUserProfile>,
+        access_token: Option<&str>,
     ) -> Result<String, OAuthError> {
         // For OIDC ID tokens, we need additional claims beyond standard JWT
         // We'll use a specialized ID token claims structure
@@ -547,6 +557,13 @@ impl TokenService {
             .auth_time(auth_time)
             .nonce(nonce)
             .expires_in_secs(ID_TOKEN_EXPIRY_SECS);
+        // OIDC Core §3.1.3.6 `at_hash`: base64url(left-most 128 bits of
+        // SHA-256(access_token)) — SHA-256 because the ID token is signed with
+        // RS256. Lets the client bind the ID token to the access token (token
+        // substitution defense), matching Auth0/Okta/Google on the code flow.
+        if let Some(at) = access_token {
+            builder = builder.at_hash(Self::access_token_hash(at));
+        }
         if let Some(profile) = profile {
             if scope_includes(scope, "email") {
                 builder = builder.email(profile.email.as_deref(), profile.email_verified);
@@ -938,6 +955,7 @@ impl TokenService {
                 auth_time,
                 scope,
                 Some(&profile),
+                Some(&access_token),
             )?)
         } else {
             None
@@ -1311,6 +1329,7 @@ impl TokenService {
                 auth_time,
                 scope,
                 Some(&profile),
+                Some(&access_token),
             )?)
         } else {
             None
@@ -1555,6 +1574,20 @@ xxU7T7aU32bKZLygCDtwsN8=
         let token1 = TokenService::generate_refresh_token_value();
         let token2 = TokenService::generate_refresh_token_value();
         assert_ne!(token1, token2);
+    }
+
+    #[test]
+    fn access_token_hash_matches_oidc_at_hash_formula() {
+        // OIDC Core §3.1.3.6: at_hash = base64url(left-most 128 bits of
+        // SHA-256(access_token)) for an RS256-signed ID token. Verify against an
+        // independent computation so the code flow's at_hash is spec-correct.
+        use sha2::{Digest, Sha256};
+        let at = "example-access-token-value";
+        let digest = Sha256::new().chain_update(at.as_bytes()).finalize();
+        let expected = URL_SAFE_NO_PAD.encode(&digest[..16]);
+        assert_eq!(TokenService::access_token_hash(at), expected);
+        // 128 bits → 16 bytes → 22 base64url chars (no padding).
+        assert_eq!(TokenService::access_token_hash(at).len(), 22);
     }
 
     #[test]

--- a/crates/xavyo-api-oidc-federation/Cargo.toml
+++ b/crates/xavyo-api-oidc-federation/Cargo.toml
@@ -56,6 +56,7 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio",
 
 # Async runtime
 tokio = { version = "1", features = ["sync"] }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/xavyo-api-oidc-federation/src/handlers/admin.rs
+++ b/crates/xavyo-api-oidc-federation/src/handlers/admin.rs
@@ -98,6 +98,9 @@ pub async fn create_identity_provider(
     );
 
     let idp = state.idp_config.create(tenant_id, req).await?;
+    // Bust HRD cache so a newly-configured domain is discovered immediately
+    // (clears any stale negative "standard" entry for that domain).
+    state.hrd.clear_tenant_cache(tenant_id).await;
     let domains = state.idp_config.get_domains(tenant_id, idp.id).await?;
     let response = IdentityProviderResponse::from_model(idp, domains, 0)?;
 
@@ -176,6 +179,8 @@ pub async fn update_identity_provider(
     );
 
     let idp = state.idp_config.update(tenant_id, idp_id, req).await?;
+    // Config may have changed the enabled state, issuer, or scopes — bust HRD cache.
+    state.hrd.clear_tenant_cache(tenant_id).await;
     let domains = state.idp_config.get_domains(tenant_id, idp_id).await?;
     let linked_users_count = state
         .idp_config
@@ -221,6 +226,8 @@ pub async fn delete_identity_provider(
     );
 
     state.idp_config.delete(tenant_id, idp_id).await?;
+    // Stop routing the deleted IdP's domains immediately.
+    state.hrd.clear_tenant_cache(tenant_id).await;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -299,6 +306,8 @@ pub async fn toggle_identity_provider(
         .idp_config
         .set_enabled(tenant_id, idp_id, req.is_enabled)
         .await?;
+    // Enabling/disabling must take effect immediately for Home Realm Discovery.
+    state.hrd.clear_tenant_cache(tenant_id).await;
     let domains = state.idp_config.get_domains(tenant_id, idp_id).await?;
     let linked_users_count = state
         .idp_config
@@ -385,6 +394,8 @@ pub async fn add_domain(
         .idp_config
         .add_domain(tenant_id, idp_id, req.domain, req.priority)
         .await?;
+    // A newly-added domain must be discoverable immediately (clear stale negative entry).
+    state.hrd.clear_tenant_cache(tenant_id).await;
 
     Ok((StatusCode::CREATED, Json(DomainResponse::from(domain))))
 }
@@ -426,6 +437,8 @@ pub async fn remove_domain(
         .idp_config
         .remove_domain(tenant_id, idp_id, domain_id)
         .await?;
+    // Stop routing the removed domain immediately.
+    state.hrd.clear_tenant_cache(tenant_id).await;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -445,5 +458,32 @@ mod tests {
             list.contains("params.is_enabled") && list.contains(".list("),
             "GET /admin/federation/identity-providers must honor advertised is_enabled"
         );
+    }
+
+    #[test]
+    fn mutating_handlers_invalidate_hrd_cache() {
+        // Every IdP/domain mutation must bust the Home Realm Discovery cache so a
+        // disable/delete/domain change takes effect immediately instead of being
+        // served stale from the cache for up to the cache TTL.
+        let src = include_str!("admin.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        for handler in [
+            "pub async fn create_identity_provider",
+            "pub async fn update_identity_provider",
+            "pub async fn delete_identity_provider",
+            "pub async fn toggle_identity_provider",
+            "pub async fn add_domain",
+            "pub async fn remove_domain",
+        ] {
+            let body = production
+                .split(handler)
+                .nth(1)
+                .and_then(|s| s.split("\npub async fn ").next())
+                .unwrap_or_else(|| panic!("handler not found: {handler}"));
+            assert!(
+                body.contains("hrd.clear_tenant_cache(tenant_id)"),
+                "{handler} must invalidate the HRD cache after mutating IdP config"
+            );
+        }
     }
 }

--- a/crates/xavyo-api-oidc-federation/src/handlers/federation.rs
+++ b/crates/xavyo-api-oidc-federation/src/handlers/federation.rs
@@ -264,19 +264,10 @@ pub async fn callback(
     // If the redirect_uri contains a path (e.g., callback page), redirect with token
     // Otherwise return JSON response
     if redirect_uri.starts_with("http") {
-        // H2: Validate redirect URI (defense in depth against open redirects)
-        // Use proper URL parsing to prevent prefix bypass (e.g., example.com.evil.com)
-        let redirect_safe = if let (Ok(redirect_url), Ok(base_url)) = (
-            url::Url::parse(&redirect_uri),
-            url::Url::parse(state.auth_flow.callback_base_url()),
-        ) {
-            redirect_url.scheme() == base_url.scheme()
-                && redirect_url.host_str() == base_url.host_str()
-                && redirect_url.port() == base_url.port()
-        } else {
-            false
-        };
-        if !redirect_safe {
+        // H2: Validate redirect URI (defense in depth against open redirects).
+        // Allowed origins are the callback base and the configured frontend, so a
+        // split frontend/backend deployment can finish login in the SPA.
+        if !state.auth_flow.redirect_uri_allowed(&redirect_uri) {
             tracing::warn!(
                 redirect_uri = %redirect_uri,
                 "Blocked potential open redirect in federation callback"
@@ -288,14 +279,20 @@ pub async fn callback(
                 refresh_token: xavyo_tokens.refresh_token,
             })));
         }
-        // Redirect with token as fragment (safer than query params)
-        // R9: URL-encode the access token per RFC 6749 Section 4.2.2
+        // Redirect with tokens as fragment (safer than query params).
+        // R9: URL-encode per RFC 6749 Section 4.2.2. Include the refresh token so
+        // the SPA can establish a full session (parity with social login).
         let encoded_token: String =
             url::form_urlencoded::byte_serialize(xavyo_tokens.access_token.as_bytes()).collect();
-        let redirect_url = format!(
+        let mut redirect_url = format!(
             "{}#access_token={encoded_token}&token_type=Bearer&expires_in={}",
             redirect_uri, xavyo_tokens.expires_in
         );
+        if let Some(ref refresh) = xavyo_tokens.refresh_token {
+            let encoded_refresh: String =
+                url::form_urlencoded::byte_serialize(refresh.as_bytes()).collect();
+            redirect_url.push_str(&format!("&refresh_token={encoded_refresh}"));
+        }
         Ok(CallbackResponse::Redirect(Redirect::temporary(
             &redirect_url,
         )))

--- a/crates/xavyo-api-oidc-federation/src/lib.rs
+++ b/crates/xavyo-api-oidc-federation/src/lib.rs
@@ -32,3 +32,4 @@ pub use error::{FederationError, FederationResult};
 pub use router::{
     admin_routes, auth_routes, create_federation_router, FederationConfig, FederationState,
 };
+pub use services::{FederationTokenIssuer, IssuedTokens};

--- a/crates/xavyo-api-oidc-federation/src/router.rs
+++ b/crates/xavyo-api-oidc-federation/src/router.rs
@@ -7,9 +7,11 @@ use axum::{
 use sqlx::PgPool;
 
 use crate::handlers::{admin, federation};
+use std::sync::Arc;
+
 use crate::services::{
-    AuthFlowService, EncryptionService, HrdService, IdpConfigService, ProvisioningService,
-    TokenIssuerService, ValidationService,
+    AuthFlowService, EncryptionService, FederationTokenIssuer, HrdService, IdpConfigService,
+    ProvisioningService, TokenIssuerService, ValidationService,
 };
 
 /// Shared state for federation handlers.
@@ -30,8 +32,10 @@ pub struct FederationState {
     pub auth_flow: AuthFlowService,
     /// Provisioning service.
     pub provisioning: ProvisioningService,
-    /// Token issuer service.
-    pub token_issuer: TokenIssuerService,
+    /// Token issuer. Defaults to the standalone JWT issuer; `idp-api` injects a
+    /// `TokenService`-backed implementation so federation refresh tokens are
+    /// persisted (refreshable + revocable like password/social login).
+    pub token_issuer: Arc<dyn FederationTokenIssuer>,
 }
 
 /// Configuration for federation router.
@@ -68,10 +72,12 @@ impl FederationState {
             config.frontend_url.clone(),
         );
         let provisioning = ProvisioningService::new(config.pool.clone());
-        let token_issuer = TokenIssuerService::new(crate::services::TokenIssuerConfig {
-            private_key_pem: config.jwt_private_key_pem.clone(),
-            ..Default::default()
-        });
+        let token_issuer: Arc<dyn FederationTokenIssuer> = Arc::new(TokenIssuerService::new(
+            crate::services::TokenIssuerConfig {
+                private_key_pem: config.jwt_private_key_pem.clone(),
+                ..Default::default()
+            },
+        ));
 
         Self {
             pool: config.pool.clone(),

--- a/crates/xavyo-api-oidc-federation/src/router.rs
+++ b/crates/xavyo-api-oidc-federation/src/router.rs
@@ -43,6 +43,11 @@ pub struct FederationConfig {
     pub master_key: [u8; 32],
     /// Base URL for callbacks (e.g., "<https://idp.example.com>").
     pub callback_base_url: String,
+    /// Frontend base URL (e.g. "<http://localhost:3000>"). Post-login browser
+    /// redirects to the SPA are allowed to target this origin in addition to
+    /// `callback_base_url`, so a split frontend/backend deployment can complete
+    /// the login in the app.
+    pub frontend_url: String,
     /// PEM-encoded RSA private key for signing federation JWTs.
     /// Must be provided — federation login will fail without a valid signing key.
     pub jwt_private_key_pem: Vec<u8>,
@@ -60,6 +65,7 @@ impl FederationState {
             config.pool.clone(),
             encryption,
             config.callback_base_url.clone(),
+            config.frontend_url.clone(),
         );
         let provisioning = ProvisioningService::new(config.pool.clone());
         let token_issuer = TokenIssuerService::new(crate::services::TokenIssuerConfig {

--- a/crates/xavyo-api-oidc-federation/src/services/auth_flow.rs
+++ b/crates/xavyo-api-oidc-federation/src/services/auth_flow.rs
@@ -21,6 +21,8 @@ pub struct AuthFlowService {
     token_verifier: TokenVerifierService,
     /// Base URL for callbacks.
     callback_base_url: String,
+    /// Frontend base URL; also an allowed post-login redirect origin.
+    frontend_url: String,
 }
 
 /// Authorization URL result.
@@ -102,13 +104,19 @@ pub struct IdTokenClaims {
 impl AuthFlowService {
     /// Create a new authorization flow service.
     #[must_use]
-    pub fn new(pool: PgPool, encryption: EncryptionService, callback_base_url: String) -> Self {
+    pub fn new(
+        pool: PgPool,
+        encryption: EncryptionService,
+        callback_base_url: String,
+        frontend_url: String,
+    ) -> Self {
         Self {
             pool,
             discovery: DiscoveryService::new(),
             encryption,
             token_verifier: TokenVerifierService::default(),
             callback_base_url,
+            frontend_url,
         }
     }
 
@@ -144,7 +152,7 @@ impl AuthFlowService {
 
         // Validate redirect URI to prevent open redirects (H2)
         if let Some(ref uri) = input.redirect_uri {
-            Self::validate_redirect_uri(uri, &self.callback_base_url)?;
+            self.validate_redirect_uri(uri)?;
         }
 
         // Determine final redirect URI
@@ -450,8 +458,16 @@ impl AuthFlowService {
         Ok(())
     }
 
-    /// Validate redirect URI to prevent open redirects.
-    fn validate_redirect_uri(redirect_uri: &str, callback_base_url: &str) -> FederationResult<()> {
+    /// Frontend base URL (an allowed post-login redirect origin).
+    #[must_use]
+    pub fn frontend_url(&self) -> &str {
+        &self.frontend_url
+    }
+
+    /// Whether a post-login `redirect_uri` is allowed: a safe relative path, or
+    /// an absolute URL whose origin matches the callback base or the frontend.
+    #[must_use]
+    pub fn redirect_uri_allowed(&self, redirect_uri: &str) -> bool {
         let trimmed = redirect_uri.trim();
         // Allow relative paths starting with / (but not // or /\)
         if trimmed.starts_with('/')
@@ -459,35 +475,41 @@ impl AuthFlowService {
             && !trimmed.starts_with("/\\")
             && !trimmed.contains("://")
         {
-            // SECURITY: Block encoded path traversal patterns that could bypass the above checks
-            // after browser URL normalization (e.g., %2f → /, %5c → \, %0a → newline).
+            // Block encoded traversal that could bypass the checks after browser
+            // URL normalization (e.g., %2f → /, %5c → \, %0a → newline).
             let lower = trimmed.to_lowercase();
-            if lower.contains("%2f")
+            return !(lower.contains("%2f")
                 || lower.contains("%5c")
                 || lower.contains("%0a")
                 || lower.contains("%0d")
-                || lower.contains("\\")
-            {
-                return Err(FederationError::InvalidCallback(
-                    "redirect_uri contains invalid encoded characters".to_string(),
-                ));
-            }
-            return Ok(());
+                || lower.contains('\\'));
         }
-        // For absolute URLs: parse both and compare scheme + host + port
-        if let (Ok(redirect), Ok(base)) =
-            (url::Url::parse(trimmed), url::Url::parse(callback_base_url))
-        {
-            if redirect.scheme() == base.scheme()
-                && redirect.host_str() == base.host_str()
-                && redirect.port() == base.port()
-            {
-                return Ok(());
-            }
+        // Absolute URLs: allow when the origin matches the callback base or frontend.
+        Self::origin_matches(trimmed, &self.callback_base_url)
+            || Self::origin_matches(trimmed, &self.frontend_url)
+    }
+
+    /// Compare the scheme+host+port of two URLs.
+    fn origin_matches(url: &str, base: &str) -> bool {
+        matches!(
+            (url::Url::parse(url), url::Url::parse(base)),
+            (Ok(u), Ok(b))
+                if u.scheme() == b.scheme()
+                    && u.host_str() == b.host_str()
+                    && u.port() == b.port()
+        )
+    }
+
+    /// Validate redirect URI to prevent open redirects.
+    fn validate_redirect_uri(&self, redirect_uri: &str) -> FederationResult<()> {
+        if self.redirect_uri_allowed(redirect_uri) {
+            Ok(())
+        } else {
+            Err(FederationError::InvalidCallback(
+                "redirect_uri must be a relative path or under the configured base/frontend URL"
+                    .to_string(),
+            ))
         }
-        Err(FederationError::InvalidCallback(
-            "redirect_uri must be a relative path or under the configured base URL".to_string(),
-        ))
     }
 
     /// Get session by ID with tenant isolation.

--- a/crates/xavyo-api-oidc-federation/src/services/discovery.rs
+++ b/crates/xavyo-api-oidc-federation/src/services/discovery.rs
@@ -72,7 +72,12 @@ impl DiscoveryService {
                 .to_string(),
             userinfo_endpoint: metadata.userinfo_endpoint().map(|e| e.url().to_string()),
             jwks_uri: metadata.jwks_uri().url().to_string(),
-            issuer: metadata.issuer().url().to_string(),
+            // Use the issuer identifier verbatim. `Url::to_string()` normalizes a
+            // host-only issuer by appending a trailing slash (e.g.
+            // `https://accounts.google.com` -> `.../`), but OIDC requires the ID
+            // token `iss` to match the issuer identifier by exact string. Using the
+            // normalized form rejects spec-compliant tokens from such providers.
+            issuer: metadata.issuer().as_str().to_string(),
         };
 
         tracing::info!(

--- a/crates/xavyo-api-oidc-federation/src/services/mod.rs
+++ b/crates/xavyo-api-oidc-federation/src/services/mod.rs
@@ -20,6 +20,8 @@ pub use hrd::{HrdResult, HrdService};
 pub use idp_config::IdpConfigService;
 pub use jwks_cache::{JwksCache, JwksCacheStats, DEFAULT_JWKS_CACHE_TTL};
 pub use provisioning::ProvisioningService;
-pub use token_issuer::{IssuedTokens, TokenIssuerConfig, TokenIssuerService};
+pub use token_issuer::{
+    FederationTokenIssuer, IssuedTokens, TokenIssuerConfig, TokenIssuerService,
+};
 pub use token_verifier::{TokenVerifierService, VerificationConfig, VerifiedToken};
 pub use validation::ValidationService;

--- a/crates/xavyo-api-oidc-federation/src/services/token_issuer.rs
+++ b/crates/xavyo-api-oidc-federation/src/services/token_issuer.rs
@@ -59,6 +59,50 @@ pub struct IssuedTokens {
     pub token_type: String,
 }
 
+/// Issues xavyo session tokens for a federated user.
+///
+/// Abstracted as a trait so `idp-api` can inject an implementation backed by the
+/// shared `TokenService` (which persists an opaque, refreshable/revocable refresh
+/// token) instead of the standalone JWT issuer, giving federation logins the same
+/// refresh/logout semantics as password and social login.
+#[async_trait::async_trait]
+pub trait FederationTokenIssuer: Send + Sync {
+    /// Issue an access + refresh token pair for the given user/tenant.
+    async fn issue_tokens(
+        &self,
+        user_id: Uuid,
+        tenant_id: Uuid,
+        roles: Vec<String>,
+        email: Option<String>,
+        name: Option<String>,
+        federation_claims: Option<FederationClaims>,
+    ) -> FederationResult<IssuedTokens>;
+}
+
+#[async_trait::async_trait]
+impl FederationTokenIssuer for TokenIssuerService {
+    async fn issue_tokens(
+        &self,
+        user_id: Uuid,
+        tenant_id: Uuid,
+        roles: Vec<String>,
+        email: Option<String>,
+        name: Option<String>,
+        federation_claims: Option<FederationClaims>,
+    ) -> FederationResult<IssuedTokens> {
+        TokenIssuerService::issue_tokens(
+            self,
+            user_id,
+            tenant_id,
+            roles,
+            email,
+            name,
+            federation_claims,
+        )
+        .await
+    }
+}
+
 impl TokenIssuerService {
     /// Create a new token issuer service with configuration.
     #[must_use]

--- a/crates/xavyo-api-oidc-federation/src/services/token_verifier.rs
+++ b/crates/xavyo-api-oidc-federation/src/services/token_verifier.rs
@@ -5,8 +5,38 @@
 
 use crate::error::{FederationError, FederationResult};
 use crate::services::jwks_cache::JwksCache;
+use serde::Deserialize;
 use tracing::{debug, info, instrument, warn};
-use xavyo_auth::{decode_token_with_algorithm, JwtClaims, ValidationConfig};
+use xavyo_auth::{decode_token_into, ValidationConfig};
+
+/// Claims parsed from an *external* IdP ID token during verification.
+///
+/// Intentionally permissive: an upstream ID token follows the OIDC spec, not
+/// xavyo's internal token contract, so it may omit `jti` and may encode `aud`
+/// as a string. Deserializing into xavyo's internal `JwtClaims` (which requires
+/// `jti` and a `Vec<String>` audience) would reject spec-compliant tokens.
+#[derive(Debug, Clone, Deserialize)]
+pub struct VerifiedIdTokenClaims {
+    /// Subject identifier at the IdP.
+    pub sub: String,
+    /// Issuer.
+    pub iss: String,
+    /// Audience (string or array per the OIDC spec).
+    #[serde(default)]
+    pub aud: serde_json::Value,
+    /// Expiration (Unix seconds).
+    #[serde(default)]
+    pub exp: Option<i64>,
+    /// Issued-at (Unix seconds).
+    #[serde(default)]
+    pub iat: Option<i64>,
+    /// Nonce echoed from the authorization request.
+    #[serde(default)]
+    pub nonce: Option<String>,
+    /// Email, when present.
+    #[serde(default)]
+    pub email: Option<String>,
+}
 
 /// Configuration for token verification.
 #[derive(Clone)]
@@ -66,7 +96,7 @@ impl VerificationConfig {
 #[derive(Debug, Clone)]
 pub struct VerifiedToken {
     /// Validated claims from the token.
-    pub claims: JwtClaims,
+    pub claims: VerifiedIdTokenClaims,
     /// Key ID used for verification (if present in token header).
     pub kid: Option<String>,
     /// Issuer from the token.
@@ -178,17 +208,22 @@ impl TokenVerifierService {
         }
 
         // Verify the token
-        let claims = decode_token_with_algorithm(token, &info.pem, info.algorithm, &validation)
-            .map_err(|e| match e {
-                xavyo_auth::AuthError::TokenExpired => FederationError::TokenExpired,
-                xavyo_auth::AuthError::InvalidSignature => {
-                    FederationError::TokenVerificationFailed("Invalid signature".to_string())
-                }
-                xavyo_auth::AuthError::InvalidAlgorithm => {
-                    FederationError::TokenVerificationFailed("Unsupported algorithm".to_string())
-                }
-                _ => FederationError::TokenVerificationFailed(e.to_string()),
-            })?;
+        let claims = decode_token_into::<VerifiedIdTokenClaims>(
+            token,
+            &info.pem,
+            info.algorithm,
+            &validation,
+        )
+        .map_err(|e| match e {
+            xavyo_auth::AuthError::TokenExpired => FederationError::TokenExpired,
+            xavyo_auth::AuthError::InvalidSignature => {
+                FederationError::TokenVerificationFailed("Invalid signature".to_string())
+            }
+            xavyo_auth::AuthError::InvalidAlgorithm => {
+                FederationError::TokenVerificationFailed("Unsupported algorithm".to_string())
+            }
+            _ => FederationError::TokenVerificationFailed(e.to_string()),
+        })?;
 
         // Validate issuer if expected
         if let Some(ref expected) = self.config.expected_issuer {
@@ -268,14 +303,19 @@ impl TokenVerifierService {
             ValidationConfig::with_leeway(self.config.clock_skew_tolerance).issuer(expected_issuer);
 
         // Verify the token
-        let claims = decode_token_with_algorithm(token, &info.pem, info.algorithm, &validation)
-            .map_err(|e| match e {
-                xavyo_auth::AuthError::TokenExpired => FederationError::TokenExpired,
-                xavyo_auth::AuthError::InvalidSignature => {
-                    FederationError::TokenVerificationFailed("Invalid signature".to_string())
-                }
-                _ => FederationError::TokenVerificationFailed(e.to_string()),
-            })?;
+        let claims = decode_token_into::<VerifiedIdTokenClaims>(
+            token,
+            &info.pem,
+            info.algorithm,
+            &validation,
+        )
+        .map_err(|e| match e {
+            xavyo_auth::AuthError::TokenExpired => FederationError::TokenExpired,
+            xavyo_auth::AuthError::InvalidSignature => {
+                FederationError::TokenVerificationFailed("Invalid signature".to_string())
+            }
+            _ => FederationError::TokenVerificationFailed(e.to_string()),
+        })?;
 
         Ok(VerifiedToken {
             issuer: claims.iss.clone(),

--- a/crates/xavyo-api-saml/src/saml/attributes.rs
+++ b/crates/xavyo-api-saml/src/saml/attributes.rs
@@ -210,13 +210,35 @@ pub fn default_attributes(user: &UserAttributes) -> Vec<ResolvedAttribute> {
 pub const NAMEID_FORMAT_EMAIL: &str = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
 pub const NAMEID_FORMAT_PERSISTENT: &str = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
 pub const NAMEID_FORMAT_TRANSIENT: &str = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient";
+pub const NAMEID_FORMAT_UNSPECIFIED: &str = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+
+/// Normalize a configured `NameID` format to its canonical URN.
+///
+/// The admin UI offers short labels (`emailAddress`, `persistent`, `transient`,
+/// `unspecified`); the assertion builder matches on the full URNs. Without this,
+/// an SP configured with a short label produced a null NameID and a 500 at SSO
+/// time. Returns `None` for genuinely unsupported formats so callers can reject
+/// them at config time rather than fail during assertion generation.
+#[must_use]
+pub fn normalize_nameid_format(format: &str) -> Option<String> {
+    match format.trim() {
+        "" | "emailAddress" | NAMEID_FORMAT_EMAIL => Some(NAMEID_FORMAT_EMAIL.to_string()),
+        "persistent" | NAMEID_FORMAT_PERSISTENT => Some(NAMEID_FORMAT_PERSISTENT.to_string()),
+        "transient" | NAMEID_FORMAT_TRANSIENT => Some(NAMEID_FORMAT_TRANSIENT.to_string()),
+        "unspecified" | NAMEID_FORMAT_UNSPECIFIED => Some(NAMEID_FORMAT_UNSPECIFIED.to_string()),
+        _ => None,
+    }
+}
 
 /// Check if a `NameID` format is supported
 #[must_use]
 pub fn is_supported_nameid_format(format: &str) -> bool {
     matches!(
         format,
-        NAMEID_FORMAT_EMAIL | NAMEID_FORMAT_PERSISTENT | NAMEID_FORMAT_TRANSIENT
+        NAMEID_FORMAT_EMAIL
+            | NAMEID_FORMAT_PERSISTENT
+            | NAMEID_FORMAT_TRANSIENT
+            | NAMEID_FORMAT_UNSPECIFIED
     )
 }
 
@@ -237,6 +259,10 @@ pub fn get_nameid_for_format(
                 .map(String::from)
                 .unwrap_or_else(|| format!("_transient_{}", uuid::Uuid::new_v4())),
         ),
+        // `unspecified` lets the IdP choose the identifier; email is the
+        // conventional default (Auth0/Okta do the same). This is an explicit,
+        // supported format — not a silent fallback for unknown ones.
+        NAMEID_FORMAT_UNSPECIFIED => Some(user.email.clone()),
         _ => None,
     }
 }
@@ -244,6 +270,46 @@ pub fn get_nameid_for_format(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_maps_short_labels_to_canonical_urns() {
+        // The admin UI offers these short labels; each must map to a URN the
+        // assertion builder recognizes (else SSO 500s with a null NameID).
+        assert_eq!(
+            normalize_nameid_format("emailAddress").as_deref(),
+            Some(NAMEID_FORMAT_EMAIL)
+        );
+        assert_eq!(
+            normalize_nameid_format("persistent").as_deref(),
+            Some(NAMEID_FORMAT_PERSISTENT)
+        );
+        assert_eq!(
+            normalize_nameid_format("transient").as_deref(),
+            Some(NAMEID_FORMAT_TRANSIENT)
+        );
+        assert_eq!(
+            normalize_nameid_format("unspecified").as_deref(),
+            Some(NAMEID_FORMAT_UNSPECIFIED)
+        );
+        // Full URNs pass through; unknown formats are rejected.
+        assert_eq!(
+            normalize_nameid_format(NAMEID_FORMAT_EMAIL).as_deref(),
+            Some(NAMEID_FORMAT_EMAIL)
+        );
+        assert_eq!(normalize_nameid_format("bogus"), None);
+    }
+
+    #[test]
+    fn every_ui_offered_format_yields_a_nameid() {
+        let user = test_user();
+        for label in ["emailAddress", "persistent", "transient", "unspecified"] {
+            let fmt = normalize_nameid_format(label).expect("normalizable");
+            assert!(
+                get_nameid_for_format(&user, &fmt, Some("sess")).is_some(),
+                "format {label} must produce a NameID"
+            );
+        }
+    }
 
     fn test_user() -> UserAttributes {
         UserAttributes {
@@ -374,14 +440,20 @@ mod tests {
             get_nameid_for_format(&user, NAMEID_FORMAT_PERSISTENT, None),
             Some("user-123".to_string())
         );
+        // A genuinely unknown/custom format must NOT silently become email.
         assert!(
             get_nameid_for_format(
                 &user,
-                "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
                 None
             )
             .is_none(),
             "unsupported NameID format must not become email"
+        );
+        // `unspecified` is an explicitly supported format → email (IdP's choice).
+        assert_eq!(
+            get_nameid_for_format(&user, NAMEID_FORMAT_UNSPECIFIED, None),
+            Some("test@example.com".to_string())
         );
         let src = include_str!("attributes.rs");
         let production = src.split("mod tests").next().expect("production source");

--- a/crates/xavyo-api-saml/src/services/sp_service.rs
+++ b/crates/xavyo-api-saml/src/services/sp_service.rs
@@ -249,6 +249,17 @@ impl SpService {
             )));
         }
 
+        // Normalize the NameID format (UI sends short labels; the assertion
+        // builder needs canonical URNs). Reject unsupported values up front
+        // rather than fail with a 500 during assertion generation.
+        let name_id_format = crate::saml::attributes::normalize_nameid_format(&req.name_id_format)
+            .ok_or_else(|| {
+                SamlError::InvalidAuthnRequest(format!(
+                    "Unsupported name_id_format: {}",
+                    req.name_id_format
+                ))
+            })?;
+
         let group_cfg = req
             .resolved_group_config()
             .map_err(|e| SamlError::InvalidAuthnRequest(format!("invalid group config: {e}")))?;
@@ -287,7 +298,7 @@ impl SpService {
         .bind(&req.acs_urls)
         .bind(&req.certificate)
         .bind(&attribute_mapping)
-        .bind(&req.name_id_format)
+        .bind(&name_id_format)
         .bind(req.sign_assertions)
         .bind(req.validate_signatures)
         .bind(req.assertion_validity_seconds)
@@ -350,7 +361,14 @@ impl SpService {
         }
         let certificate = req.certificate.or(existing.certificate);
         let attribute_mapping = req.attribute_mapping.unwrap_or(existing.attribute_mapping);
-        let name_id_format = req.name_id_format.unwrap_or(existing.name_id_format);
+        let name_id_format = match req.name_id_format {
+            Some(fmt) => {
+                crate::saml::attributes::normalize_nameid_format(&fmt).ok_or_else(|| {
+                    SamlError::InvalidAuthnRequest(format!("Unsupported name_id_format: {fmt}"))
+                })?
+            }
+            None => existing.name_id_format,
+        };
         let sign_assertions = req.sign_assertions.unwrap_or(existing.sign_assertions);
         let validate_signatures = req
             .validate_signatures

--- a/crates/xavyo-api-scim/src/services/user_service.rs
+++ b/crates/xavyo-api-scim/src/services/user_service.rs
@@ -227,15 +227,17 @@ impl UserService {
         Ok(mapper.to_scim_user(&user, groups, &self.base_url))
     }
 
-    /// Find an active user by ID, returning error if not found or deactivated.
+    /// Find a non-deleted user by ID, returning error if not found or SCIM-deleted.
     ///
-    /// SCIM DELETE deactivates users (sets is_active=false). Per RFC 7644 Section 3.6,
-    /// subsequent GET on a deleted resource should return 404.
+    /// A *deactivated* user (`is_active = false`) still exists and must be readable,
+    /// reactivatable, and deletable via SCIM — only a SCIM *delete* (which sets
+    /// `scim_deleted_at`) hides the resource so a subsequent GET returns 404 per
+    /// RFC 7644 Section 3.6.
     async fn find_user(&self, tenant_id: Uuid, user_id: Uuid) -> ScimResult<User> {
         let user: Option<User> = sqlx::query_as(
             r"
             SELECT * FROM users
-            WHERE id = $1 AND tenant_id = $2 AND is_active = true
+            WHERE id = $1 AND tenant_id = $2 AND scim_deleted_at IS NULL
             ",
         )
         .bind(user_id)
@@ -256,11 +258,14 @@ impl UserService {
         let mapper = self.get_mapper(tenant_id).await?;
         let filter_mapper = AttributeMapper::for_users();
 
-        // Build query — only return active users (SCIM DELETE deactivates, per RFC 7644 Section 3.6)
+        // Return all non-deleted users (active *and* deactivated); SCIM DELETE sets
+        // scim_deleted_at to hide the resource. Callers filter by `active` via the
+        // SCIM `filter` parameter, matching Okta/Azure list semantics.
         let mut base_query =
-            String::from("SELECT * FROM users WHERE tenant_id = $1 AND is_active = true");
-        let mut count_query =
-            String::from("SELECT COUNT(*) FROM users WHERE tenant_id = $1 AND is_active = true");
+            String::from("SELECT * FROM users WHERE tenant_id = $1 AND scim_deleted_at IS NULL");
+        let mut count_query = String::from(
+            "SELECT COUNT(*) FROM users WHERE tenant_id = $1 AND scim_deleted_at IS NULL",
+        );
         let mut params: Vec<String> = vec![];
 
         // Apply filter
@@ -673,9 +678,10 @@ impl UserService {
             r"
             UPDATE users SET
                 is_active = false,
+                scim_deleted_at = NOW(),
                 scim_last_sync = NOW(),
                 updated_at = NOW()
-            WHERE id = $1 AND tenant_id = $2 AND is_active = true
+            WHERE id = $1 AND tenant_id = $2 AND scim_deleted_at IS NULL
             ",
         )
         .bind(user_id)
@@ -743,6 +749,53 @@ fn patch_optional_string(value: &serde_json::Value, field: &str) -> ScimResult<O
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deactivated_users_remain_manageable_only_scim_delete_hides_them() {
+        // Regression: SCIM overloaded `is_active` for both "deactivated" and
+        // "deleted", so once an IdP deactivated a user (PATCH active=false) that
+        // user became invisible — it could not be fetched, reactivated, or deleted
+        // through SCIM. Reads/lists must key off `scim_deleted_at`, and only DELETE
+        // may set it (so deactivated users stay readable/reactivatable, per Okta/Azure).
+        let src = include_str!("user_service.rs");
+        let production = src.split("mod tests").next().expect("production source");
+
+        // find_user (get/patch/replace lookup) must hide only SCIM-deleted rows.
+        let find = production
+            .split("async fn find_user")
+            .nth(1)
+            .expect("find_user");
+        assert!(
+            find.contains("scim_deleted_at IS NULL"),
+            "find_user must key off scim_deleted_at, not is_active"
+        );
+        assert!(
+            !find.contains("is_active = true"),
+            "find_user must not filter deactivated users out"
+        );
+
+        // List must include deactivated (non-deleted) users.
+        assert!(
+            production.contains(
+                "SELECT * FROM users WHERE tenant_id = $1 AND scim_deleted_at IS NULL"
+            ),
+            "list must return active + deactivated (non-deleted) users"
+        );
+
+        // DELETE is the only path that sets the soft-delete marker.
+        let delete = production
+            .split("pub async fn delete_user")
+            .nth(1)
+            .expect("delete_user");
+        assert!(
+            delete.contains("scim_deleted_at = NOW()"),
+            "delete_user must set the scim_deleted_at soft-delete marker"
+        );
+        assert!(
+            delete.contains("scim_deleted_at IS NULL"),
+            "delete_user must target non-deleted rows (idempotent on active or deactivated)"
+        );
+    }
 
     #[test]
     fn test_patch_op_replace_active() {

--- a/crates/xavyo-api-scim/src/services/user_service.rs
+++ b/crates/xavyo-api-scim/src/services/user_service.rs
@@ -776,9 +776,8 @@ mod tests {
 
         // List must include deactivated (non-deleted) users.
         assert!(
-            production.contains(
-                "SELECT * FROM users WHERE tenant_id = $1 AND scim_deleted_at IS NULL"
-            ),
+            production
+                .contains("SELECT * FROM users WHERE tenant_id = $1 AND scim_deleted_at IS NULL"),
             "list must return active + deactivated (non-deleted) users"
         );
 

--- a/crates/xavyo-api-social/src/handlers/admin.rs
+++ b/crates/xavyo-api-social/src/handlers/admin.rs
@@ -142,14 +142,13 @@ pub async fn disable_provider(
 }
 
 /// Secret is required when enabling. Disabling without a secret must keep the stored secret.
-fn social_update_secret(enabled: bool, secret: Option<&str>) -> SocialResult<Option<&str>> {
-    let secret = secret.map(str::trim).filter(|s| !s.is_empty());
-    if enabled && secret.is_none() {
-        return Err(SocialError::ConfigurationError {
-            message: "client_secret is required when enabling a provider".to_string(),
-        });
-    }
-    Ok(secret)
+fn social_update_secret(_enabled: bool, secret: Option<&str>) -> SocialResult<Option<&str>> {
+    // Normalize only: empty/whitespace -> None. Whether a secret is REQUIRED
+    // (enabling a provider that has none stored yet) is enforced in the service
+    // layer, which can see the persisted secret; the handler cannot. Previously
+    // this rejected enable-without-secret outright, so an admin toggling an
+    // already-configured provider on got a 500 ("client_secret is required").
+    Ok(secret.map(str::trim).filter(|s| !s.is_empty()))
 }
 
 #[cfg(test)]
@@ -158,7 +157,10 @@ mod tests {
 
     #[test]
     fn disable_without_secret_does_not_send_empty() {
-        assert!(social_update_secret(true, None).is_err());
+        // Enabling without a secret in the request is NOT rejected here — the
+        // service enforces it against the stored secret (so an admin can toggle an
+        // already-configured provider on). The handler only normalizes.
+        assert_eq!(social_update_secret(true, None).unwrap(), None);
         assert_eq!(
             social_update_secret(true, Some("s3cret")).unwrap(),
             Some("s3cret")

--- a/crates/xavyo-api-social/src/handlers/authorize.rs
+++ b/crates/xavyo-api-social/src/handlers/authorize.rs
@@ -54,6 +54,9 @@ pub async fn authorize(
             provider: provider_type,
         })?;
 
+    // Tenant-configured scopes (if any) override each provider's defaults.
+    let cfg_scopes = config.scopes.clone();
+
     // Generate PKCE challenge
     let pkce = OAuthService::generate_pkce();
 
@@ -77,7 +80,8 @@ pub async fn authorize(
     let nonce_ref = oidc_nonce.as_deref();
     let auth_url = match provider_type {
         ProviderType::Google => {
-            let p = ProviderFactory::google(config.client_id, config.client_secret);
+            let p = ProviderFactory::google(config.client_id, config.client_secret)
+                .with_scopes(cfg_scopes.clone());
             p.authorization_url(&state_token, &pkce.challenge, &redirect_uri, nonce_ref)
         }
         ProviderType::Microsoft => {
@@ -88,7 +92,8 @@ pub async fn authorize(
                 .and_then(|v| v.as_str())
                 .map(String::from);
             let p =
-                ProviderFactory::microsoft(config.client_id, config.client_secret, azure_tenant)?;
+                ProviderFactory::microsoft(config.client_id, config.client_secret, azure_tenant)?
+                    .with_scopes(cfg_scopes.clone());
             p.authorization_url(&state_token, &pkce.challenge, &redirect_uri, nonce_ref)
         }
         ProviderType::Apple => {
@@ -120,11 +125,13 @@ pub async fn authorize(
                 })?
                 .to_string();
 
-            let p = ProviderFactory::apple(config.client_id, team_id, key_id, private_key)?;
+            let p = ProviderFactory::apple(config.client_id, team_id, key_id, private_key)?
+                .with_scopes(cfg_scopes.clone());
             p.authorization_url(&state_token, &pkce.challenge, &redirect_uri, nonce_ref)
         }
         ProviderType::Github => {
-            let p = ProviderFactory::github(config.client_id, config.client_secret);
+            let p = ProviderFactory::github(config.client_id, config.client_secret)
+                .with_scopes(cfg_scopes.clone());
             p.authorization_url(&state_token, &pkce.challenge, &redirect_uri, nonce_ref)
         }
     };

--- a/crates/xavyo-api-social/src/handlers/authorize.rs
+++ b/crates/xavyo-api-social/src/handlers/authorize.rs
@@ -70,11 +70,8 @@ pub async fn authorize(
         oidc_nonce.clone(),
     )?;
 
-    // Build redirect URI
-    let redirect_uri = format!(
-        "{}/api/v1/auth/social/{}/callback",
-        state.base_url, provider_type
-    );
+    // Build redirect URI (must match the mounted callback route, `/auth/social/{provider}/callback`)
+    let redirect_uri = format!("{}/auth/social/{}/callback", state.base_url, provider_type);
 
     // Create provider instance and get authorization URL
     let nonce_ref = oidc_nonce.as_deref();
@@ -159,4 +156,23 @@ pub async fn available_providers(
         .collect();
 
     Ok(Json(AvailableProvidersResponse { providers }))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn authorize_redirect_uri_matches_mounted_route() {
+        // The redirect_uri sent to the provider must match the callback route
+        // mounted at `/auth/social/{provider}/callback` (see idp-api main.rs).
+        let src = include_str!("authorize.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        assert!(
+            !production.contains("/api/v1/auth/social/"),
+            "authorize redirect_uri must not use the unmounted /api/v1 prefix"
+        );
+        assert!(
+            production.contains("{}/auth/social/{}/callback"),
+            "authorize redirect_uri must target the mounted /auth/social route"
+        );
+    }
 }

--- a/crates/xavyo-api-social/src/handlers/callback.rs
+++ b/crates/xavyo-api-social/src/handlers/callback.rs
@@ -204,11 +204,8 @@ async fn process_callback(
         .and_then(|v| v.as_str())
         .map(String::from);
 
-    // Build redirect URI
-    let redirect_uri = format!(
-        "{}/api/v1/auth/social/{}/callback",
-        state.base_url, provider_type
-    );
+    // Build redirect URI (must match the mounted callback route, `/auth/social/{provider}/callback`)
+    let redirect_uri = format!("{}/auth/social/{}/callback", state.base_url, provider_type);
 
     // Exchange code for tokens and get user info
     let (tokens, mut user_info) = match provider_type {
@@ -804,6 +801,23 @@ mod tests {
         assert!(
             production.contains("social_login_allowed(user.is_active, user.is_locked())"),
             "existing social logins must refuse locked accounts"
+        );
+    }
+
+    #[test]
+    fn social_callback_redirect_uri_matches_mounted_route() {
+        // The redirect_uri sent to the provider must match the callback route
+        // mounted at `/auth/social/{provider}/callback` (see idp-api main.rs).
+        // A stale `/api/v1` prefix breaks token exchange and yields a 404 on return.
+        let src = include_str!("callback.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        assert!(
+            !production.contains("/api/v1/auth/social/"),
+            "social callback redirect_uri must not use the unmounted /api/v1 prefix"
+        );
+        assert!(
+            production.contains("{}/auth/social/{}/callback"),
+            "social callback redirect_uri must target the mounted /auth/social route"
         );
     }
 

--- a/crates/xavyo-api-social/src/handlers/callback.rs
+++ b/crates/xavyo-api-social/src/handlers/callback.rs
@@ -160,6 +160,105 @@ pub async fn callback_apple_post(
     process_callback(state, ProviderType::Apple, &code, &form.state, apple_user).await
 }
 
+/// Verify an OIDC provider's ID token and reconcile it with the userinfo result.
+///
+/// Shared by the login callback and the account-link flow so both enforce the
+/// same checks: JWKS-backed signature/issuer/audience verification, subject
+/// cross-check against userinfo (blocks token substitution), and OIDC nonce
+/// replay protection. On success, `email_verified` is upgraded from the signed
+/// ID token (never downgraded). A JWKS-fetch infrastructure failure is
+/// non-fatal (the token still came from the provider's token endpoint), but
+/// signature/claim failures fail closed. No-op for non-OIDC providers (GitHub)
+/// or when no ID token is present.
+pub(crate) async fn verify_provider_id_token(
+    state: &SocialState,
+    provider_type: ProviderType,
+    id_token: Option<&str>,
+    user_info: &mut SocialUserInfo,
+    expected_nonce: Option<&str>,
+    azure_tenant: Option<&str>,
+    client_id: &str,
+) -> Result<(), SocialError> {
+    let Some(id_token) = id_token else {
+        return Ok(());
+    };
+
+    let verify_params: Option<(String, String)> = match provider_type {
+        ProviderType::Google => Some((
+            "https://www.googleapis.com/oauth2/v3/certs".to_string(),
+            "https://accounts.google.com".to_string(),
+        )),
+        ProviderType::Microsoft => {
+            let t = azure_tenant.unwrap_or("common");
+            Some((
+                format!("https://login.microsoftonline.com/{t}/discovery/v2.0/keys"),
+                format!("https://login.microsoftonline.com/{t}/v2.0"),
+            ))
+        }
+        ProviderType::Apple => Some((
+            "https://appleid.apple.com/auth/keys".to_string(),
+            "https://appleid.apple.com".to_string(),
+        )),
+        ProviderType::Github => None,
+    };
+
+    let Some((jwks_uri, issuer)) = verify_params else {
+        return Ok(());
+    };
+
+    match state
+        .id_token_verifier
+        .verify(id_token, &jwks_uri, &issuer, client_id)
+        .await
+    {
+        Ok(verified_claims) => {
+            // Cross-check: verified sub must match userinfo sub
+            if verified_claims.sub != user_info.provider_user_id {
+                warn!(
+                    provider = %provider_type,
+                    id_token_sub = %verified_claims.sub,
+                    userinfo_sub = %user_info.provider_user_id,
+                    "ID token sub mismatch — possible token substitution"
+                );
+                return Err(SocialError::IdTokenVerificationFailed {
+                    provider: provider_type,
+                    reason: "Subject mismatch between ID token and userinfo".to_string(),
+                });
+            }
+
+            // OIDC nonce validation: the ID token nonce must match what we sent
+            if let Some(expected_nonce) = expected_nonce {
+                if verified_claims.nonce.as_deref() != Some(expected_nonce) {
+                    warn!(
+                        provider = %provider_type,
+                        "OIDC nonce mismatch — possible replay attack"
+                    );
+                    return Err(SocialError::NonceMismatch {
+                        provider: provider_type,
+                    });
+                }
+            }
+
+            // Propagate email_verified from the JWKS-verified ID token (upgrade only).
+            if verified_claims.email_verified == Some(true) {
+                user_info.email_verified = Some(true);
+            }
+
+            info!(provider = %provider_type, "ID token verified successfully");
+        }
+        Err(SocialError::JwksFetchFailed { provider, reason }) => {
+            warn!(
+                provider = %provider,
+                reason = %reason,
+                "JWKS fetch failed, continuing without ID token verification"
+            );
+        }
+        Err(e) => return Err(e),
+    }
+
+    Ok(())
+}
+
 /// Process the OAuth callback and handle user creation/login.
 async fn process_callback(
     state: SocialState,
@@ -307,82 +406,16 @@ async fn process_callback(
 
     // Defense-in-depth: Verify ID token signature for OIDC providers.
     // GitHub has no ID token. All OIDC providers (Google, Microsoft, Apple) are verified.
-    if let Some(ref id_token) = tokens.id_token {
-        let verify_params: Option<(String, String)> = match provider_type {
-            ProviderType::Google => Some((
-                "https://www.googleapis.com/oauth2/v3/certs".to_string(),
-                "https://accounts.google.com".to_string(),
-            )),
-            ProviderType::Microsoft => {
-                let t = azure_tenant_for_verify.as_deref().unwrap_or("common");
-                Some((
-                    format!("https://login.microsoftonline.com/{t}/discovery/v2.0/keys"),
-                    format!("https://login.microsoftonline.com/{t}/v2.0"),
-                ))
-            }
-            ProviderType::Apple => Some((
-                "https://appleid.apple.com/auth/keys".to_string(),
-                "https://appleid.apple.com".to_string(),
-            )),
-            _ => None,
-        };
-
-        if let Some((jwks_uri, issuer)) = verify_params {
-            match state
-                .id_token_verifier
-                .verify(id_token, &jwks_uri, &issuer, &client_id_for_verify)
-                .await
-            {
-                Ok(verified_claims) => {
-                    // Cross-check: verified sub must match userinfo sub
-                    if verified_claims.sub != user_info.provider_user_id {
-                        warn!(
-                            provider = %provider_type,
-                            id_token_sub = %verified_claims.sub,
-                            userinfo_sub = %user_info.provider_user_id,
-                            "ID token sub mismatch — possible token substitution"
-                        );
-                        return Err(SocialError::IdTokenVerificationFailed {
-                            provider: provider_type,
-                            reason: "Subject mismatch between ID token and userinfo".to_string(),
-                        });
-                    }
-
-                    // OIDC nonce validation: verify the nonce in the ID token matches what we sent
-                    if let Some(ref expected_nonce) = claims.oidc_nonce {
-                        if verified_claims.nonce.as_deref() != Some(expected_nonce.as_str()) {
-                            warn!(
-                                provider = %provider_type,
-                                "OIDC nonce mismatch — possible replay attack"
-                            );
-                            return Err(SocialError::NonceMismatch {
-                                provider: provider_type,
-                            });
-                        }
-                    }
-
-                    // Propagate email_verified from JWKS-verified ID token.
-                    // The ID token is signed by the provider's private key, making
-                    // it more authoritative than the userinfo endpoint's default.
-                    // Only upgrade false→true (never downgrade true→false).
-                    if verified_claims.email_verified == Some(true) {
-                        user_info.email_verified = Some(true);
-                    }
-
-                    info!(provider = %provider_type, "ID token verified successfully");
-                }
-                Err(SocialError::JwksFetchFailed { provider, reason }) => {
-                    warn!(
-                        provider = %provider,
-                        reason = %reason,
-                        "JWKS fetch failed, continuing without ID token verification"
-                    );
-                    // Defense-in-depth: don't block login for infrastructure issues
-                }
-                Err(e) => return Err(e),
-            }
-        }
-    }
+    verify_provider_id_token(
+        &state,
+        provider_type,
+        tokens.id_token.as_deref(),
+        &mut user_info,
+        claims.oidc_nonce.as_deref(),
+        azure_tenant_for_verify.as_deref(),
+        &client_id_for_verify,
+    )
+    .await?;
 
     info!(
         provider = %provider_type,

--- a/crates/xavyo-api-social/src/handlers/link.rs
+++ b/crates/xavyo-api-social/src/handlers/link.rs
@@ -94,8 +94,17 @@ pub async fn link_account(
     // Build redirect URI (must match the mounted callback route, `/auth/social/{provider}/callback`)
     let redirect_uri = format!("{}/auth/social/{}/callback", state.base_url, provider_type);
 
+    // Capture ID-token verification inputs before `config` is consumed below.
+    let client_id_for_verify = config.client_id.clone();
+    let azure_tenant_for_verify = config
+        .additional_config
+        .as_ref()
+        .and_then(|c| c.get("azure_tenant"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
     // Exchange code for tokens (similar to callback)
-    let (tokens, user_info) = match provider_type {
+    let (tokens, mut user_info) = match provider_type {
         ProviderType::Google => {
             let p =
                 crate::providers::ProviderFactory::google(config.client_id, config.client_secret);
@@ -181,6 +190,20 @@ pub async fn link_account(
             (tokens, user_info)
         }
     };
+
+    // Defense-in-depth: verify the OIDC ID token (signature/issuer/audience,
+    // subject cross-check, nonce) — parity with the login callback so linking
+    // trusts the same verified identity, not just the userinfo response.
+    super::callback::verify_provider_id_token(
+        &state,
+        provider_type,
+        tokens.id_token.as_deref(),
+        &mut user_info,
+        claims.oidc_nonce.as_deref(),
+        azure_tenant_for_verify.as_deref(),
+        &client_id_for_verify,
+    )
+    .await?;
 
     // Link the account
     let connection_id = state
@@ -388,4 +411,25 @@ pub async fn list_connections(
     Ok(Json(ConnectionsListResponse {
         connections: responses,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    /// Account linking must verify the OIDC ID token before trusting the
+    /// identity — parity with the login callback (defense-in-depth against
+    /// token substitution / unsigned userinfo).
+    #[test]
+    fn link_account_verifies_id_token() {
+        let src = include_str!("link.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        let link = production
+            .split("pub async fn link_account")
+            .nth(1)
+            .and_then(|s| s.split("pub async fn initiate_link").next())
+            .expect("link_account handler");
+        assert!(
+            link.contains("verify_provider_id_token("),
+            "link_account must verify the provider ID token before linking"
+        );
+    }
 }

--- a/crates/xavyo-api-social/src/handlers/link.rs
+++ b/crates/xavyo-api-social/src/handlers/link.rs
@@ -91,11 +91,8 @@ pub async fn link_account(
             provider: provider_type,
         })?;
 
-    // Build redirect URI
-    let redirect_uri = format!(
-        "{}/api/v1/auth/social/{}/callback",
-        state.base_url, provider_type
-    );
+    // Build redirect URI (must match the mounted callback route, `/auth/social/{provider}/callback`)
+    let redirect_uri = format!("{}/auth/social/{}/callback", state.base_url, provider_type);
 
     // Exchange code for tokens (similar to callback)
     let (tokens, user_info) = match provider_type {
@@ -282,11 +279,8 @@ pub async fn initiate_link(
         oidc_nonce.clone(),
     )?;
 
-    // Build redirect URI
-    let redirect_uri = format!(
-        "{}/api/v1/auth/social/{}/callback",
-        state.base_url, provider_type
-    );
+    // Build redirect URI (must match the mounted callback route, `/auth/social/{provider}/callback`)
+    let redirect_uri = format!("{}/auth/social/{}/callback", state.base_url, provider_type);
 
     // Get authorization URL
     let nonce_ref = oidc_nonce.as_deref();

--- a/crates/xavyo-api-social/src/models/responses.rs
+++ b/crates/xavyo-api-social/src/models/responses.rs
@@ -88,6 +88,9 @@ pub struct TenantProvidersListResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct UpdateProviderRequest {
     pub enabled: bool,
+    /// Required when first configuring a provider. Omitted for a plain
+    /// enable/disable toggle, in which case the stored value is preserved.
+    #[serde(default)]
     pub client_id: String,
     /// Only required when enabling or changing.
     pub client_secret: Option<String>,
@@ -152,4 +155,23 @@ pub struct SocialLoginSuccessResponse {
     pub refresh_token: String,
     pub token_type: String,
     pub expires_in: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UpdateProviderRequest;
+
+    /// Regression: the admin UI's enable/disable toggle sends only
+    /// `{ "enabled": <bool> }`. `client_id` must be `#[serde(default)]` so this
+    /// deserializes (previously it 422'd as a missing required field). The empty
+    /// client_id is then treated as "preserve stored value" by the service.
+    #[test]
+    fn update_provider_request_deserializes_from_enabled_only() {
+        let req: UpdateProviderRequest =
+            serde_json::from_str(r#"{"enabled":true}"#).expect("enabled-only toggle must parse");
+        assert!(req.enabled);
+        assert_eq!(req.client_id, "");
+        assert!(req.client_secret.is_none());
+        assert!(req.scopes.is_none());
+    }
 }

--- a/crates/xavyo-api-social/src/providers/apple.rs
+++ b/crates/xavyo-api-social/src/providers/apple.rs
@@ -117,6 +117,7 @@ pub struct AppleProvider {
     key_id: String,
     private_key: EncodingKey,
     http_client: Client,
+    configured_scopes: Option<Vec<String>>,
 }
 
 impl AppleProvider {
@@ -149,7 +150,21 @@ impl AppleProvider {
                 .timeout(Duration::from_secs(10))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
+            configured_scopes: None,
         })
+    }
+
+    /// Override the requested scopes with the tenant-configured set (empty → defaults).
+    #[must_use]
+    pub fn with_scopes(mut self, scopes: Option<Vec<String>>) -> Self {
+        self.configured_scopes = scopes.filter(|s| !s.is_empty());
+        self
+    }
+
+    fn effective_scopes(&self) -> Vec<String> {
+        self.configured_scopes
+            .clone()
+            .unwrap_or_else(|| self.default_scopes())
     }
 
     /// Generate a client secret JWT for Apple.
@@ -335,7 +350,7 @@ impl SocialProvider for AppleProvider {
         redirect_uri: &str,
         nonce: Option<&str>,
     ) -> String {
-        let scopes = self.default_scopes().join(" ");
+        let scopes = self.effective_scopes().join(" ");
 
         // Apple uses form_post response mode
         let mut url = format!(

--- a/crates/xavyo-api-social/src/providers/github.rs
+++ b/crates/xavyo-api-social/src/providers/github.rs
@@ -47,6 +47,7 @@ pub struct GithubProvider {
     client_id: String,
     client_secret: String,
     http_client: Client,
+    configured_scopes: Option<Vec<String>>,
 }
 
 impl GithubProvider {
@@ -60,7 +61,21 @@ impl GithubProvider {
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
+            configured_scopes: None,
         }
+    }
+
+    /// Override the requested scopes with the tenant-configured set (empty → defaults).
+    #[must_use]
+    pub fn with_scopes(mut self, scopes: Option<Vec<String>>) -> Self {
+        self.configured_scopes = scopes.filter(|s| !s.is_empty());
+        self
+    }
+
+    fn effective_scopes(&self) -> Vec<String> {
+        self.configured_scopes
+            .clone()
+            .unwrap_or_else(|| self.default_scopes())
     }
 
     /// Fetch the primary verified email from GitHub.
@@ -135,7 +150,7 @@ impl SocialProvider for GithubProvider {
         redirect_uri: &str,
         _nonce: Option<&str>,
     ) -> String {
-        let scopes = self.default_scopes().join(" ");
+        let scopes = self.effective_scopes().join(" ");
 
         // SECURITY: GitHub doesn't support PKCE (code_challenge/code_verifier).
         // Mitigations: signed single-use CSRF state token + server-side client_secret

--- a/crates/xavyo-api-social/src/providers/google.rs
+++ b/crates/xavyo-api-social/src/providers/google.rs
@@ -41,6 +41,7 @@ pub struct GoogleProvider {
     client_id: String,
     client_secret: String,
     http_client: Client,
+    configured_scopes: Option<Vec<String>>,
 }
 
 impl GoogleProvider {
@@ -54,7 +55,21 @@ impl GoogleProvider {
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
+            configured_scopes: None,
         }
+    }
+
+    /// Override the requested scopes with the tenant-configured set (empty → defaults).
+    #[must_use]
+    pub fn with_scopes(mut self, scopes: Option<Vec<String>>) -> Self {
+        self.configured_scopes = scopes.filter(|s| !s.is_empty());
+        self
+    }
+
+    fn effective_scopes(&self) -> Vec<String> {
+        self.configured_scopes
+            .clone()
+            .unwrap_or_else(|| self.default_scopes())
     }
 }
 
@@ -71,7 +86,7 @@ impl SocialProvider for GoogleProvider {
         redirect_uri: &str,
         nonce: Option<&str>,
     ) -> String {
-        let scopes = self.default_scopes().join(" ");
+        let scopes = self.effective_scopes().join(" ");
 
         let mut url = format!(
             "{}?client_id={}&redirect_uri={}&response_type=code&scope={}&state={}&code_challenge={}&code_challenge_method=S256&access_type=offline&prompt=consent",
@@ -196,6 +211,31 @@ mod tests {
         assert!(url.contains("scope=openid"));
         assert!(url.contains("access_type=offline"));
         assert!(!url.contains("nonce="));
+    }
+
+    #[test]
+    fn authorization_url_uses_configured_scopes() {
+        // Tenant-configured scopes must override the provider defaults in the
+        // authorize URL (previously configured scopes were silently ignored).
+        let provider = GoogleProvider::new("client-id".to_string(), "client-secret".to_string())
+            .with_scopes(Some(vec![
+                "openid".to_string(),
+                "email".to_string(),
+                "https://www.googleapis.com/auth/drive.readonly".to_string(),
+            ]));
+        let url = provider.authorization_url("s0123456789abcdef", "chal", "https://x/cb", None);
+        assert!(
+            url.contains("drive.readonly"),
+            "configured custom scope must appear in the authorize URL; got {url}"
+        );
+    }
+
+    #[test]
+    fn authorization_url_falls_back_to_defaults_when_no_scopes_configured() {
+        let provider = GoogleProvider::new("client-id".to_string(), "client-secret".to_string())
+            .with_scopes(Some(vec![])); // empty → defaults
+        let url = provider.authorization_url("s0123456789abcdef", "chal", "https://x/cb", None);
+        assert!(url.contains("scope=openid"));
     }
 
     #[test]

--- a/crates/xavyo-api-social/src/providers/microsoft.rs
+++ b/crates/xavyo-api-social/src/providers/microsoft.rs
@@ -40,6 +40,7 @@ pub struct MicrosoftProvider {
     client_secret: String,
     tenant: String,
     http_client: Client,
+    configured_scopes: Option<Vec<String>>,
 }
 
 impl MicrosoftProvider {
@@ -80,7 +81,21 @@ impl MicrosoftProvider {
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
+            configured_scopes: None,
         })
+    }
+
+    /// Override the requested scopes with the tenant-configured set (empty → defaults).
+    #[must_use]
+    pub fn with_scopes(mut self, scopes: Option<Vec<String>>) -> Self {
+        self.configured_scopes = scopes.filter(|s| !s.is_empty());
+        self
+    }
+
+    fn effective_scopes(&self) -> Vec<String> {
+        self.configured_scopes
+            .clone()
+            .unwrap_or_else(|| self.default_scopes())
     }
 
     /// Get the authorization endpoint URL.
@@ -118,7 +133,7 @@ impl SocialProvider for MicrosoftProvider {
         redirect_uri: &str,
         nonce: Option<&str>,
     ) -> String {
-        let scopes = self.default_scopes().join(" ");
+        let scopes = self.effective_scopes().join(" ");
 
         let mut url = format!(
             "{}?client_id={}&redirect_uri={}&response_type=code&scope={}&state={}&code_challenge={}&code_challenge_method=S256&response_mode=query",
@@ -143,7 +158,7 @@ impl SocialProvider for MicrosoftProvider {
         pkce_verifier: &str,
         redirect_uri: &str,
     ) -> SocialResult<TokenResponse> {
-        let scopes = self.default_scopes().join(" ");
+        let scopes = self.effective_scopes().join(" ");
 
         let params = [
             ("client_id", self.client_id.as_str()),

--- a/crates/xavyo-api-social/src/router.rs
+++ b/crates/xavyo-api-social/src/router.rs
@@ -144,8 +144,8 @@ pub fn admin_social_router() -> Router<SocialState> {
 
 /// Create the complete social router with all routes.
 ///
-/// Typically, you would mount this at `/api/v1/auth/social` for public/auth routes
-/// and `/api/v1/admin/social-providers` for admin routes.
+/// Mount this at `/auth/social` for public/auth routes
+/// and `/admin/social-providers` for admin routes.
 pub fn social_router() -> Router<SocialState> {
     Router::new()
         .merge(public_social_router())

--- a/crates/xavyo-api-social/src/services/tenant_provider_service.rs
+++ b/crates/xavyo-api-social/src/services/tenant_provider_service.rs
@@ -255,38 +255,41 @@ impl TenantProviderService {
         additional_config: Option<serde_json::Value>,
         scopes: Option<Vec<String>>,
     ) -> SocialResult<TenantProviderResponse> {
-        // L7: Validate required fields are non-empty
-        if client_id.trim().is_empty() {
+        // Look up the existing row once: whether it exists at all and whether it
+        // already has a stored secret. This lets a plain enable/disable toggle
+        // ({ enabled }) succeed without re-sending client_id / secret / scopes
+        // (the UPDATE branch below preserves the stored values), while still
+        // requiring them the first time a provider is configured.
+        let mut check_conn = self.pool.acquire().await?;
+        sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+            .bind(tenant_id.to_string())
+            .execute(&mut *check_conn)
+            .await?;
+        let existing: Option<(bool,)> = sqlx::query_as(
+            "SELECT client_secret_encrypted IS NOT NULL \
+             FROM tenant_social_providers WHERE tenant_id = $1 AND provider = $2",
+        )
+        .bind(tenant_id)
+        .bind(provider.to_string())
+        .fetch_optional(&mut *check_conn)
+        .await?;
+        drop(check_conn);
+        let provider_exists = existing.is_some();
+        let has_stored_secret = existing.map(|r| r.0).unwrap_or(false);
+
+        // client_id is required to CREATE a provider; an existing provider keeps
+        // its stored client_id when the request omits it (e.g. a toggle).
+        if client_id.trim().is_empty() && !provider_exists {
             return Err(crate::error::SocialError::ConfigurationError {
                 message: "client_id cannot be empty".to_string(),
             });
         }
-        if enabled && client_secret.is_none() {
-            // Enabling without a secret in the request is valid when the provider
-            // is already configured with one (e.g. an admin toggles an
-            // already-saved provider on). The UPDATE branch below preserves the
-            // stored secret. Reject only when no secret exists anywhere — otherwise
-            // toggling a configured provider on 500'd with "client_secret cannot be
-            // empty".
-            let mut check_conn = self.pool.acquire().await?;
-            sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
-                .bind(tenant_id.to_string())
-                .execute(&mut *check_conn)
-                .await?;
-            let has_stored_secret: bool = sqlx::query_scalar(
-                "SELECT client_secret_encrypted IS NOT NULL \
-                 FROM tenant_social_providers WHERE tenant_id = $1 AND provider = $2",
-            )
-            .bind(tenant_id)
-            .bind(provider.to_string())
-            .fetch_optional(&mut *check_conn)
-            .await?
-            .unwrap_or(false);
-            if !has_stored_secret {
-                return Err(crate::error::SocialError::ConfigurationError {
-                    message: "client_secret cannot be empty".to_string(),
-                });
-            }
+        // A secret is required to ENABLE a provider that has none stored yet.
+        // Toggling an already-configured provider on does not need to re-send it.
+        if enabled && client_secret.is_none() && !has_stored_secret {
+            return Err(crate::error::SocialError::ConfigurationError {
+                message: "client_secret cannot be empty".to_string(),
+            });
         }
 
         // R9: Validate additional_config size to prevent storage abuse
@@ -328,10 +331,10 @@ impl TenantProviderService {
                 ON CONFLICT (tenant_id, provider)
                 DO UPDATE SET
                     enabled = EXCLUDED.enabled,
-                    client_id = EXCLUDED.client_id,
+                    client_id = COALESCE(NULLIF(EXCLUDED.client_id, ''), tenant_social_providers.client_id),
                     client_secret_encrypted = EXCLUDED.client_secret_encrypted,
-                    additional_config = EXCLUDED.additional_config,
-                    scopes = EXCLUDED.scopes,
+                    additional_config = COALESCE(EXCLUDED.additional_config, tenant_social_providers.additional_config),
+                    scopes = COALESCE(EXCLUDED.scopes, tenant_social_providers.scopes),
                     updated_at = NOW()
                 RETURNING provider, enabled, client_id, scopes, created_at, updated_at
                 ",
@@ -350,9 +353,9 @@ impl TenantProviderService {
                 r"
                 UPDATE tenant_social_providers
                 SET enabled = $3,
-                    client_id = $4,
-                    additional_config = $5,
-                    scopes = $6,
+                    client_id = COALESCE(NULLIF($4, ''), client_id),
+                    additional_config = COALESCE($5, additional_config),
+                    scopes = COALESCE($6, scopes),
                     updated_at = NOW()
                 WHERE tenant_id = $1 AND provider = $2
                 RETURNING provider, enabled, client_id, scopes, created_at, updated_at
@@ -460,27 +463,41 @@ struct AdminProviderRow {
 
 #[cfg(test)]
 mod tests {
-    /// Regression: toggling an already-configured social provider to `enabled`
-    /// sends `{ enabled: true }` with no `client_secret`. The upfront validation
-    /// must NOT hard-reject that — it should allow it when a secret is already
-    /// stored (the UPDATE branch preserves it). Previously this 500'd with
-    /// "client_secret cannot be empty", so admins could not enable a saved
-    /// provider from the UI.
+    /// Regression: a plain enable/disable toggle from the admin UI sends only
+    /// `{ enabled }` — no client_id, secret, or scopes. update_provider must
+    /// treat that as a partial update against an existing provider: keep the
+    /// stored client_id/secret/scopes and only flip `enabled`. Previously it
+    /// rejected the empty client_id ("client_id cannot be empty") and the missing
+    /// secret ("client_secret cannot be empty") with a 500, so an admin could not
+    /// enable a provider they had already configured. First-time configuration
+    /// still requires client_id + secret.
     #[test]
-    fn enable_without_secret_allowed_when_secret_already_stored() {
+    fn enable_toggle_preserves_stored_config_for_existing_provider() {
         let src = include_str!("tenant_provider_service.rs");
         let production = src.split("mod tests").next().expect("production source");
         let update = production
             .split("pub async fn update_provider")
             .nth(1)
             .expect("update_provider");
+        // Existence is checked so create-vs-update can be distinguished.
         assert!(
-            update.contains("has_stored_secret"),
-            "update_provider must check for an already-stored secret before rejecting enable"
+            update.contains("provider_exists") && update.contains("has_stored_secret"),
+            "update_provider must distinguish an existing provider from a new one"
+        );
+        // client_id / secret only required when the provider does NOT yet exist.
+        assert!(
+            update.contains("client_id.trim().is_empty() && !provider_exists"),
+            "client_id must be required only when creating a provider"
         );
         assert!(
-            update.contains("client_secret_encrypted IS NOT NULL"),
-            "the stored-secret check must query client_secret_encrypted"
+            update.contains("enabled && client_secret.is_none() && !has_stored_secret"),
+            "a secret must be required only when enabling an unconfigured provider"
+        );
+        // The UPDATE branch must preserve stored values on a toggle.
+        assert!(
+            update.contains("client_id = COALESCE(NULLIF($4, ''), client_id)")
+                && update.contains("scopes = COALESCE($6, scopes)"),
+            "toggling must preserve the stored client_id and scopes"
         );
     }
 }

--- a/crates/xavyo-api-social/src/services/tenant_provider_service.rs
+++ b/crates/xavyo-api-social/src/services/tenant_provider_service.rs
@@ -262,9 +262,31 @@ impl TenantProviderService {
             });
         }
         if enabled && client_secret.is_none() {
-            return Err(crate::error::SocialError::ConfigurationError {
-                message: "client_secret cannot be empty".to_string(),
-            });
+            // Enabling without a secret in the request is valid when the provider
+            // is already configured with one (e.g. an admin toggles an
+            // already-saved provider on). The UPDATE branch below preserves the
+            // stored secret. Reject only when no secret exists anywhere — otherwise
+            // toggling a configured provider on 500'd with "client_secret cannot be
+            // empty".
+            let mut check_conn = self.pool.acquire().await?;
+            sqlx::query("SELECT set_config('app.current_tenant', $1::text, true)")
+                .bind(tenant_id.to_string())
+                .execute(&mut *check_conn)
+                .await?;
+            let has_stored_secret: bool = sqlx::query_scalar(
+                "SELECT client_secret_encrypted IS NOT NULL \
+                 FROM tenant_social_providers WHERE tenant_id = $1 AND provider = $2",
+            )
+            .bind(tenant_id)
+            .bind(provider.to_string())
+            .fetch_optional(&mut *check_conn)
+            .await?
+            .unwrap_or(false);
+            if !has_stored_secret {
+                return Err(crate::error::SocialError::ConfigurationError {
+                    message: "client_secret cannot be empty".to_string(),
+                });
+            }
         }
 
         // R9: Validate additional_config size to prevent storage abuse
@@ -434,4 +456,31 @@ struct AdminProviderRow {
     scopes: Option<Vec<String>>,
     created_at: chrono::DateTime<chrono::Utc>,
     updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    /// Regression: toggling an already-configured social provider to `enabled`
+    /// sends `{ enabled: true }` with no `client_secret`. The upfront validation
+    /// must NOT hard-reject that — it should allow it when a secret is already
+    /// stored (the UPDATE branch preserves it). Previously this 500'd with
+    /// "client_secret cannot be empty", so admins could not enable a saved
+    /// provider from the UI.
+    #[test]
+    fn enable_without_secret_allowed_when_secret_already_stored() {
+        let src = include_str!("tenant_provider_service.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        let update = production
+            .split("pub async fn update_provider")
+            .nth(1)
+            .expect("update_provider");
+        assert!(
+            update.contains("has_stored_secret"),
+            "update_provider must check for an already-stored secret before rejecting enable"
+        );
+        assert!(
+            update.contains("client_secret_encrypted IS NOT NULL"),
+            "the stored-secret check must query client_secret_encrypted"
+        );
+    }
 }

--- a/crates/xavyo-auth/src/jwt.rs
+++ b/crates/xavyo-auth/src/jwt.rs
@@ -232,6 +232,27 @@ pub fn decode_token_with_algorithm(
     algorithm: Algorithm,
     config: &ValidationConfig,
 ) -> Result<JwtClaims, AuthError> {
+    decode_token_into::<JwtClaims>(token, public_key_pem, algorithm, config)
+}
+
+/// Verify a token's signature/expiry/issuer and deserialize its claims into `T`.
+///
+/// Use this for tokens whose claim shape is not [`JwtClaims`] — most importantly
+/// ID tokens minted by *external* OIDC providers, which follow the OIDC spec (no
+/// `jti`, `aud` may be a string) rather than xavyo's internal token contract.
+/// Deserializing a foreign ID token into [`JwtClaims`] would reject spec-compliant
+/// tokens (e.g. Google's, which omit `jti`).
+///
+/// # Errors
+///
+/// Returns an [`AuthError`] if the key is invalid, the signature/claims fail
+/// validation, or the claims cannot be deserialized into `T`.
+pub fn decode_token_into<T: serde::de::DeserializeOwned>(
+    token: &str,
+    public_key_pem: &[u8],
+    algorithm: Algorithm,
+    config: &ValidationConfig,
+) -> Result<T, AuthError> {
     let key = match algorithm {
         Algorithm::RS256 | Algorithm::RS384 | Algorithm::RS512 => {
             DecodingKey::from_rsa_pem(public_key_pem)
@@ -256,8 +277,7 @@ pub fn decode_token_with_algorithm(
         validation.validate_aud = false;
     }
 
-    let token_data: TokenData<JwtClaims> =
-        decode(token, &key, &validation).map_err(map_jwt_error)?;
+    let token_data: TokenData<T> = decode(token, &key, &validation).map_err(map_jwt_error)?;
 
     Ok(token_data.claims)
 }
@@ -366,6 +386,57 @@ pwIDAQAB
 
         // Token should have 3 parts separated by dots
         assert_eq!(token.split('.').count(), 3);
+    }
+
+    #[test]
+    fn decode_token_into_accepts_spec_id_token_without_jti() {
+        // An external OIDC provider's ID token follows the spec: it has no `jti`
+        // and may encode `aud` as a plain string. The generic decoder must accept
+        // it, while the strict internal `JwtClaims` (requires `jti`, `Vec<String>`
+        // aud) must reject it — that gap is exactly why federation needs the
+        // permissive path.
+        #[derive(serde::Deserialize)]
+        struct IdTok {
+            sub: String,
+            iss: String,
+        }
+
+        let now = Utc::now().timestamp();
+        let claims = serde_json::json!({
+            "sub": "google-user-1",
+            "iss": "https://accounts.google.com",
+            "aud": "client-abc", // string audience (spec-legal), not an array
+            "exp": now + 3600,
+            "iat": now,
+            "email": "user@example.com",
+            // deliberately no `jti` and no xavyo-internal claims
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        let key = jsonwebtoken::EncodingKey::from_rsa_pem(TEST_PRIVATE_KEY).unwrap();
+        let token = jsonwebtoken::encode(&header, &claims, &key).unwrap();
+
+        let cfg = ValidationConfig::default().issuer("https://accounts.google.com");
+
+        let decoded: IdTok = decode_token_into(
+            &token,
+            TEST_PUBLIC_KEY,
+            jsonwebtoken::Algorithm::RS256,
+            &cfg,
+        )
+        .expect("permissive decode must accept a spec-compliant ID token");
+        assert_eq!(decoded.sub, "google-user-1");
+        assert_eq!(decoded.iss, "https://accounts.google.com");
+
+        let strict = decode_token_with_algorithm(
+            &token,
+            TEST_PUBLIC_KEY,
+            jsonwebtoken::Algorithm::RS256,
+            &cfg,
+        );
+        assert!(
+            strict.is_err(),
+            "strict internal JwtClaims must reject a jti-less external ID token"
+        );
     }
 
     #[test]

--- a/crates/xavyo-auth/src/lib.rs
+++ b/crates/xavyo-auth/src/lib.rs
@@ -69,8 +69,8 @@ pub use error::AuthError;
 pub use jsonwebtoken::Algorithm;
 pub use jwks::{JwkSet, JwksClient};
 pub use jwt::{
-    decode_token, decode_token_with_algorithm, decode_token_with_config, encode_token,
-    encode_token_with_kid, extract_kid, ValidationConfig,
+    decode_token, decode_token_into, decode_token_with_algorithm, decode_token_with_config,
+    encode_token, encode_token_with_kid, extract_kid, ValidationConfig,
 };
 pub use mtls::{
     cert_binding_satisfied, compute_x5t_s256, forwarded_cert_thumbprint, x5t_s256_from_pem,

--- a/crates/xavyo-db/migrations/0221_scim_soft_delete.sql
+++ b/crates/xavyo-db/migrations/0221_scim_soft_delete.sql
@@ -1,0 +1,12 @@
+-- SCIM must distinguish a *deactivated* user (active=false, still exists and can be
+-- read/reactivated/deleted) from a *deleted* user (gone; GET must 404 per RFC 7644
+-- Section 3.6). Previously the SCIM layer overloaded `is_active` for both, so once an
+-- IdP (Okta/Azure) deactivated a user via PATCH active=false the user became invisible:
+-- it could no longer be fetched, reactivated, or deleted through SCIM. This dedicated
+-- soft-delete marker lets deactivation and deletion be independent.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS scim_deleted_at TIMESTAMPTZ;
+
+-- Fast lookups that exclude SCIM-deleted rows (the common SCIM read/list path).
+CREATE INDEX IF NOT EXISTS idx_users_scim_deleted_at
+    ON users (tenant_id)
+    WHERE scim_deleted_at IS NULL;

--- a/crates/xavyo-db/src/models/device_code.rs
+++ b/crates/xavyo-db/src/models/device_code.rs
@@ -243,6 +243,33 @@ impl DeviceCode {
         .await
     }
 
+    /// Resolve the owning tenant of a pending device code from its `user_code`
+    /// alone (no tenant context).
+    ///
+    /// RFC 8628 has the user open `verification_uri` in a plain browser, which
+    /// cannot send the `X-Tenant-ID` header this app normally uses for tenant
+    /// resolution. Because `user_code` is globally unique
+    /// (`device_codes_user_code_unique`), it unambiguously identifies the tenant.
+    /// This mirrors the header-less authorization-code lookup in the token
+    /// endpoint (`lookup_authorization_code`), which likewise resolves the tenant
+    /// from a globally-unique code before any tenant context exists.
+    pub async fn resolve_tenant_by_user_code(
+        pool: &PgPool,
+        user_code: &str,
+    ) -> Result<Option<Uuid>, sqlx::Error> {
+        sqlx::query_scalar::<_, Uuid>(
+            r"
+            SELECT tenant_id FROM device_codes
+            WHERE user_code = $1
+              AND status = 'pending'
+              AND expires_at > NOW()
+            ",
+        )
+        .bind(user_code)
+        .fetch_optional(pool)
+        .await
+    }
+
     /// Update the status of a device code.
     pub async fn update_status(
         pool: &PgPool,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backend IAM defects found while testing the full authentication/access-management surface through the web UI (benchmarked against Auth0/Okta). Pairs with the frontend work in xavyo-web PR (`cursor/iam-fixes-8277`).

See the commit history on this branch for the full list of hardening fixes across authentication (login/signup/verification/reset, MFA/TOTP, WebAuthn, passwordless, sessions, OAuth2/OIDC, SAML, OIDC federation, social) and access management (users, groups, invitations, RBAC, OAuth clients, SCIM, security self-service).

`CI / Tests`: the two `user_agent_parser` failures previously red on `master` are now fixed by this branch. Remaining CI status should reflect only unrelated items, if any.

## Social provider admin config (follow-up)

Found via UI testing of Federation → Social provider management (Auth0/Okta let admins toggle a configured connection on/off without re-entering the secret):

- **Enable toggle 500 for a configured provider** — `social_update_secret` (handler) and `update_provider` (service) both rejected `{ enabled: true }` without a `client_secret`, even when one was already stored, so an admin could not enable a provider they had saved. The service now looks up the existing row once and requires `client_id`/secret only when *creating*; toggles preserve stored `client_id`/secret/scopes via `COALESCE`.
- **Enable toggle 422** — `UpdateProviderRequest.client_id` was a required serde field, so a plain `{ enabled }` toggle failed to deserialize. `client_id` is now `#[serde(default)]`.

Regression tests added (`enable_toggle_preserves_stored_config_for_existing_provider`, `update_provider_request_deserializes_from_enabled_only`, `disable_without_secret_does_not_send_empty`). `cargo test -p xavyo-api-social` green (66 tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f12b7349-ed8e-4838-bbc6-fb5773358277?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f12b7349-ed8e-4838-bbc6-fb5773358277&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

