### PR TITLE
fix(governance,nhi,personas): stop create-flow 500s from bad input / unset config

### DIFF
--- a/crates/xavyo-api-governance/src/models/birthright_policy.rs
+++ b/crates/xavyo-api-governance/src/models/birthright_policy.rs
@@ -536,11 +536,10 @@ mod tests {
         let create = production
             .split("struct CreateBirthrightPolicyRequest")
             .nth(1)
-            .and_then(|s| s.split("pub conditions").nth(1))
             .and_then(|s| s.split("pub entitlement_ids").next())
             .unwrap_or("");
         assert!(
-            create.contains("nested"),
+            create.contains("pub conditions") && create.contains("nested"),
             "CreateBirthrightPolicyRequest.conditions must be #[validate(nested)]"
         );
     }

--- a/crates/xavyo-api-governance/src/models/birthright_policy.rs
+++ b/crates/xavyo-api-governance/src/models/birthright_policy.rs
@@ -91,7 +91,10 @@ pub struct CreateBirthrightPolicyRequest {
     pub priority: i32,
 
     /// Conditions that must ALL match for policy to apply (AND logic).
-    #[validate(length(min = 1, message = "At least one condition is required"))]
+    #[validate(
+        length(min = 1, message = "At least one condition is required"),
+        nested
+    )]
     pub conditions: Vec<PolicyConditionRequest>,
 
     /// Entitlement IDs to grant when conditions match.
@@ -135,6 +138,7 @@ pub struct UpdateBirthrightPolicyRequest {
 
     /// Conditions that must ALL match.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(nested)]
     pub conditions: Option<Vec<PolicyConditionRequest>>,
 
     /// Entitlement IDs to grant.
@@ -521,6 +525,26 @@ pub enum UserImpactType {
 
 #[cfg(test)]
 mod tests {
+    /// Regression: a condition with an empty attribute used to 500 because the
+    /// nested per-condition validation (attribute length 1..=100) never ran — the
+    /// `conditions` field lacked `#[validate(nested)]`. It must now be present so a
+    /// bad condition returns a 400 validation error.
+    #[test]
+    fn condition_fields_are_nested_validated() {
+        let src = include_str!("birthright_policy.rs");
+        let production = src.split("mod tests").next().expect("production source");
+        let create = production
+            .split("struct CreateBirthrightPolicyRequest")
+            .nth(1)
+            .and_then(|s| s.split("pub conditions").nth(1))
+            .and_then(|s| s.split("pub entitlement_ids").next())
+            .unwrap_or("");
+        assert!(
+            create.contains("nested"),
+            "CreateBirthrightPolicyRequest.conditions must be #[validate(nested)]"
+        );
+    }
+
     #[test]
     fn birthright_response_does_not_default_on_invalid_json() {
         let src = include_str!("birthright_policy.rs");

--- a/crates/xavyo-api-governance/src/services/persona_authorization_service.rs
+++ b/crates/xavyo-api-governance/src/services/persona_authorization_service.rs
@@ -293,9 +293,7 @@ impl PersonaAuthorizationService {
                 let roles = UserRole::get_user_roles(&self.pool, user_id, tenant_id)
                     .await
                     .map_err(GovernanceError::Database)?;
-                Ok(roles
-                    .iter()
-                    .any(|r| r == "admin" || r == "super_admin"))
+                Ok(roles.iter().any(|r| r == "admin" || r == "super_admin"))
             }
             PersonaPermission::DeletePersona => {
                 // TODO: Check if user has delete permission

--- a/crates/xavyo-api-governance/src/services/persona_authorization_service.rs
+++ b/crates/xavyo-api-governance/src/services/persona_authorization_service.rs
@@ -8,7 +8,7 @@ use sqlx::PgPool;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use xavyo_db::models::{GovPersona, GovPersonaArchetype};
+use xavyo_db::models::{GovPersona, GovPersonaArchetype, UserRole};
 use xavyo_governance::error::{GovernanceError, Result};
 
 /// Permission types for persona operations.
@@ -274,27 +274,28 @@ impl PersonaAuthorizationService {
     /// integrate with the full RBAC/entitlement system.
     async fn check_permission(
         &self,
-        _tenant_id: Uuid,
-        _user_id: Uuid,
+        tenant_id: Uuid,
+        user_id: Uuid,
         permission: PersonaPermission,
     ) -> Result<bool> {
-        // For now, we grant basic permissions to all authenticated users
-        // In production, this would check:
-        // 1. User's roles/entitlements
-        // 2. Delegated admin permissions
-        // 3. Archetype-specific grants
-
         match permission {
             // Self-management of own personas is allowed by default
             PersonaPermission::ManageOwnPersonas => Ok(true),
             // Creating personas requires explicit grant (would check entitlements)
             // For now, allow authenticated users to create their own personas
             PersonaPermission::CreatePersona => Ok(true),
-            // Admin permissions would require role check
+            // Managing personas for OTHER users is an admin capability. The persona
+            // routes are already admin-gated, so mirror that by granting tenant
+            // admins / super admins. Previously this was hard-coded to false, so no
+            // one — not even an admin — could create a persona for another user, and
+            // the resulting denial surfaced as a 500.
             PersonaPermission::ManageAllPersonas => {
-                // TODO: Check if user has admin role
-                // For now, return false (requires explicit admin grant)
-                Ok(false)
+                let roles = UserRole::get_user_roles(&self.pool, user_id, tenant_id)
+                    .await
+                    .map_err(GovernanceError::Database)?;
+                Ok(roles
+                    .iter()
+                    .any(|r| r == "admin" || r == "super_admin"))
             }
             PersonaPermission::DeletePersona => {
                 // TODO: Check if user has delete permission

--- a/crates/xavyo-api-governance/src/services/sod_rule_service.rs
+++ b/crates/xavyo-api-governance/src/services/sod_rule_service.rs
@@ -4,7 +4,8 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use xavyo_db::models::{
-    CreateGovSodRule, GovSodRule, GovSodRuleStatus, GovSodSeverity, SodRuleFilter, UpdateGovSodRule,
+    CreateGovSodRule, GovEntitlement, GovSodRule, GovSodRuleStatus, GovSodSeverity, SodRuleFilter,
+    UpdateGovSodRule,
 };
 use xavyo_governance::error::{GovernanceError, Result};
 
@@ -82,6 +83,26 @@ impl SodRuleService {
         // Validate entitlement IDs are different
         if input.first_entitlement_id == input.second_entitlement_id {
             return Err(GovernanceError::SodSameEntitlement);
+        }
+
+        // Validate both entitlements actually exist for this tenant. Without this, a
+        // bad/stale entitlement id hit the FK constraint and surfaced to the user as a
+        // raw 500 "Database error"; now it returns a clear 400.
+        if GovEntitlement::find_by_id(&self.pool, tenant_id, input.first_entitlement_id)
+            .await?
+            .is_none()
+        {
+            return Err(GovernanceError::Validation(
+                "First entitlement not found".to_string(),
+            ));
+        }
+        if GovEntitlement::find_by_id(&self.pool, tenant_id, input.second_entitlement_id)
+            .await?
+            .is_none()
+        {
+            return Err(GovernanceError::Validation(
+                "Second entitlement not found".to_string(),
+            ));
         }
 
         // Check for duplicate name
@@ -274,5 +295,28 @@ mod tests {
         let ent_a = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
         let ent_b = ent_a;
         assert_eq!(ent_a, ent_b, "Same entitlement IDs should be detected");
+    }
+
+    /// Regression: creating an SoD rule with a non-existent entitlement id used to
+    /// hit the FK constraint and surface as a raw 500 "Database error". create_rule
+    /// must first verify both entitlements exist and return a Validation (400) error
+    /// instead.
+    #[test]
+    fn create_rule_validates_entitlement_existence() {
+        let src = include_str!("sod_rule_service.rs");
+        let create = src
+            .split("pub async fn create_rule")
+            .nth(1)
+            .and_then(|s| s.split("pub async fn update_rule").next())
+            .expect("create_rule body");
+        assert!(
+            create.matches("GovEntitlement::find_by_id").count() >= 2,
+            "create_rule must look up both entitlements before inserting"
+        );
+        assert!(
+            create.contains("First entitlement not found")
+                && create.contains("Second entitlement not found"),
+            "create_rule must return a clear validation error for missing entitlements"
+        );
     }
 }

--- a/crates/xavyo-api-nhi/src/error.rs
+++ b/crates/xavyo-api-nhi/src/error.rs
@@ -101,6 +101,37 @@ impl IntoResponse for NhiApiError {
                 )
             }
             Self::Database(ref e) => {
+                // Constraint violations are caused by bad client input (e.g. a
+                // referenced entity id that doesn't exist, or a duplicate). Surfacing
+                // them as a raw 500 "database error" is misleading — map them to a
+                // clear 4xx instead.
+                if let Some(db_err) = e.as_database_error() {
+                    match db_err.code().as_deref() {
+                        // foreign_key_violation
+                        Some("23503") => {
+                            return (
+                                StatusCode::BAD_REQUEST,
+                                Json(ErrorResponse {
+                                    error: "invalid_reference".to_string(),
+                                    message: "A referenced entity does not exist".to_string(),
+                                }),
+                            )
+                                .into_response();
+                        }
+                        // unique_violation
+                        Some("23505") => {
+                            return (
+                                StatusCode::CONFLICT,
+                                Json(ErrorResponse {
+                                    error: "conflict".to_string(),
+                                    message: "A conflicting record already exists".to_string(),
+                                }),
+                            )
+                                .into_response();
+                        }
+                        _ => {}
+                    }
+                }
                 tracing::error!("Database error: {:?}", e);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -133,6 +164,28 @@ mod tests {
     use super::*;
     use axum::body::to_bytes;
     use axum::response::IntoResponse;
+
+    /// Regression: DB constraint violations from bad client input (e.g. a
+    /// non-existent referenced id) must map to a clear 4xx, not a raw 500
+    /// "database error". Previously creating a delegation with a non-existent
+    /// actor_nhi_id 500'd.
+    #[test]
+    fn database_error_maps_constraint_violations_to_4xx() {
+        let src = include_str!("error.rs");
+        let arm = src
+            .split("Self::Database(ref e) =>")
+            .nth(1)
+            .and_then(|s| s.split("let body = Json").next())
+            .expect("Database arm");
+        assert!(
+            arm.contains("23503") && arm.contains("StatusCode::BAD_REQUEST"),
+            "foreign_key_violation (23503) must map to 400"
+        );
+        assert!(
+            arm.contains("23505") && arm.contains("StatusCode::CONFLICT"),
+            "unique_violation (23505) must map to 409"
+        );
+    }
 
     #[tokio::test]
     async fn not_implemented_into_response_is_501() {

--- a/crates/xavyo-governance/src/error.rs
+++ b/crates/xavyo-governance/src/error.rs
@@ -2655,6 +2655,9 @@ impl GovernanceError {
                 // Power of Attorney (F-PoA)
                 | Self::PoaScopeViolation(_)
                 | Self::PersonaExtensionRequiresApproval
+                // Persona authorization denials (must be 403, not 500)
+                | Self::PersonaCreationNotAuthorized
+                | Self::PersonaArchetypeNotAuthorized(_)
         )
     }
 
@@ -3148,3 +3151,17 @@ impl GovernanceError {
 
 /// Result type alias for governance operations.
 pub type Result<T> = std::result::Result<T, GovernanceError>;
+
+#[cfg(test)]
+mod forbidden_mapping_tests {
+    use super::GovernanceError;
+
+    /// Regression: persona authorization denials must be classified as forbidden
+    /// so the API maps them to 403. Previously PersonaCreationNotAuthorized fell
+    /// through to the generic 500 "internal error" arm.
+    #[test]
+    fn persona_authorization_denials_are_forbidden() {
+        assert!(GovernanceError::PersonaCreationNotAuthorized.is_forbidden());
+        assert!(GovernanceError::PersonaArchetypeNotAuthorized(uuid::Uuid::nil()).is_forbidden());
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backend defects found while UI-testing the non-IAM surfaces (governance, NHI, personas, connectors). A recurring pattern: create endpoints surfaced bad client input or normal "not configured" states as raw **500 "database error"/"internal error"** instead of clean 4xx responses. Pairs with the frontend fixes in xavyo-web (`cursor/surface-fixes-8277`).

## Fixes
- **SoD rules** — creating a rule with a non-existent entitlement id hit a FK constraint → 500. `create_rule` now verifies both entitlements exist and returns a 400 (`First/Second entitlement not found`).
- **Personas** — `POST /governance/personas` (admin-gated) had `ManageAllPersonas` hard-coded to `false`, so *no one* — not even a tenant admin — could create a persona for another user, and the denial fell through to a generic 500. Now: admins/super_admins are granted manage-all (role check), and `PersonaCreationNotAuthorized` / `PersonaArchetypeNotAuthorized` are classified as forbidden → **403** instead of 500.
- **NHI** — DB constraint violations now map to clear 4xx at the `NhiApiError` boundary: foreign_key_violation (23503) → **400 invalid_reference**, unique_violation (23505) → **409 conflict**. Fixes e.g. creating a delegation with a non-existent `actor_nhi_id` (was 500).
- **Birthright policies** — a condition with an empty attribute (the form's default first row) returned 500 because the `conditions` field lacked `#[validate(nested)]`, so the per-condition attribute check never ran. Added nested validation → **400** with a field-level message.

## Verification
- `cargo test -p xavyo-api-governance -p xavyo-governance -p xavyo-api-nhi` — green (1525 + 86 + 219). Regression tests added for each fix.
- Reproduced each defect via the API before/after: SoD bad-id 500→400; delegation bad-ref 500→400; persona cross-user 500→201 (admin) / 403 (denied); birthright empty-attribute 500→400; happy paths return 201.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f12b7349-ed8e-4838-bbc6-fb5773358277?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f12b7349-ed8e-4838-bbc6-fb5773358277&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

